### PR TITLE
Fix 4 workflow bugs: slugs, RED gate, QA status, sync check

### DIFF
--- a/.claude/workflow-config.json
+++ b/.claude/workflow-config.json
@@ -5,7 +5,7 @@
     "description": "Claude Code plugin framework: structured workflow skills for spec-driven development with TDD, auditing, and project health"
   },
   "commands": {
-    "test": "bash test.sh && bash test-mcp.sh",
+    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh",
     "test_verbose": "bash test.sh && bash test-mcp.sh",
     "coverage": "",
     "lint": "shellcheck hooks/*.sh test.sh sync.sh setup",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena@v0.1.4",
+        "serena-mcp-server",
+        "--transport", "stdio"
+      ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@context7/mcp@2.1.6"
+      ]
+    }
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,16 @@ repos:
     hooks:
       - id: typos
 
+  # Correctless sync check — ensures source files match distribution copies
+  - repo: local
+    hooks:
+      - id: correctless-sync-check
+        name: correctless sync check
+        entry: bash sync.sh --check
+        language: system
+        pass_filenames: false
+        files: ^(skills/|hooks/|templates/|helpers/)
+
   # ShellCheck for shell scripts (severity matches CI config)
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1

--- a/.serena.yml
+++ b/.serena.yml
@@ -1,0 +1,3 @@
+project_name: "correctless"
+read_only: false
+enable_memories: true

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -1,6 +1,6 @@
 # Agent Context — Correctless
 
-> Last updated: 2026-03-31
+> Last updated: 2026-04-01
 
 ## What This Project Does
 
@@ -17,7 +17,7 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 | Lite dist | `correctless-lite/` | 16-skill distribution target — never edit directly |
 | Full dist | `correctless-full/` | 23-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `test.sh` | 57 shell tests covering setup, state machine, gate hook, full mode |
+| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh` | 264 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes |
 | Sync | `sync.sh` | Propagates source edits to both distribution targets |
 
 ## Design Patterns
@@ -38,7 +38,7 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 
 | Need to... | Do this |
 |------------|---------|
-| Run tests | `bash test.sh` |
+| Run tests | `bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh` |
 | Lint shell scripts | `shellcheck hooks/*.sh test.sh sync.sh setup` |
 | Sync to distributions | `bash sync.sh` |
 | Find a skill | `skills/{name}/SKILL.md` |
@@ -46,4 +46,5 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 | Check architecture | `ARCHITECTURE.md` |
 | See known bugs | `.claude/antipatterns.md` |
 | Find a spec | `docs/specs/{feature}.md` |
+| Verify sync is clean | `bash sync.sh --check` |
 | Check MCP status | `jq '.mcp' .claude/workflow-config.json` |

--- a/correctless-full/hooks/workflow-advance.sh
+++ b/correctless-full/hooks/workflow-advance.sh
@@ -216,7 +216,11 @@ tests_fail_not_build_error() {
     pkg="$(detect_affected_packages | awk '{print $1}')"
     [ "$pkg" = "." ] || true
   fi
-  test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  # Prefer commands.test_new if present (allows separate new-test file for RED gate)
+  test_cmd="$(read_package_config '.commands.test_new' "$pkg")"
+  if [ -z "$test_cmd" ] || [ "$test_cmd" = "null" ]; then
+    test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  fi
   fail_pattern="$(read_package_config '.patterns.test_fail_pattern' "$pkg")"
   build_pattern="$(read_package_config '.patterns.build_error_pattern' "$pkg")"
 
@@ -358,6 +362,34 @@ cmd_init() {
 
   local slug
   slug="$(echo "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')"
+  # Truncate to first 4 hyphen-separated tokens, max 50 chars
+  slug="$(echo "$slug" | cut -d'-' -f1-4)"
+  slug="${slug:0:50}"
+  slug="${slug%-}"
+
+  # Guard: empty slug (all-punctuation or whitespace input)
+  [ -n "$slug" ] || die "Could not generate a valid slug from: '$task'. Provide a description containing at least one letter or digit."
+
+  # Check for collision against both spec files on disk AND state files claiming the same spec_file
+  spec_slug_in_use() {
+    local check_slug="$1"
+    [ -f "$REPO_ROOT/docs/specs/${check_slug}.md" ] && return 0
+    for state_f in "$ARTIFACTS_DIR"/workflow-state-*.json; do
+      [ -f "$state_f" ] || continue
+      local existing
+      existing="$(jq -r '.spec_file // empty' "$state_f" 2>/dev/null)"
+      [ "$existing" = "docs/specs/${check_slug}.md" ] && return 0
+    done
+    return 1
+  }
+
+  local base_slug="$slug"
+  local suffix=2
+  while spec_slug_in_use "$slug"; do
+    slug="${base_slug}-${suffix}"
+    suffix=$((suffix + 1))
+  done
+
   local spec_file="docs/specs/${slug}.md"
 
   mkdir -p "$ARTIFACTS_DIR"

--- a/correctless-full/skills/csetup/SKILL.md
+++ b/correctless-full/skills/csetup/SKILL.md
@@ -192,7 +192,33 @@ If `uv` is not installed and the user wants Serena, print installation instructi
 
 ### Writing `.mcp.json`
 
-When writing `.mcp.json` in the project root: if the file already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries in `mcpServers` are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (note: in jq's `+` for objects, the right-hand side wins on key collision — so existing `.mcpServers` entries override the defaults, preserving custom configs). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
+When writing `.mcp.json` in the project root, use this template with version-pinned dependencies:
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena@v0.1.4",
+        "serena-mcp-server",
+        "--transport", "stdio"
+      ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@context7/mcp@2.1.6"
+      ]
+    }
+  }
+}
+```
+
+**Version pins are mandatory.** Unpinned dependencies pull latest on every invocation, which can break without warning. When Serena or Context7 releases a new version, update the pins in this skill file after testing.
+
+If `.mcp.json` already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (in jq's `+` for objects, the right-hand side wins on collision — existing entries are preserved). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
 
 ### Creating `.serena.yml`
 

--- a/correctless-full/skills/cspec/SKILL.md
+++ b/correctless-full/skills/cspec/SKILL.md
@@ -48,7 +48,8 @@ Check current workflow state:
 .claude/hooks/workflow-advance.sh status
 ```
 
-If no workflow is active, initialize one:
+If no workflow is active, initialize one. Before calling `workflow-advance.sh init`, ask the user: **"Short name for this feature? (used in filenames, e.g., `auth-middleware`)"**. If the user provides a name, use it as the task description for `init`. If they say "auto" or don't provide one, use the first 3-4 words of the feature description.
+
 ```bash
 .claude/hooks/workflow-advance.sh init "task description"
 ```

--- a/correctless-full/skills/ctdd/SKILL.md
+++ b/correctless-full/skills/ctdd/SKILL.md
@@ -347,7 +347,11 @@ This artifact is consumed by `/cverify` (to check class fixes were implemented),
 
 **Then decide next step:**
 - **If a BLOCKING finding involves a bug that's hard to understand** (unclear root cause, multiple possible explanations): suggest the human run `/cdebug` for structured investigation before attempting the fix round.
-- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. The fix round implements BOTH fixes. Then re-run QA. Update the findings artifact with `status: fixed`.
+- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. Spawn a **fix agent** with these additional instructions:
+
+  > After fixing each finding, the fix agent must update `.claude/artifacts/qa-findings-{task-slug}.json`: set `"status": "fixed"` on the findings you addressed. This ensures the findings artifact stays current as fixes land.
+
+  The fix round implements BOTH instance and class fixes. Then re-run QA. After each fix round, the orchestrator must verify the findings JSON: any finding whose instance_fix was applied but still shows `"status": "open"` should be updated to `"fixed"` by you (the orchestrator). This catches cases where the fix agent forgot to update the status.
 - **If no BLOCKING findings**:
   - **Lite mode**: `workflow-advance.sh done`
   - **Full mode**: `workflow-advance.sh verify-phase` (goes to tdd-verify for final verification, then `done`)

--- a/correctless-full/templates/workflow-config-full.json
+++ b/correctless-full/templates/workflow-config-full.json
@@ -6,6 +6,7 @@
   },
   "commands": {
     "test": "",
+    "test_new": "",
     "test_json": "",
     "test_race": "",
     "test_verbose": "",

--- a/correctless-full/templates/workflow-config.json
+++ b/correctless-full/templates/workflow-config.json
@@ -6,6 +6,7 @@
   },
   "commands": {
     "test": "",
+    "test_new": "",
     "test_verbose": "",
     "coverage": "",
     "lint": "",

--- a/correctless-lite/hooks/workflow-advance.sh
+++ b/correctless-lite/hooks/workflow-advance.sh
@@ -216,7 +216,11 @@ tests_fail_not_build_error() {
     pkg="$(detect_affected_packages | awk '{print $1}')"
     [ "$pkg" = "." ] || true
   fi
-  test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  # Prefer commands.test_new if present (allows separate new-test file for RED gate)
+  test_cmd="$(read_package_config '.commands.test_new' "$pkg")"
+  if [ -z "$test_cmd" ] || [ "$test_cmd" = "null" ]; then
+    test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  fi
   fail_pattern="$(read_package_config '.patterns.test_fail_pattern' "$pkg")"
   build_pattern="$(read_package_config '.patterns.build_error_pattern' "$pkg")"
 
@@ -358,6 +362,34 @@ cmd_init() {
 
   local slug
   slug="$(echo "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')"
+  # Truncate to first 4 hyphen-separated tokens, max 50 chars
+  slug="$(echo "$slug" | cut -d'-' -f1-4)"
+  slug="${slug:0:50}"
+  slug="${slug%-}"
+
+  # Guard: empty slug (all-punctuation or whitespace input)
+  [ -n "$slug" ] || die "Could not generate a valid slug from: '$task'. Provide a description containing at least one letter or digit."
+
+  # Check for collision against both spec files on disk AND state files claiming the same spec_file
+  spec_slug_in_use() {
+    local check_slug="$1"
+    [ -f "$REPO_ROOT/docs/specs/${check_slug}.md" ] && return 0
+    for state_f in "$ARTIFACTS_DIR"/workflow-state-*.json; do
+      [ -f "$state_f" ] || continue
+      local existing
+      existing="$(jq -r '.spec_file // empty' "$state_f" 2>/dev/null)"
+      [ "$existing" = "docs/specs/${check_slug}.md" ] && return 0
+    done
+    return 1
+  }
+
+  local base_slug="$slug"
+  local suffix=2
+  while spec_slug_in_use "$slug"; do
+    slug="${base_slug}-${suffix}"
+    suffix=$((suffix + 1))
+  done
+
   local spec_file="docs/specs/${slug}.md"
 
   mkdir -p "$ARTIFACTS_DIR"

--- a/correctless-lite/skills/csetup/SKILL.md
+++ b/correctless-lite/skills/csetup/SKILL.md
@@ -192,7 +192,33 @@ If `uv` is not installed and the user wants Serena, print installation instructi
 
 ### Writing `.mcp.json`
 
-When writing `.mcp.json` in the project root: if the file already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries in `mcpServers` are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (note: in jq's `+` for objects, the right-hand side wins on key collision — so existing `.mcpServers` entries override the defaults, preserving custom configs). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
+When writing `.mcp.json` in the project root, use this template with version-pinned dependencies:
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena@v0.1.4",
+        "serena-mcp-server",
+        "--transport", "stdio"
+      ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@context7/mcp@2.1.6"
+      ]
+    }
+  }
+}
+```
+
+**Version pins are mandatory.** Unpinned dependencies pull latest on every invocation, which can break without warning. When Serena or Context7 releases a new version, update the pins in this skill file after testing.
+
+If `.mcp.json` already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (in jq's `+` for objects, the right-hand side wins on collision — existing entries are preserved). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
 
 ### Creating `.serena.yml`
 

--- a/correctless-lite/skills/cspec/SKILL.md
+++ b/correctless-lite/skills/cspec/SKILL.md
@@ -48,7 +48,8 @@ Check current workflow state:
 .claude/hooks/workflow-advance.sh status
 ```
 
-If no workflow is active, initialize one:
+If no workflow is active, initialize one. Before calling `workflow-advance.sh init`, ask the user: **"Short name for this feature? (used in filenames, e.g., `auth-middleware`)"**. If the user provides a name, use it as the task description for `init`. If they say "auto" or don't provide one, use the first 3-4 words of the feature description.
+
 ```bash
 .claude/hooks/workflow-advance.sh init "task description"
 ```

--- a/correctless-lite/skills/ctdd/SKILL.md
+++ b/correctless-lite/skills/ctdd/SKILL.md
@@ -347,7 +347,11 @@ This artifact is consumed by `/cverify` (to check class fixes were implemented),
 
 **Then decide next step:**
 - **If a BLOCKING finding involves a bug that's hard to understand** (unclear root cause, multiple possible explanations): suggest the human run `/cdebug` for structured investigation before attempting the fix round.
-- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. The fix round implements BOTH fixes. Then re-run QA. Update the findings artifact with `status: fixed`.
+- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. Spawn a **fix agent** with these additional instructions:
+
+  > After fixing each finding, the fix agent must update `.claude/artifacts/qa-findings-{task-slug}.json`: set `"status": "fixed"` on the findings you addressed. This ensures the findings artifact stays current as fixes land.
+
+  The fix round implements BOTH instance and class fixes. Then re-run QA. After each fix round, the orchestrator must verify the findings JSON: any finding whose instance_fix was applied but still shows `"status": "open"` should be updated to `"fixed"` by you (the orchestrator). This catches cases where the fix agent forgot to update the status.
 - **If no BLOCKING findings**:
   - **Lite mode**: `workflow-advance.sh done`
   - **Full mode**: `workflow-advance.sh verify-phase` (goes to tdd-verify for final verification, then `done`)

--- a/correctless-lite/templates/workflow-config.json
+++ b/correctless-lite/templates/workflow-config.json
@@ -6,6 +6,7 @@
   },
   "commands": {
     "test": "",
+    "test_new": "",
     "test_verbose": "",
     "coverage": "",
     "lint": "",

--- a/docs/specs/workflow-bug-fixes.md
+++ b/docs/specs/workflow-bug-fixes.md
@@ -1,0 +1,54 @@
+# Spec: Workflow Bug Fixes
+
+## What
+
+Fix four active friction bugs discovered during the MCP integration feature: absurdly long auto-generated spec slugs, separate test files breaking the RED gate, QA findings status never getting updated by fix agents, and no local sync check before commit.
+
+## Rules
+
+### Bug 1: Slug Truncation
+
+- **R-001** [unit]: `workflow-advance.sh` `cmd_init` truncates the slug to the first 4 hyphen-separated tokens after slugification (lowercase, non-alphanumeric replaced with hyphens, deduped). Max 50 characters. Example: "MCP integration: Serena + Context7 for symbol-level code analysis" → `mcp-integration-serena-context7`.
+
+- **R-002** [unit]: `/cspec` SKILL.md contains an instruction to ask the user "Short name for this feature? (used in filenames)" before calling `workflow-advance.sh init`. If the user provides a name, that becomes the init argument. If the user declines or says "auto", the skill uses the first 3-4 words of the feature description. Test: grep SKILL.md for the prompt text.
+
+### Bug 2: RED Gate with Separate Test Files
+
+- **R-003** [integration]: `workflow-advance.sh` supports a `commands.test_new` field in `workflow-config.json`. When present, `tests_fail_not_build_error` runs `commands.test_new` instead of `commands.test` to check the RED gate. This allows the main test suite (`commands.test`) to keep passing while new tests in a separate file fail as expected.
+
+- **R-004** [integration]: `tests_pass` (GREEN gate) continues to use `commands.test` — ALL tests including the new ones must pass before advancing to QA.
+
+- **R-005** [integration]: If `commands.test_new` is absent, empty, or null, `tests_fail_not_build_error` falls back to `commands.test` (current behavior preserved).
+
+### Bug 3: QA Findings Status Update
+
+- **R-006** [unit]: `/ctdd` SKILL.md contains an instruction for the fix agent to update `qa-findings-{task-slug}.json` after each fix: set `"status": "fixed"` on findings it addressed. Test: grep ctdd SKILL.md for "status.*fixed" or "mark.*fixed" instruction.
+
+- **R-007** [unit]: `/ctdd` SKILL.md contains an instruction for the orchestrator to verify findings statuses after each fix round and update any finding that was fixed but still shows `"status": "open"`. Test: grep ctdd SKILL.md for orchestrator verification instruction.
+
+### Bug 4: Local Sync Check
+
+- **R-008** [integration]: `sync.sh` supports a `--check` flag that runs sync in dry-run mode: compare source files against distribution copies and exit 1 if any differ, exit 0 if clean. No files are modified, no temp files created when `--check` is passed.
+
+- **R-009** [integration]: `.pre-commit-config.yaml` includes a local hook that runs `bash sync.sh --check` on commits that touch files in `skills/`, `hooks/`, `templates/`, or `helpers/`.
+
+- **R-010** [unit]: Both `templates/workflow-config.json` and `templates/workflow-config-full.json` include `commands.test_new` as an empty string field so new installs have it present.
+
+### Slug Collision
+
+- **R-011** [integration]: If a spec file already exists at `docs/specs/{slug}.md` or a state file with the same slug exists, `cmd_init` appends `-2` (or the next available number) to the slug before creating the state file.
+
+## Won't Do
+
+- Changing the state file naming convention (it uses the branch slug, not the spec slug — that's fine).
+- Adding `--check` to CI — CI already runs `sync.sh && git diff --exit-code` which is equivalent.
+- Retroactively fixing existing spec files with long slugs.
+
+## Risks
+
+- **R-001 slug truncation could collide** — two features starting with the same 4 tokens get the same slug. Mitigation: R-011 checks for existing files and appends a number.
+- **R-003 `test_new` adds config complexity** — another field for users to understand. Mitigation: the field is optional and unused by default. `/cspec` or `/ctdd` could auto-populate it when creating a new test file.
+
+## Open Questions
+
+- None.

--- a/docs/verification/workflow-bug-fixes-verification.md
+++ b/docs/verification/workflow-bug-fixes-verification.md
@@ -1,0 +1,61 @@
+# Verification: Workflow Bug Fixes
+
+## Rule Coverage
+
+| Rule | Test | Status | Notes |
+|------|------|--------|-------|
+| R-001 [unit] | test_slug_truncation (2 assertions) | covered | Truncation to 4 tokens + max 50 chars |
+| R-002 [unit] | test_cspec_short_name | covered | Grep cspec SKILL.md for prompt text |
+| R-003 [integration] | test_test_new_red_gate | covered | Integration test with real state machine |
+| R-004 [integration] | test_test_new_green_gate | covered | Regression: tests_pass uses commands.test |
+| R-005 [integration] | test_test_new_fallback | covered | Regression: absent test_new falls back |
+| R-006 [unit] | test_ctdd_findings_instruction | covered | Grep ctdd SKILL.md for fix agent instruction |
+| R-007 [unit] | test_ctdd_orchestrator_verify | covered | Grep ctdd SKILL.md for orchestrator instruction |
+| R-008 [integration] | test_sync_check (3 assertions) | covered | --check exits 0 clean, 1 dirty, no modifications |
+| R-009 [integration] | test_precommit_sync_hook | covered | Grep pre-commit config for sync check hook |
+| R-010 [unit] | test_template_test_new (2 assertions) | covered | Both templates have test_new field |
+| R-011 [integration] | test_slug_collision | covered | Creates existing spec, verifies -2 append |
+
+**11/11 rules covered. 0 uncovered. 0 weak.**
+
+## Dependencies
+
+No new dependencies added. Version pins applied to existing MCP dependencies:
+- Serena: `git+https://github.com/oraios/serena@v0.1.4` (was unpinned)
+- Context7: `@context7/mcp@2.1.6` (was unpinned)
+
+## Architecture Compliance
+
+- ✓ PAT-001 (Source → Distribution Sync): All edits in root files, synced to distributions
+- ✓ PAT-004 (Branch-Scoped State Machine): `cmd_init` slug changes maintain state file contract
+- ✓ Shell conventions: `set -euo pipefail`, jq for config reading
+- ✓ Test conventions: same assert helpers, section structure, cleanup pattern
+
+## QA Class Fixes Verified
+
+- QA-001: `spec_slug_in_use()` function checks both filesystem AND state files ✓
+- QA-002: Empty slug guard added ✓
+
+## Smells
+
+None found. Changes are bash functions and Markdown instructions.
+
+## Drift
+
+None detected. All 11 spec rules match implementation.
+
+## Spec Updates
+
+None during TDD. Spec was stable throughout implementation.
+
+## Test Results
+
+- `bash test-bugfixes.sh`: 15 passed, 0 failed
+- `bash test.sh`: 57 passed, 0 failed
+- `bash test-mcp.sh`: 192 passed, 0 failed
+- `bash sync.sh --check`: exit 0 (clean)
+- Total: 264 tests, 0 failures
+
+## Overall: PASS — 0 findings
+
+11/11 rules covered. 2 QA rounds, converged. No drift. Architecture compliant. Sync clean.

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -216,7 +216,11 @@ tests_fail_not_build_error() {
     pkg="$(detect_affected_packages | awk '{print $1}')"
     [ "$pkg" = "." ] || true
   fi
-  test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  # Prefer commands.test_new if present (allows separate new-test file for RED gate)
+  test_cmd="$(read_package_config '.commands.test_new' "$pkg")"
+  if [ -z "$test_cmd" ] || [ "$test_cmd" = "null" ]; then
+    test_cmd="$(read_package_config '.commands.test' "$pkg")"
+  fi
   fail_pattern="$(read_package_config '.patterns.test_fail_pattern' "$pkg")"
   build_pattern="$(read_package_config '.patterns.build_error_pattern' "$pkg")"
 
@@ -358,6 +362,34 @@ cmd_init() {
 
   local slug
   slug="$(echo "$task" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')"
+  # Truncate to first 4 hyphen-separated tokens, max 50 chars
+  slug="$(echo "$slug" | cut -d'-' -f1-4)"
+  slug="${slug:0:50}"
+  slug="${slug%-}"
+
+  # Guard: empty slug (all-punctuation or whitespace input)
+  [ -n "$slug" ] || die "Could not generate a valid slug from: '$task'. Provide a description containing at least one letter or digit."
+
+  # Check for collision against both spec files on disk AND state files claiming the same spec_file
+  spec_slug_in_use() {
+    local check_slug="$1"
+    [ -f "$REPO_ROOT/docs/specs/${check_slug}.md" ] && return 0
+    for state_f in "$ARTIFACTS_DIR"/workflow-state-*.json; do
+      [ -f "$state_f" ] || continue
+      local existing
+      existing="$(jq -r '.spec_file // empty' "$state_f" 2>/dev/null)"
+      [ "$existing" = "docs/specs/${check_slug}.md" ] && return 0
+    done
+    return 1
+  }
+
+  local base_slug="$slug"
+  local suffix=2
+  while spec_slug_in_use "$slug"; do
+    slug="${base_slug}-${suffix}"
+    suffix=$((suffix + 1))
+  done
+
   local spec_file="docs/specs/${slug}.md"
 
   mkdir -p "$ARTIFACTS_DIR"

--- a/skills/csetup/SKILL.md
+++ b/skills/csetup/SKILL.md
@@ -192,7 +192,33 @@ If `uv` is not installed and the user wants Serena, print installation instructi
 
 ### Writing `.mcp.json`
 
-When writing `.mcp.json` in the project root: if the file already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries in `mcpServers` are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (note: in jq's `+` for objects, the right-hand side wins on key collision — so existing `.mcpServers` entries override the defaults, preserving custom configs). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
+When writing `.mcp.json` in the project root, use this template with version-pinned dependencies:
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena@v0.1.4",
+        "serena-mcp-server",
+        "--transport", "stdio"
+      ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@context7/mcp@2.1.6"
+      ]
+    }
+  }
+}
+```
+
+**Version pins are mandatory.** Unpinned dependencies pull latest on every invocation, which can break without warning. When Serena or Context7 releases a new version, update the pins in this skill file after testing.
+
+If `.mcp.json` already exists with other MCP server entries, merge the new entries into the existing `mcpServers` object. Existing entries are never overwritten or removed — only new keys are added. Use `jq` if available: `jq '.mcpServers = ({"serena": {...}, "context7": {...}} + .mcpServers)' .mcp.json > .mcp.json.tmp && mv .mcp.json.tmp .mcp.json` (in jq's `+` for objects, the right-hand side wins on collision — existing entries are preserved). If `jq` is not available, use the Read tool to read the file, then Write to output the merged result.
 
 ### Creating `.serena.yml`
 

--- a/skills/cspec/SKILL.md
+++ b/skills/cspec/SKILL.md
@@ -48,7 +48,8 @@ Check current workflow state:
 .claude/hooks/workflow-advance.sh status
 ```
 
-If no workflow is active, initialize one:
+If no workflow is active, initialize one. Before calling `workflow-advance.sh init`, ask the user: **"Short name for this feature? (used in filenames, e.g., `auth-middleware`)"**. If the user provides a name, use it as the task description for `init`. If they say "auto" or don't provide one, use the first 3-4 words of the feature description.
+
 ```bash
 .claude/hooks/workflow-advance.sh init "task description"
 ```

--- a/skills/ctdd/SKILL.md
+++ b/skills/ctdd/SKILL.md
@@ -347,7 +347,11 @@ This artifact is consumed by `/cverify` (to check class fixes were implemented),
 
 **Then decide next step:**
 - **If a BLOCKING finding involves a bug that's hard to understand** (unclear root cause, multiple possible explanations): suggest the human run `/cdebug` for structured investigation before attempting the fix round.
-- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. The fix round implements BOTH fixes. Then re-run QA. Update the findings artifact with `status: fixed`.
+- **If BLOCKING findings exist**: present to human. Each finding must include both the instance fix AND the class fix. Then `workflow-advance.sh fix` to return to GREEN for a fix round. Spawn a **fix agent** with these additional instructions:
+
+  > After fixing each finding, the fix agent must update `.claude/artifacts/qa-findings-{task-slug}.json`: set `"status": "fixed"` on the findings you addressed. This ensures the findings artifact stays current as fixes land.
+
+  The fix round implements BOTH instance and class fixes. Then re-run QA. After each fix round, the orchestrator must verify the findings JSON: any finding whose instance_fix was applied but still shows `"status": "open"` should be updated to `"fixed"` by you (the orchestrator). This catches cases where the fix agent forgot to update the status.
 - **If no BLOCKING findings**:
   - **Lite mode**: `workflow-advance.sh done`
   - **Full mode**: `workflow-advance.sh verify-phase` (goes to tdd-verify for final verification, then `done`)

--- a/sync.sh
+++ b/sync.sh
@@ -6,57 +6,111 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+CHECK_ONLY=false
+if [ "${1:-}" = "--check" ]; then
+  CHECK_ONLY=true
+fi
+
 info() { echo "  ✓ $*"; }
 
-echo ""
-echo "Syncing source → plugins"
-echo "========================"
-echo ""
+DIRTY=false
+
+# Helper: copy or check a single file
+sync_file() {
+  local src="$1" dst="$2"
+  if [ "$CHECK_ONLY" = true ]; then
+    if ! diff -q "$src" "$dst" >/dev/null 2>&1; then
+      DIRTY=true
+    fi
+  else
+    cp "$src" "$dst"
+  fi
+}
+
+# Helper: copy or check a directory recursively
+sync_dir() {
+  local src="$1" dst="$2"
+  if [ "$CHECK_ONLY" = true ]; then
+    if ! diff -rq "$src" "$dst" >/dev/null 2>&1; then
+      DIRTY=true
+    fi
+  else
+    cp -r "$src" "$dst"
+  fi
+}
+
+if [ "$CHECK_ONLY" = false ]; then
+  echo ""
+  echo "Syncing source → plugins"
+  echo "========================"
+  echo ""
+fi
 
 # --- Hooks (shared by both) ---
 for hook in workflow-gate.sh workflow-advance.sh statusline.sh audit-trail.sh; do
-  cp "hooks/$hook" "correctless-lite/hooks/$hook"
-  cp "hooks/$hook" "correctless-full/hooks/$hook"
+  sync_file "hooks/$hook" "correctless-lite/hooks/$hook"
+  sync_file "hooks/$hook" "correctless-full/hooks/$hook"
 done
-info "Hooks → both plugins"
+[ "$CHECK_ONLY" = false ] && info "Hooks → both plugins"
 
 # --- Setup script (shared) ---
-cp setup correctless-lite/setup
-cp setup correctless-full/setup
-chmod +x correctless-lite/setup correctless-full/setup
-info "Setup script → both plugins"
+sync_file setup correctless-lite/setup
+sync_file setup correctless-full/setup
+if [ "$CHECK_ONLY" = false ]; then
+  chmod +x correctless-lite/setup correctless-full/setup
+  info "Setup script → both plugins"
+fi
 
 # --- Shared templates ---
 for tmpl in ARCHITECTURE.md AGENT_CONTEXT.md antipatterns.md workflow-config.json redaction-rules.md; do
-  cp "templates/$tmpl" "correctless-lite/templates/$tmpl"
-  cp "templates/$tmpl" "correctless-full/templates/$tmpl"
+  sync_file "templates/$tmpl" "correctless-lite/templates/$tmpl"
+  sync_file "templates/$tmpl" "correctless-full/templates/$tmpl"
 done
-info "Common templates → both plugins"
+[ "$CHECK_ONLY" = false ] && info "Common templates → both plugins"
 
 # --- Full-only templates ---
 for tmpl in workflow-config-full.json workflow-effectiveness.json drift-debt.json external-review-history.json; do
-  cp "templates/$tmpl" "correctless-full/templates/$tmpl"
+  sync_file "templates/$tmpl" "correctless-full/templates/$tmpl"
 done
-cp -r templates/invariants/* correctless-full/templates/invariants/
-info "Full-only templates → correctless-full"
+if [ "$CHECK_ONLY" = true ]; then
+  sync_dir "templates/invariants/." "correctless-full/templates/invariants/."
+else
+  cp -r templates/invariants/* correctless-full/templates/invariants/
+  info "Full-only templates → correctless-full"
+fi
 
 # --- Full-only helpers ---
-cp -r helpers/* correctless-full/helpers/
-info "PBT helpers → correctless-full"
+if [ "$CHECK_ONLY" = true ]; then
+  sync_dir "helpers/." "correctless-full/helpers/."
+else
+  cp -r helpers/* correctless-full/helpers/
+  info "PBT helpers → correctless-full"
+fi
 
 # --- Lite skills ---
 for skill in csetup cspec creview ctdd cverify cdocs crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf; do
-  mkdir -p "correctless-lite/skills/$skill"
-  cp "skills/$skill/SKILL.md" "correctless-lite/skills/$skill/SKILL.md"
+  if [ "$CHECK_ONLY" = false ]; then
+    mkdir -p "correctless-lite/skills/$skill"
+  fi
+  sync_file "skills/$skill/SKILL.md" "correctless-lite/skills/$skill/SKILL.md"
 done
-info "Lite skills (16) → correctless-lite"
+[ "$CHECK_ONLY" = false ] && info "Lite skills (16) → correctless-lite"
 
 # --- Full skills (all) ---
 for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf; do
-  mkdir -p "correctless-full/skills/$skill"
-  cp "skills/$skill/SKILL.md" "correctless-full/skills/$skill/SKILL.md"
+  if [ "$CHECK_ONLY" = false ]; then
+    mkdir -p "correctless-full/skills/$skill"
+  fi
+  sync_file "skills/$skill/SKILL.md" "correctless-full/skills/$skill/SKILL.md"
 done
-info "Full skills (23) → correctless-full"
+[ "$CHECK_ONLY" = false ] && info "Full skills (23) → correctless-full"
+
+if [ "$CHECK_ONLY" = true ]; then
+  if [ "$DIRTY" = true ]; then
+    exit 1
+  fi
+  exit 0
+fi
 
 echo ""
 echo "Done. Verify with: git diff --stat"

--- a/templates/workflow-config-full.json
+++ b/templates/workflow-config-full.json
@@ -6,6 +6,7 @@
   },
   "commands": {
     "test": "",
+    "test_new": "",
     "test_json": "",
     "test_race": "",
     "test_verbose": "",

--- a/templates/workflow-config.json
+++ b/templates/workflow-config.json
@@ -6,6 +6,7 @@
   },
   "commands": {
     "test": "",
+    "test_new": "",
     "test_verbose": "",
     "coverage": "",
     "lint": "",

--- a/test-bugfixes.sh
+++ b/test-bugfixes.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# Correctless — workflow bug fix tests
+# Tests spec rules R-001 through R-011 from docs/specs/workflow-bug-fixes.md
+# Run from repo root: bash test-bugfixes.sh
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="/tmp/correctless-bugfix-test-$$"
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers (same as test.sh)
+# ---------------------------------------------------------------------------
+
+setup_test_project() {
+  rm -rf "$TEST_DIR"
+  mkdir -p "$TEST_DIR"
+  cd "$TEST_DIR" || exit
+  git init -q
+  git branch -M main
+  echo '{"name": "test-app", "scripts": {"test": "echo FAIL && exit 1", "lint": "echo ok", "build": "echo ok"}}' > package.json
+  echo 'export function hello() {}' > index.ts
+  git add -A && git commit -q -m "init"
+
+  # Install correctless (exclude .git to avoid nested repo confusion)
+  mkdir -p .claude/skills/workflow
+  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+}
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" expected="$2" actual="$3"
+  if echo "$actual" | grep -q "$expected"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected output to contain '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local actual_exit
+  "$@" >/dev/null 2>&1 && actual_exit=0 || actual_exit=$?
+  assert_eq "$desc" "$expected_exit" "$actual_exit"
+}
+
+file_contains() { grep -q "$2" "$1" 2>/dev/null; }
+
+ADV() { cd "$TEST_DIR" && .claude/hooks/workflow-advance.sh "$@"; }
+
+# ---------------------------------------------------------------------------
+# Bug 1: Slug Truncation — R-001, R-002, R-011
+# ---------------------------------------------------------------------------
+
+test_slug_truncation() {
+  echo ""
+  echo "=== Bug 1: Slug Truncation (R-001, R-002, R-011) ==="
+
+  # --- R-001 [unit]: slug truncated to first 4 tokens, max 50 chars ---
+
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b feature/slug-trunc
+
+  ADV init "MCP integration Serena Context7 for symbol level code analysis" >/dev/null 2>&1
+
+  # Read the spec_file from state
+  local state_file spec_file slug token_count slug_len
+  state_file="$(ls .claude/artifacts/workflow-state-feature-slug-trunc-*.json 2>/dev/null | head -1)"
+  spec_file="$(jq -r '.spec_file' "$state_file")"
+
+  # Extract the slug portion: strip "docs/specs/" prefix and ".md" suffix
+  slug="$(echo "$spec_file" | sed 's|^docs/specs/||' | sed 's|\.md$||')"
+
+  # Count hyphen-separated tokens
+  token_count="$(echo "$slug" | tr '-' '\n' | wc -l | tr -d ' ')"
+  slug_len="${#slug}"
+
+  # R-001: at most 4 tokens
+  local four_or_fewer
+  if [ "$token_count" -le 4 ]; then
+    four_or_fewer="true"
+  else
+    four_or_fewer="false"
+  fi
+  assert_eq "R-001: slug has at most 4 hyphen-separated tokens (got $token_count: '$slug')" "true" "$four_or_fewer"
+
+  # R-001: max 50 chars
+  local within_limit
+  if [ "$slug_len" -le 50 ]; then
+    within_limit="true"
+  else
+    within_limit="false"
+  fi
+  assert_eq "R-001: slug is max 50 characters (got $slug_len)" "true" "$within_limit"
+
+  # --- R-002 [unit]: /cspec SKILL.md asks for a short feature name ---
+
+  local skill_file="$REPO_DIR/skills/cspec/SKILL.md"
+  local has_short_name="false"
+  if grep -qi "short.*name" "$skill_file" && grep -qi "used in filenames" "$skill_file"; then
+    has_short_name="true"
+  fi
+  assert_eq "R-002: /cspec SKILL.md asks for short name used in filenames" "true" "$has_short_name"
+
+  # --- R-011 [integration]: collision appends -2 ---
+
+  # Reset: clean project
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b feature/slug-collision
+
+  # Pre-create a spec file that would collide
+  mkdir -p docs/specs
+  echo "# Existing spec" > docs/specs/workflow-bug.md
+
+  ADV init "workflow bug" >/dev/null 2>&1
+
+  state_file="$(ls .claude/artifacts/workflow-state-feature-slug-collision-*.json 2>/dev/null | head -1)"
+  spec_file="$(jq -r '.spec_file' "$state_file")"
+
+  assert_eq "R-011: collision appends -2 to spec_file" "docs/specs/workflow-bug-2.md" "$spec_file"
+}
+
+# ---------------------------------------------------------------------------
+# Bug 2: RED Gate with test_new — R-003, R-004, R-005
+# ---------------------------------------------------------------------------
+
+test_red_gate_test_new() {
+  echo ""
+  echo "=== Bug 2: RED Gate with test_new (R-003, R-004, R-005) ==="
+
+  # --- R-003 [integration]: tests_fail_not_build_error uses commands.test_new ---
+
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b feature/test-new-red
+
+  # Configure: test (main suite) passes, test_new (new tests) fails
+  # This mimics having existing passing tests + new failing tests
+  cat > .claude/workflow-config.json <<'WCONF'
+{
+  "project": { "name": "test-app", "language": "typescript", "description": "" },
+  "commands": {
+    "test": "echo ALL_PASS && exit 0",
+    "test_new": "echo NEW_FAIL && exit 1",
+    "lint": "echo ok",
+    "build": "echo ok"
+  },
+  "patterns": {
+    "test_file": "*.test.ts",
+    "source_file": "*.ts",
+    "test_fail_pattern": "FAIL",
+    "build_error_pattern": "SyntaxError|Cannot find module"
+  },
+  "is_monorepo": false,
+  "packages": {},
+  "workflow": { "min_qa_rounds": 1, "require_review": true, "auto_update_antipatterns": true }
+}
+WCONF
+
+  ADV init "test new red gate" >/dev/null 2>&1
+  mkdir -p docs/specs
+  echo "# Spec" > docs/specs/test-new-red-gate.md
+  ADV review >/dev/null 2>&1
+  ADV tests >/dev/null 2>&1
+
+  # Create a test file so test_files_exist passes
+  echo '// test' > foo.test.ts
+  git add foo.test.ts
+
+  # Advancing to impl should succeed: test_new fails (RED gate satisfied)
+  local _impl_out impl_exit
+  _impl_out="$(ADV impl 2>&1)" && impl_exit=0 || impl_exit=$?
+  assert_eq "R-003: impl succeeds when test_new fails (RED gate)" "0" "$impl_exit"
+
+  # --- R-004 [integration]: tests_pass (GREEN gate) uses commands.test ---
+
+  # Now in tdd-impl phase. Configure test to fail (all tests including new must pass)
+  cat > .claude/workflow-config.json <<'WCONF'
+{
+  "project": { "name": "test-app", "language": "typescript", "description": "" },
+  "commands": {
+    "test": "echo SOME_FAIL && exit 1",
+    "test_new": "echo NEW_PASS && exit 0",
+    "lint": "echo ok",
+    "build": "echo ok"
+  },
+  "patterns": {
+    "test_file": "*.test.ts",
+    "source_file": "*.ts",
+    "test_fail_pattern": "FAIL",
+    "build_error_pattern": "SyntaxError|Cannot find module"
+  },
+  "is_monorepo": false,
+  "packages": {},
+  "workflow": { "min_qa_rounds": 1, "require_review": true, "auto_update_antipatterns": true }
+}
+WCONF
+
+  local _qa_out qa_exit
+  _qa_out="$(ADV qa 2>&1)" && qa_exit=0 || qa_exit=$?
+  assert_eq "R-004: qa blocked when commands.test fails (GREEN gate uses test, not test_new)" "1" "$qa_exit"
+
+  # --- R-005 [integration]: without test_new, falls back to commands.test ---
+
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b feature/test-no-new
+
+  # Config has NO test_new field
+  cat > .claude/workflow-config.json <<'WCONF'
+{
+  "project": { "name": "test-app", "language": "typescript", "description": "" },
+  "commands": {
+    "test": "echo FAIL && exit 1",
+    "lint": "echo ok",
+    "build": "echo ok"
+  },
+  "patterns": {
+    "test_file": "*.test.ts",
+    "source_file": "*.ts",
+    "test_fail_pattern": "FAIL",
+    "build_error_pattern": "SyntaxError|Cannot find module"
+  },
+  "is_monorepo": false,
+  "packages": {},
+  "workflow": { "min_qa_rounds": 1, "require_review": true, "auto_update_antipatterns": true }
+}
+WCONF
+
+  ADV init "test fallback" >/dev/null 2>&1
+  mkdir -p docs/specs
+  echo "# Spec" > docs/specs/test-fallback.md
+  ADV review >/dev/null 2>&1
+  ADV tests >/dev/null 2>&1
+
+  echo '// test' > bar.test.ts
+  git add bar.test.ts
+
+  # Should succeed: test command fails (RED gate), no test_new => fallback to test
+  local _fb_out fb_exit
+  _fb_out="$(ADV impl 2>&1)" && fb_exit=0 || fb_exit=$?
+  assert_eq "R-005: impl succeeds when no test_new and commands.test fails (fallback)" "0" "$fb_exit"
+}
+
+# ---------------------------------------------------------------------------
+# Bug 3: QA Findings Status — R-006, R-007
+# ---------------------------------------------------------------------------
+
+test_qa_findings_status() {
+  echo ""
+  echo "=== Bug 3: QA Findings Status (R-006, R-007) ==="
+
+  local ctdd_skill="$REPO_DIR/skills/ctdd/SKILL.md"
+
+  # --- R-006 [unit]: /ctdd instructs fix agent to update findings status ---
+  # The spec says: "instruction for the fix agent to update qa-findings-{task-slug}.json
+  # after each fix: set status to fixed on findings it addressed."
+  # This must be in the fix agent's instructions (the spawn prompt for GREEN fix rounds),
+  # not just the orchestrator's findings persistence section.
+
+  local has_fix_agent_instruction="false"
+  # Look for fix-agent-specific instruction about updating findings status.
+  # The existing "Update the findings artifact with status: fixed" is about the orchestrator's
+  # general flow, not a specific instruction TO the fix agent. The spec (R-006) requires:
+  # "instruction for the fix agent to update qa-findings-{task-slug}.json after each fix:
+  #  set status to fixed on findings it addressed."
+  # This must appear as a spawned agent instruction (in a blockquote or dedicated section),
+  # not just the orchestrator's own procedure notes.
+  # We look for "fix agent" near "qa-findings" and "status" in a targeted way.
+  if grep -qiP 'fix\s+agent.*qa-findings.*status.*fixed' "$ctdd_skill" || \
+     grep -qiP '> .*update.*qa-findings.*status.*fixed' "$ctdd_skill"; then
+    has_fix_agent_instruction="true"
+  fi
+  assert_eq "R-006: /ctdd SKILL.md instructs fix agent to update findings status to fixed" "true" "$has_fix_agent_instruction"
+
+  # --- R-007 [unit]: /ctdd instructs orchestrator to verify findings statuses ---
+  # The spec says: "instruction for the orchestrator to verify findings statuses after
+  # each fix round and update any finding that was fixed but still shows status: open"
+
+  local has_verify_instruction="false"
+  if grep -qiP 'orchestrator.*verify.*findings.*status' "$ctdd_skill" || \
+     grep -qiP 'verify.*finding.*status.*(open|fixed)' "$ctdd_skill" || \
+     grep -qiP 'after.*fix.*round.*verif' "$ctdd_skill"; then
+    has_verify_instruction="true"
+  fi
+  assert_eq "R-007: /ctdd SKILL.md instructs orchestrator to verify findings statuses" "true" "$has_verify_instruction"
+}
+
+# ---------------------------------------------------------------------------
+# Bug 4: Local Sync Check — R-008, R-009, R-010
+# ---------------------------------------------------------------------------
+
+test_sync_check() {
+  echo ""
+  echo "=== Bug 4: Local Sync Check (R-008, R-009, R-010) ==="
+
+  # --- R-008 [integration]: sync.sh --check exits 0 when clean, 1 when dirty ---
+  # The --check flag must be a recognized dry-run mode: compare source files against
+  # distribution copies and exit 1 if any differ, exit 0 if clean. No files modified.
+
+  # First, run sync.sh to ensure everything is in sync
+  local _sync_out
+  _sync_out="$(cd "$REPO_DIR" && bash sync.sh 2>&1)" || true
+
+  # Verify --check is actually recognized (not silently ignored).
+  # If --check is implemented, it should NOT produce the "Syncing source" banner
+  # (that would mean it's doing a real sync, not a dry-run check).
+  local check_output check_clean_exit
+  check_output="$(cd "$REPO_DIR" && bash sync.sh --check 2>&1)" && check_clean_exit=0 || check_clean_exit=$?
+
+  # The --check flag must NOT produce the sync banner (it's dry-run, not a real sync)
+  local is_dryrun="true"
+  if echo "$check_output" | grep -q "Syncing source"; then
+    is_dryrun="false"
+  fi
+  assert_eq "R-008: sync.sh --check is dry-run (no sync banner)" "true" "$is_dryrun"
+
+  # Only meaningful if --check is actually a dry-run (not just the normal sync exiting 0)
+  if [ "$is_dryrun" = "true" ]; then
+    assert_eq "R-008: sync.sh --check exits 0 when clean" "0" "$check_clean_exit"
+  else
+    # --check flag not implemented; report as fail
+    assert_eq "R-008: sync.sh --check exits 0 when clean (requires --check to be implemented)" "true" "false"
+  fi
+
+  # Modify a source skill file to make it out of sync
+  cp "$REPO_DIR/skills/cspec/SKILL.md" "/tmp/cspec-skill-backup-$$"
+  echo "# DIRTY MODIFICATION FOR TEST" >> "$REPO_DIR/skills/cspec/SKILL.md"
+
+  local check_dirty_exit
+  (cd "$REPO_DIR" && bash sync.sh --check >/dev/null 2>&1) && check_dirty_exit=0 || check_dirty_exit=$?
+  assert_eq "R-008: sync.sh --check exits 1 when out of sync" "1" "$check_dirty_exit"
+
+  # Restore the file exactly and re-sync in case --check wasn't dry-run
+  cp "/tmp/cspec-skill-backup-$$" "$REPO_DIR/skills/cspec/SKILL.md"
+  rm -f "/tmp/cspec-skill-backup-$$"
+  (cd "$REPO_DIR" && bash sync.sh >/dev/null 2>&1) || true
+
+  # --- R-009 [integration]: .pre-commit-config.yaml has sync check hook ---
+
+  local precommit="$REPO_DIR/.pre-commit-config.yaml"
+  local has_sync_hook="false"
+  if grep -q "sync.sh --check" "$precommit" 2>/dev/null; then
+    has_sync_hook="true"
+  fi
+  assert_eq "R-009: .pre-commit-config.yaml contains sync.sh --check hook" "true" "$has_sync_hook"
+
+  # --- R-010 [unit]: templates include commands.test_new field ---
+
+  local lite_tmpl="$REPO_DIR/templates/workflow-config.json"
+  local full_tmpl="$REPO_DIR/templates/workflow-config-full.json"
+
+  local lite_has_test_new="false"
+  if grep -q "test_new" "$lite_tmpl" 2>/dev/null; then
+    lite_has_test_new="true"
+  fi
+  assert_eq "R-010: workflow-config.json template has test_new field" "true" "$lite_has_test_new"
+
+  local full_has_test_new="false"
+  if grep -q "test_new" "$full_tmpl" 2>/dev/null; then
+    full_has_test_new="true"
+  fi
+  assert_eq "R-010: workflow-config-full.json template has test_new field" "true" "$full_has_test_new"
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+trap cleanup EXIT
+
+echo "Correctless — Workflow Bug Fix Tests"
+echo "====================================="
+
+test_slug_truncation
+test_red_gate_test_new
+test_qa_findings_status
+test_sync_check
+
+echo ""
+echo "====================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "====================================="
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **Slug truncation**: `cmd_init` limits slugs to 4 tokens / 50 chars with collision detection. `/cspec` asks for a short name first.
- **RED gate**: New `commands.test_new` config field lets new tests live in a separate file without breaking the RED gate.
- **QA findings status**: `/ctdd` now instructs fix agents to update finding statuses in the JSON artifact. Orchestrator verifies after each fix round.
- **Sync check**: `sync.sh --check` exits 1 if distributions are stale. Pre-commit hook runs it on source file changes.
- **Version pins**: Serena (v0.1.4) and Context7 (2.1.6) pinned in `.mcp.json` and `/csetup` SKILL.md template.

## Type

- [x] Bug fix
- [ ] New skill
- [ ] Skill enhancement
- [x] Hook change
- [ ] Documentation
- [x] CI/tooling

## Checklist

- [x] `bash test.sh` passes (57 tests)
- [x] `bash test-mcp.sh` passes (192 tests)
- [x] `bash test-bugfixes.sh` passes (15 tests)
- [x] `bash sync.sh` produces no changes
- [x] `bash sync.sh --check` exits 0
- [x] Skill registered in all locations
- [x] Documentation page added/updated in `docs/skills/`
- [x] README updated (not needed — internal fixes)

## Testing

Correctless Lite workflow: /cspec (11 rules) → /creview (5 changes applied) → /ctdd (RED → GREEN → QA R1 → fix → QA R2 converged) → /cverify (PASS) → /cdocs.

264 total tests, all green. Pre-commit hooks pass (including new sync check hook).