### PR TITLE
Add QoL improvements: /cquick, workflow history, time-in-phase, spec templates

### DIFF
--- a/.claude/workflow-config.json
+++ b/.claude/workflow-config.json
@@ -5,7 +5,7 @@
     "description": "Claude Code plugin framework: structured workflow skills for spec-driven development with TDD, auditing, and project health"
   },
   "commands": {
-    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh",
+    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh",
     "test_verbose": "bash test.sh && bash test-mcp.sh",
     "coverage": "",
     "lint": "shellcheck hooks/*.sh test.sh sync.sh setup",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Workflow history is append-only — use union merge to avoid conflicts
+docs/workflow-history.md merge=union

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -10,14 +10,14 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| Skills | `skills/*/SKILL.md` | 23 skill definitions. Each is a slash command with frontmatter contract. |
+| Skills | `skills/*/SKILL.md` | 24 skill definitions. Each is a slash command with frontmatter contract. |
 | Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh |
 | Templates | `templates/` | Scaffolding for new projects: ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, configs |
 | Helpers | `helpers/` | PBT guides per language (Full-only) |
 | Lite dist | `correctless-lite/` | 16-skill distribution target — never edit directly |
 | Full dist | `correctless-full/` | 23-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh` | 264 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes |
+| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh`, `test-qol.sh` | 289 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL improvements |
 | Sync | `sync.sh` | Propagates source edits to both distribution targets |
 
 ## Design Patterns
@@ -38,7 +38,7 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 
 | Need to... | Do this |
 |------------|---------|
-| Run tests | `bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh` |
+| Run tests | `bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh` |
 | Lint shell scripts | `shellcheck hooks/*.sh test.sh sync.sh setup` |
 | Sync to distributions | `bash sync.sh` |
 | Find a skill | `skills/{name}/SKILL.md` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,22 +7,29 @@ Thanks for your interest in contributing! Correctless is a set of Claude Code sk
 ```bash
 git clone https://github.com/joshft/correctless.git
 cd correctless
-bash test.sh          # Run the 57-test suite
-bash sync.sh          # Propagate source → both plugins
+bash test.sh              # 57 infrastructure tests
+bash test-mcp.sh          # 192 MCP integration tests
+bash test-bugfixes.sh     # 15 bug fix tests
+bash test-qol.sh          # 25 QoL improvement tests
+bash sync.sh              # Propagate source → both plugins
+bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 ```
 
 ## Project Structure
 
 ```
-skills/               # Source skills (23 SKILL.md files)
+skills/               # Source skills (24 SKILL.md files)
 hooks/                # Bash hooks (gate, state machine, statusline, audit trail)
-templates/            # Config and doc templates
+templates/            # Config, doc, and spec templates
 helpers/              # PBT helpers (Full mode only)
 setup                 # Install script
-test.sh               # Automated test suite
+test.sh               # Infrastructure tests (57)
+test-mcp.sh           # MCP integration tests (192)
+test-bugfixes.sh      # Bug fix tests (15)
+test-qol.sh           # QoL improvement tests (25)
 sync.sh               # Copies source → correctless-lite/ and correctless-full/
-correctless-lite/     # Lite plugin (16 skills)
-correctless-full/     # Full plugin (23 skills)
+correctless-lite/     # Lite plugin (17 skills)
+correctless-full/     # Full plugin (24 skills)
 docs/skills/          # Per-skill documentation pages
 ```
 
@@ -83,12 +90,30 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Testing
 
 ```bash
-bash test.sh          # 57 tests covering setup, state machine, gate, utilities, Full mode
-bash sync.sh          # Must produce no changes (git diff --exit-code)
-shellcheck hooks/*.sh # Must pass with -S warning
+bash test.sh              # 57 infrastructure tests
+bash test-mcp.sh          # 192 MCP integration tests
+bash test-bugfixes.sh     # 15 bug fix tests
+bash test-qol.sh          # 25 QoL improvement tests
+bash sync.sh --check      # Distributions must be in sync
+shellcheck hooks/*.sh     # Must pass with -S warning
 ```
 
-CI runs all three on every PR.
+CI runs tests + sync check + ShellCheck on every PR.
+
+## Pre-commit Hooks
+
+Install pre-commit hooks for local checks before commits:
+
+```bash
+pip install pre-commit   # or: pipx install pre-commit
+pre-commit install
+```
+
+Hooks: gitleaks (secret scanning), typos, shellcheck, trailing whitespace, sync check.
+
+## Quick Fixes
+
+For small changes (< 50 LOC, < 3 files), use `/cquick` instead of the full workflow. It enforces TDD but skips spec/review/verify/docs.
 
 ## QA Process
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/joshft/correctless/badge)](https://scorecard.dev/viewer/?uri=github.com/joshft/correctless)
 [![CI](https://github.com/joshft/correctless/actions/workflows/ci.yml/badge.svg)](https://github.com/joshft/correctless/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills: 23](https://img.shields.io/badge/skills-23-blue.svg)](docs/skills/)
+[![Skills: 24](https://img.shields.io/badge/skills-23-blue.svg)](docs/skills/)
 [![Version: 2.0.0](https://img.shields.io/badge/version-2.0.0-green.svg)](CHANGELOG.md)
 
 Composable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that enforce a correctness-oriented development workflow. Spec before you code. Test before you implement. Never let an agent grade its own work.
@@ -210,6 +210,7 @@ graph TD
 
 | Skill | When to Use | Description |
 |-------|------------|-------------|
+| [`/cquick`](docs/skills/cquick.md) | Small, well-understood changes | TDD without the ceremony — scope-guarded at 50 LOC / 3 files |
 | [`/crefactor`](docs/skills/crefactor.md) | Restructuring without changing behavior | Characterization tests, behavioral equivalence, agent separation |
 | [`/cdebug`](docs/skills/cdebug.md) | Stuck on a bug | Root cause → hypothesis → bisect → TDD fix → class fix |
 | [`/cpr-review`](docs/skills/cpr-review.md) | Someone opens a PR against your project | Architecture, security, tests, antipatterns, dep bumps |

--- a/correctless-full/skills/cdocs/SKILL.md
+++ b/correctless-full/skills/cdocs/SKILL.md
@@ -113,6 +113,19 @@ Structure your output:
 
 ## After Documentation
 
+### Workflow History
+
+Before advancing the state machine, append a workflow summary to `docs/workflow-history.md`. This file is append-only — never rewrite or delete existing entries. If the file doesn't exist, create it with a `# Workflow History` header.
+
+Each entry is one paragraph:
+
+```
+### {date} — {feature name}
+Branch: {branch}. Rules: {count}. QA rounds: {N}. Findings fixed: {N}. {one-line description}.
+```
+
+Read the workflow state file (`.claude/artifacts/workflow-state-{branch-slug}.json`): use `.branch` for the branch name, `.qa_rounds` for QA round count, `.spec_file` for the spec path. Count rules from the spec file (count lines matching `R-[0-9]` or `INV-[0-9]`). Count fixed findings from `.claude/artifacts/qa-findings-{task-slug}.json` if it exists (count entries where `.status == "fixed"`). Use today's date and the feature name from the spec's `# Spec: {title}` heading.
+
 ### Convention Learning
 
 If this is the 3rd or more feature where the same architectural pattern has appeared (check docs/specs/ for recurring patterns), append to the `## Correctless Learnings` section of `CLAUDE.md`:

--- a/correctless-full/skills/chelp/SKILL.md
+++ b/correctless-full/skills/chelp/SKILL.md
@@ -57,6 +57,7 @@ Feature workflow:
   /cdocs        Update documentation
 
 Other:
+  /cquick       Quick fix with TDD — no spec/review for small changes
   /crefactor    Structured refactoring (tests must pass before + after)
   /cpr-review   Review someone else's PR
   /ccontribute  Contribute to someone else's project

--- a/correctless-full/skills/cquick/SKILL.md
+++ b/correctless-full/skills/cquick/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cquick
+description: Quick fix with TDD — no spec/review for small changes. Branch, test, implement, commit.
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
+---
+
+# /cquick — Quick Fix with TDD
+
+You are the quick-fix agent. Your job is to implement a small, focused change using TDD without the full Correctless ceremony. No spec, no review, no verify, no docs — just branch, write test, implement, verify tests pass, and commit.
+
+## Before You Start
+
+### Branch Guard
+
+Check the current branch:
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`, stop immediately and tell the user: "You're on the main branch. Create a feature branch first: `git checkout -b fix/short-description`." Do not auto-create branches — the human decides the branch name.
+
+### Active Workflow Guard
+
+Check if a workflow is already active on this branch:
+```bash
+.claude/hooks/workflow-advance.sh status 2>/dev/null
+```
+
+If a workflow is active, stop and tell the user: "There's an active Correctless workflow on this branch. Use the workflow skills (`/ctdd`, `/cverify`, etc.) instead of `/cquick`. This skill is for standalone small fixes outside of an active workflow."
+
+## Scope Guard
+
+Before writing any code, assess the change:
+- If the change will exceed 50 LOC (lines of code) or touch more than 3 files, stop and say: "This is bigger than a quick fix — run `/cspec` to start the full workflow."
+- Re-evaluate during implementation. If you realize mid-way that the change is growing beyond 50 LOC or 3 files, stop and escalate to `/cspec`.
+
+## TDD Workflow
+
+Follow strict TDD — write at least one test before implementing the change.
+
+### 1. Write Test First
+
+Write at least one test that describes the expected behavior of the fix. The test must fail before implementation (RED phase). Run the test command and display the failure output. Do NOT proceed to implementation until the failing test output is shown to the user. This is the RED phase — the user must see the test fail before any implementation begins.
+
+```bash
+# Run the relevant test suite and show the failure output
+```
+
+### 2. Implement
+
+Write the minimal code to make the test pass (GREEN phase). Do not write more code than necessary.
+
+### 3. Verify
+
+Run the full relevant test suite to confirm:
+- The new test passes
+- No existing tests broke
+
+```bash
+# Run tests and verify all pass
+```
+
+### 4. Measure Scope
+
+Before committing, verify the change stayed within quick-fix limits:
+```bash
+git diff --stat
+```
+
+Count the actual LOC changed and files touched from the diff output. If the change exceeds 50 LOC or 3 files, stop and tell the user: "This grew beyond a quick fix ({N} LOC, {N} files). Consider running `/cspec` to formalize." Do not commit until the user acknowledges.
+
+### 5. Commit
+
+Stage and commit the change with a clear message explaining what was fixed and why:
+```bash
+git add <changed files>
+git commit -m "Fix: <description>"
+```
+
+## Constraints
+
+- **TDD is mandatory.** You must write test before implementing — no exceptions. This is TDD without the ceremony, not no-TDD.
+- **No spec, no review, no verify, no docs.** This is for small, obvious fixes.
+- **Scope limit:** 50 LOC, 3 files max. If the change grows beyond this, stop and tell the user to run `/cspec`.
+- **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
+- **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
+
+## If Something Goes Wrong
+
+- Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.
+- Scope creep: stop and escalate to `/cspec`. Don't try to force a large change through `/cquick`.
+- On wrong branch: tell the user to create a feature branch.

--- a/correctless-full/skills/crefactor/SKILL.md
+++ b/correctless-full/skills/crefactor/SKILL.md
@@ -323,6 +323,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when checking whether a dependency migration path exists during refactoring:
+
+- Use `resolve-library-id` + `get-library-docs` to check if the target library version has a migration guide
+- Useful when refactoring involves upgrading a dependency (e.g., "does library-x v3 have a codemod for v2 → v3?")
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes mid-refactor**: Re-run `/crefactor`. The refactor intent document (`.claude/artifacts/refactor-intent-{slug}.md`) and baseline (`.claude/artifacts/refactor-baseline-{slug}.json`) persist — the skill can pick up context from these. However, partially completed refactor phases may need manual review.

--- a/correctless-full/skills/creview/SKILL.md
+++ b/correctless-full/skills/creview/SKILL.md
@@ -274,6 +274,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 to verify library-related claims in the spec (e.g., "bcrypt cost 12 is recommended", "use Zod for validation"):
+
+- Use `resolve-library-id` to find the library, then `get-library-docs` to fetch current docs
+- Compare the spec's claims against actual current documentation
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.

--- a/correctless-full/skills/cspec/SKILL.md
+++ b/correctless-full/skills/cspec/SKILL.md
@@ -179,6 +179,12 @@ After receiving the research subagent's output, **you** (the cspec agent) write 
 
 ### Step 3: Draft the Spec
 
+Before drafting, read the appropriate spec template file and use it as the skeleton:
+- Lite mode: read `templates/spec-lite.md` from the Correctless plugin directory
+- Full mode: read `templates/spec-full.md` from the Correctless plugin directory
+
+Use the template as the skeleton — fill in the placeholders with the feature-specific content rather than reconstructing the format from these instructions.
+
 Write the spec to `docs/specs/{task-slug}.md`.
 
 **Lite mode** — use 5 sections (What, Rules with R-xxx IDs, Won't Do, Risks, Open Questions). Keep it simple.

--- a/correctless-full/skills/cstatus/SKILL.md
+++ b/correctless-full/skills/cstatus/SKILL.md
@@ -39,6 +39,17 @@ If no active workflow, also run:
 - Start a new feature: `git checkout -b feature/my-feature` then `/cspec`
 - Check other branches: {show status-all output if there are active workflows elsewhere}"
 
+**When displaying the current phase, calculate and show the time spent in this phase.** Read `phase_entered_at` from the state file, compute the duration as `now - phase_entered_at`, and display in human-readable format:
+- Under 60 minutes: '{N} minutes' (e.g., '12 minutes')
+- 1-24 hours: '{N} hours' (e.g., '2 hours')
+- Over 24 hours: '{N} days' (e.g., '1 day')
+
+Format: 'Phase: {phase} ({duration})'
+
+Proactive warnings at thresholds:
+- After more than 1 hour in a phase: 'This phase has been active for {duration}. If you are stuck, try re-running the skill for this phase.'
+- After more than 24 hours: 'This workflow has been in {phase} for {duration}. The workflow may be stalled — re-run the skill or use `workflow-advance.sh override` if needed.'
+
 **If workflow is active, show a pipeline diagram with the current phase marked.** Use `▶` to indicate the active phase. For Lite mode:
 
 ```
@@ -117,10 +128,7 @@ Read `.claude/workflow-config.json`. If `workflow.intensity` is set, also show F
 
 After showing phase and commands, proactively check for issues:
 
-**Stale workflow**: Read `phase_entered_at` from the state file. Calculate how long the current phase has been active. If >24 hours: "This workflow has been in `{phase}` for {N} days. If you're stuck:
-- Re-run the skill for this phase (e.g., `/ctdd` for tdd-impl, `/cverify` for done)
-- If an agent crashed, the state machine is waiting for the next transition — re-running resumes
-- If truly stuck: `workflow-advance.sh override 'resuming after stall'`"
+**Stale workflow**: If >24 hours in a phase, this is already handled by the time-in-phase display in section 3 above — do not repeat the warning here. Only check for stale workflows if section 3 did not already display a >24h warning (e.g., if phase_entered_at was missing or unparsable).
 
 **Empty docs**: Check if ARCHITECTURE.md contains `{PROJECT_NAME}` or `{PLACEHOLDER}` markers, or if AGENT_CONTEXT.md contains `{PROJECT_NAME}` or `{PLACEHOLDERS}`. If either is still the template: "ARCHITECTURE.md / AGENT_CONTEXT.md is still the default template. Run `/csetup` to populate it from your codebase — this significantly improves spec and review quality."
 

--- a/correctless-full/skills/ctdd/SKILL.md
+++ b/correctless-full/skills/ctdd/SKILL.md
@@ -431,6 +431,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, the test agent (RED phase) can use Context7 to understand a library's test utilities and assertion patterns:
+
+- Use `resolve-library-id` + `get-library-docs` to fetch testing docs for the libraries under test
+- Useful when the test agent needs to know how a library's test helpers work (e.g., testing hooks in React, test fixtures in pytest)
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes or context overflow**: The state machine remembers your phase. Re-run this skill — it will resume from the current phase.

--- a/correctless-lite/skills/cdocs/SKILL.md
+++ b/correctless-lite/skills/cdocs/SKILL.md
@@ -113,6 +113,19 @@ Structure your output:
 
 ## After Documentation
 
+### Workflow History
+
+Before advancing the state machine, append a workflow summary to `docs/workflow-history.md`. This file is append-only — never rewrite or delete existing entries. If the file doesn't exist, create it with a `# Workflow History` header.
+
+Each entry is one paragraph:
+
+```
+### {date} — {feature name}
+Branch: {branch}. Rules: {count}. QA rounds: {N}. Findings fixed: {N}. {one-line description}.
+```
+
+Read the workflow state file (`.claude/artifacts/workflow-state-{branch-slug}.json`): use `.branch` for the branch name, `.qa_rounds` for QA round count, `.spec_file` for the spec path. Count rules from the spec file (count lines matching `R-[0-9]` or `INV-[0-9]`). Count fixed findings from `.claude/artifacts/qa-findings-{task-slug}.json` if it exists (count entries where `.status == "fixed"`). Use today's date and the feature name from the spec's `# Spec: {title}` heading.
+
 ### Convention Learning
 
 If this is the 3rd or more feature where the same architectural pattern has appeared (check docs/specs/ for recurring patterns), append to the `## Correctless Learnings` section of `CLAUDE.md`:

--- a/correctless-lite/skills/chelp/SKILL.md
+++ b/correctless-lite/skills/chelp/SKILL.md
@@ -57,6 +57,7 @@ Feature workflow:
   /cdocs        Update documentation
 
 Other:
+  /cquick       Quick fix with TDD — no spec/review for small changes
   /crefactor    Structured refactoring (tests must pass before + after)
   /cpr-review   Review someone else's PR
   /ccontribute  Contribute to someone else's project

--- a/correctless-lite/skills/cquick/SKILL.md
+++ b/correctless-lite/skills/cquick/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cquick
+description: Quick fix with TDD — no spec/review for small changes. Branch, test, implement, commit.
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
+---
+
+# /cquick — Quick Fix with TDD
+
+You are the quick-fix agent. Your job is to implement a small, focused change using TDD without the full Correctless ceremony. No spec, no review, no verify, no docs — just branch, write test, implement, verify tests pass, and commit.
+
+## Before You Start
+
+### Branch Guard
+
+Check the current branch:
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`, stop immediately and tell the user: "You're on the main branch. Create a feature branch first: `git checkout -b fix/short-description`." Do not auto-create branches — the human decides the branch name.
+
+### Active Workflow Guard
+
+Check if a workflow is already active on this branch:
+```bash
+.claude/hooks/workflow-advance.sh status 2>/dev/null
+```
+
+If a workflow is active, stop and tell the user: "There's an active Correctless workflow on this branch. Use the workflow skills (`/ctdd`, `/cverify`, etc.) instead of `/cquick`. This skill is for standalone small fixes outside of an active workflow."
+
+## Scope Guard
+
+Before writing any code, assess the change:
+- If the change will exceed 50 LOC (lines of code) or touch more than 3 files, stop and say: "This is bigger than a quick fix — run `/cspec` to start the full workflow."
+- Re-evaluate during implementation. If you realize mid-way that the change is growing beyond 50 LOC or 3 files, stop and escalate to `/cspec`.
+
+## TDD Workflow
+
+Follow strict TDD — write at least one test before implementing the change.
+
+### 1. Write Test First
+
+Write at least one test that describes the expected behavior of the fix. The test must fail before implementation (RED phase). Run the test command and display the failure output. Do NOT proceed to implementation until the failing test output is shown to the user. This is the RED phase — the user must see the test fail before any implementation begins.
+
+```bash
+# Run the relevant test suite and show the failure output
+```
+
+### 2. Implement
+
+Write the minimal code to make the test pass (GREEN phase). Do not write more code than necessary.
+
+### 3. Verify
+
+Run the full relevant test suite to confirm:
+- The new test passes
+- No existing tests broke
+
+```bash
+# Run tests and verify all pass
+```
+
+### 4. Measure Scope
+
+Before committing, verify the change stayed within quick-fix limits:
+```bash
+git diff --stat
+```
+
+Count the actual LOC changed and files touched from the diff output. If the change exceeds 50 LOC or 3 files, stop and tell the user: "This grew beyond a quick fix ({N} LOC, {N} files). Consider running `/cspec` to formalize." Do not commit until the user acknowledges.
+
+### 5. Commit
+
+Stage and commit the change with a clear message explaining what was fixed and why:
+```bash
+git add <changed files>
+git commit -m "Fix: <description>"
+```
+
+## Constraints
+
+- **TDD is mandatory.** You must write test before implementing — no exceptions. This is TDD without the ceremony, not no-TDD.
+- **No spec, no review, no verify, no docs.** This is for small, obvious fixes.
+- **Scope limit:** 50 LOC, 3 files max. If the change grows beyond this, stop and tell the user to run `/cspec`.
+- **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
+- **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
+
+## If Something Goes Wrong
+
+- Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.
+- Scope creep: stop and escalate to `/cspec`. Don't try to force a large change through `/cquick`.
+- On wrong branch: tell the user to create a feature branch.

--- a/correctless-lite/skills/crefactor/SKILL.md
+++ b/correctless-lite/skills/crefactor/SKILL.md
@@ -323,6 +323,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when checking whether a dependency migration path exists during refactoring:
+
+- Use `resolve-library-id` + `get-library-docs` to check if the target library version has a migration guide
+- Useful when refactoring involves upgrading a dependency (e.g., "does library-x v3 have a codemod for v2 → v3?")
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes mid-refactor**: Re-run `/crefactor`. The refactor intent document (`.claude/artifacts/refactor-intent-{slug}.md`) and baseline (`.claude/artifacts/refactor-baseline-{slug}.json`) persist — the skill can pick up context from these. However, partially completed refactor phases may need manual review.

--- a/correctless-lite/skills/creview/SKILL.md
+++ b/correctless-lite/skills/creview/SKILL.md
@@ -274,6 +274,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 to verify library-related claims in the spec (e.g., "bcrypt cost 12 is recommended", "use Zod for validation"):
+
+- Use `resolve-library-id` to find the library, then `get-library-docs` to fetch current docs
+- Compare the spec's claims against actual current documentation
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.

--- a/correctless-lite/skills/cspec/SKILL.md
+++ b/correctless-lite/skills/cspec/SKILL.md
@@ -179,6 +179,12 @@ After receiving the research subagent's output, **you** (the cspec agent) write 
 
 ### Step 3: Draft the Spec
 
+Before drafting, read the appropriate spec template file and use it as the skeleton:
+- Lite mode: read `templates/spec-lite.md` from the Correctless plugin directory
+- Full mode: read `templates/spec-full.md` from the Correctless plugin directory
+
+Use the template as the skeleton — fill in the placeholders with the feature-specific content rather than reconstructing the format from these instructions.
+
 Write the spec to `docs/specs/{task-slug}.md`.
 
 **Lite mode** — use 5 sections (What, Rules with R-xxx IDs, Won't Do, Risks, Open Questions). Keep it simple.

--- a/correctless-lite/skills/cstatus/SKILL.md
+++ b/correctless-lite/skills/cstatus/SKILL.md
@@ -39,6 +39,17 @@ If no active workflow, also run:
 - Start a new feature: `git checkout -b feature/my-feature` then `/cspec`
 - Check other branches: {show status-all output if there are active workflows elsewhere}"
 
+**When displaying the current phase, calculate and show the time spent in this phase.** Read `phase_entered_at` from the state file, compute the duration as `now - phase_entered_at`, and display in human-readable format:
+- Under 60 minutes: '{N} minutes' (e.g., '12 minutes')
+- 1-24 hours: '{N} hours' (e.g., '2 hours')
+- Over 24 hours: '{N} days' (e.g., '1 day')
+
+Format: 'Phase: {phase} ({duration})'
+
+Proactive warnings at thresholds:
+- After more than 1 hour in a phase: 'This phase has been active for {duration}. If you are stuck, try re-running the skill for this phase.'
+- After more than 24 hours: 'This workflow has been in {phase} for {duration}. The workflow may be stalled — re-run the skill or use `workflow-advance.sh override` if needed.'
+
 **If workflow is active, show a pipeline diagram with the current phase marked.** Use `▶` to indicate the active phase. For Lite mode:
 
 ```
@@ -117,10 +128,7 @@ Read `.claude/workflow-config.json`. If `workflow.intensity` is set, also show F
 
 After showing phase and commands, proactively check for issues:
 
-**Stale workflow**: Read `phase_entered_at` from the state file. Calculate how long the current phase has been active. If >24 hours: "This workflow has been in `{phase}` for {N} days. If you're stuck:
-- Re-run the skill for this phase (e.g., `/ctdd` for tdd-impl, `/cverify` for done)
-- If an agent crashed, the state machine is waiting for the next transition — re-running resumes
-- If truly stuck: `workflow-advance.sh override 'resuming after stall'`"
+**Stale workflow**: If >24 hours in a phase, this is already handled by the time-in-phase display in section 3 above — do not repeat the warning here. Only check for stale workflows if section 3 did not already display a >24h warning (e.g., if phase_entered_at was missing or unparsable).
 
 **Empty docs**: Check if ARCHITECTURE.md contains `{PROJECT_NAME}` or `{PLACEHOLDER}` markers, or if AGENT_CONTEXT.md contains `{PROJECT_NAME}` or `{PLACEHOLDERS}`. If either is still the template: "ARCHITECTURE.md / AGENT_CONTEXT.md is still the default template. Run `/csetup` to populate it from your codebase — this significantly improves spec and review quality."
 

--- a/correctless-lite/skills/ctdd/SKILL.md
+++ b/correctless-lite/skills/ctdd/SKILL.md
@@ -431,6 +431,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, the test agent (RED phase) can use Context7 to understand a library's test utilities and assertion patterns:
+
+- Use `resolve-library-id` + `get-library-docs` to fetch testing docs for the libraries under test
+- Useful when the test agent needs to know how a library's test helpers work (e.g., testing hooks in React, test fixtures in pytest)
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes or context overflow**: The state machine remembers your phase. Re-run this skill — it will resume from the current phase.

--- a/docs/skills/cquick.md
+++ b/docs/skills/cquick.md
@@ -1,0 +1,49 @@
+# /cquick — Quick Fix with TDD
+
+> Small, focused fixes with TDD — no spec, no review, no verify, no docs. Just branch, test, implement, commit.
+
+## When to Use
+
+- For small bug fixes or minor improvements that don't need the full workflow
+- When the change is under 50 lines of code and touches 3 files or fewer
+- When there's no active Correctless workflow on the branch
+- **Not for:** features that need a spec, changes that touch many files, or mid-workflow shortcuts
+
+## How It Fits in the Workflow
+
+`/cquick` is a standalone skill — it operates outside the main pipeline. It's for small fixes that don't justify the full /cspec → /creview → /ctdd → /cverify → /cdocs pipeline. If the change grows beyond the scope guard (50 LOC, 3 files), it tells you to switch to `/cspec`.
+
+## What It Does
+
+1. **Branch guard** — refuses to run on `main` or `master`; tells you to create a feature branch
+2. **Active workflow guard** — refuses if a Correctless workflow is already active on the branch
+3. **Scope assessment** — checks that the change fits within 50 LOC and 3 files
+4. **Write test** — writes at least one failing test before implementing (TDD)
+5. **Implement** — writes the minimal code to make the test pass
+6. **Verify** — runs the test suite to confirm nothing broke
+7. **Commit** — stages and commits with a clear message
+
+## Example
+
+```
+Agent: Checking branch... on fix/typo-in-readme. Good.
+       No active workflow. Scope looks small — 5 lines, 1 file.
+
+       Writing test for the fix...
+       Test written and confirmed failing (RED).
+
+       Implementing fix...
+       All tests passing (GREEN).
+
+       Committed: "Fix typo in configuration example"
+```
+
+## Lite vs Full
+
+`/cquick` works the same in both modes. It deliberately skips all ceremony — that's the point.
+
+## Common Issues
+
+- **"This is bigger than a quick fix"**: The scope guard triggered. Your change exceeds 50 LOC or 3 files. Run `/cspec` instead.
+- **"You're on the main branch"**: Create a feature branch first with `git checkout -b fix/description`.
+- **"Active workflow on this branch"**: Use the workflow skills instead of `/cquick`.

--- a/docs/specs/qol-improvements.md
+++ b/docs/specs/qol-improvements.md
@@ -1,0 +1,62 @@
+# Spec: QoL Improvements
+
+## What
+
+Four quality-of-life improvements to the Correctless workflow: a `/cquick` lightweight mode for small changes that don't need the full pipeline, persistent workflow history that survives merge, time-in-phase display in `/cstatus`, and spec templates for consistent formatting.
+
+## Rules
+
+### Item 1: /cquick — Lightweight Mode
+
+- **R-001** [unit]: A new skill `skills/cquick/SKILL.md` exists with frontmatter defining the `/cquick` slash command.
+
+- **R-002** [unit]: `/cquick` SKILL.md instructs the agent to: implement the change with TDD (write test → implement → verify tests pass) and commit. No spec, no review, no verify, no docs steps. If on main/master, tell the user to create a feature branch first (same guard as `/cspec`) — do not auto-create branches.
+
+- **R-003** [unit]: `/cquick` SKILL.md includes a scope guard: if the change exceeds 50 LOC or touches more than 3 files, the skill stops and says "This is bigger than a quick fix — run `/cspec` to start the full workflow."
+
+- **R-004** [unit]: `/cquick` SKILL.md requires tests — it's TDD without the ceremony, not no-TDD. The agent must write at least one test before implementing.
+
+- **R-005** [integration]: `/cquick` is included in the Lite skill list in `sync.sh` so it syncs to `correctless-lite/`. It is also included in Full.
+
+- **R-006** [unit]: `/chelp` SKILL.md lists `/cquick` in the "Other" commands section with description "Quick fix with TDD — no spec/review for small changes".
+
+### Item 2: Workflow History
+
+- **R-007** [unit]: `/cdocs` SKILL.md contains an instruction to append a workflow summary to `docs/workflow-history.md` before advancing to `documented`. The summary includes: date, feature name, branch, rules count, QA rounds, findings fixed, and a one-line description.
+
+- **R-008** [unit]: The workflow history entry is append-only — `/cdocs` never rewrites or deletes existing entries in `docs/workflow-history.md`. If the file doesn't exist, create it with a header.
+
+- **R-009** [unit]: `docs/workflow-history.md` is NOT gitignored — it persists across merges as a committed file.
+
+### Item 3: Time-in-Phase Display
+
+- **R-010** [unit]: `/cstatus` SKILL.md contains an instruction to calculate and display time in the current phase using `phase_entered_at` from the state file. Format: "Phase: {phase} ({duration})" where duration is human-readable (e.g., "12 minutes", "2 hours", "1 day").
+
+- **R-011** [unit]: `/cstatus` SKILL.md contains an instruction to warn proactively at thresholds: >1 hour suggests re-running the skill for the current phase, >24 hours suggests the workflow may be stalled (existing stale detection, but now surfaced earlier).
+
+### Item 4: Spec Templates
+
+- **R-012** [unit]: A template file `templates/spec-lite.md` exists containing the Lite spec skeleton (What, Rules, Won't Do, Risks, Open Questions sections with placeholder markers).
+
+- **R-013** [unit]: A template file `templates/spec-full.md` exists containing the Full spec skeleton (all sections scaled to standard intensity with placeholder markers).
+
+- **R-014** [unit]: `/cspec` SKILL.md contains an instruction to read the appropriate template file and use it as the skeleton when drafting, rather than reconstructing the format from the skill instructions.
+
+### Item 5: Skill Registration
+
+- **R-015** [unit]: A documentation page `docs/skills/cquick.md` exists describing the `/cquick` skill.
+
+## Won't Do
+
+- `/cquick` does NOT bypass the workflow gate — if a workflow is already active on the branch, `/cquick` refuses. It's for standalone small fixes, not mid-workflow shortcuts.
+- Workflow history does NOT include token cost — that requires session-meta data which is deferred.
+- Spec templates do NOT auto-fill any content — they're skeletons with section headers and placeholder markers that the agent fills in.
+
+## Risks
+
+- `/cquick` scope guard (R-003) relies on the agent counting LOC and files — LLMs are bad at counting. Mitigation: the guard is a prompt instruction, not enforcement. If the agent miscounts, the user still sees the change growing and can switch to `/cspec` manually.
+- Workflow history could grow unbounded. Mitigation: one paragraph per feature, append-only. At 50 features it's ~50 lines. Acceptable for years.
+
+## Open Questions
+
+- None.

--- a/docs/verification/qol-improvements-verification.md
+++ b/docs/verification/qol-improvements-verification.md
@@ -1,0 +1,73 @@
+# Verification: QoL Improvements
+
+## Rule Coverage
+
+| Rule | Test | Status | Notes |
+|------|------|--------|-------|
+| R-001 [unit] | test_cquick_exists (2 assertions) | covered | SKILL.md exists + frontmatter |
+| R-002 [unit] | test_cquick_tdd (2 assertions) | covered | TDD instruction + branch guard |
+| R-003 [unit] | test_cquick_scope (3 assertions) | covered | 50 LOC, 3 files, /cspec escalation |
+| R-004 [unit] | test_cquick_tests_required | covered | Test-before-implement requirement |
+| R-005 [integration] | test_cquick_sync (2 assertions) | covered | Lite + Full skill lists in for-loop |
+| R-006 [unit] | test_chelp_cquick | covered | /cquick in chelp commands |
+| R-007 [unit] | test_cdocs_history (2 assertions) | covered | workflow-history.md ref + required fields |
+| R-008 [unit] | test_cdocs_append_only | covered | Append-only instruction |
+| R-009 [unit] | test_gitignore_no_history | covered | Not gitignored (regression guard) |
+| R-010 [unit] | test_cstatus_duration (2 assertions) | covered | phase_entered_at + human-readable format |
+| R-011 [unit] | test_cstatus_thresholds (2 assertions) | covered | >1 hour + >24 hours warnings |
+| R-012 [unit] | test_spec_lite (2 assertions) | covered | Template exists + 5 `##` section headers |
+| R-013 [unit] | test_spec_full (2 assertions) | covered | Template exists + 6 `##` section headers |
+| R-014 [unit] | test_cspec_template_ref | covered | cspec reads template instruction |
+| R-015 [unit] | test_cquick_docs | covered | docs/skills/cquick.md exists |
+
+**15/15 rules covered. 0 uncovered. 0 weak.**
+
+## Dependencies
+
+No new dependencies. New files:
+- `skills/cquick/SKILL.md` — new skill
+- `docs/skills/cquick.md` — documentation page
+- `templates/spec-lite.md` — Lite spec skeleton
+- `templates/spec-full.md` — Full spec skeleton
+- `.gitattributes` — merge=union for workflow-history.md
+
+## Architecture Compliance
+
+- ✓ PAT-001 (Source → Distribution Sync): New skill in root `skills/`, synced to both distributions
+- ✓ PAT-005 (Skill Frontmatter Contract): cquick has standard frontmatter
+- ✓ sync.sh skill lists updated (17 Lite, 24 Full)
+- ✓ Sync check clean
+
+## QA Findings
+
+2 rounds. 9 findings total (2 HIGH, 5 MEDIUM, 2 LOW), all addressed:
+- H-001: Post-implementation scope measurement via git diff --stat ✓
+- H-002: RED phase requires displaying test failure output ✓
+- M-001: Exact state file field paths in cdocs ✓
+- M-002: Deduplicated >24h warnings in cstatus ✓
+- M-003: Template tests accept only `##` headings ✓
+- M-004: R-013 now checks all 6 sections ✓
+- M-005: Sync test reads for-loop, not comment ✓
+- L-001: /cquick moved to top of "Other" list in chelp ✓
+- L-002: .gitattributes merge=union for workflow-history.md ✓
+
+## Smells
+
+None.
+
+## Drift
+
+None detected.
+
+## Test Results
+
+- `bash test-qol.sh`: 25 passed, 0 failed
+- `bash test.sh`: 57 passed, 0 failed
+- `bash test-mcp.sh`: 192 passed, 0 failed
+- `bash test-bugfixes.sh`: 15 passed, 0 failed
+- `bash sync.sh --check`: exit 0 (clean)
+- Total: 289 tests, 0 failures
+
+## Overall: PASS — 0 findings
+
+15/15 rules covered. 9 QA findings all addressed. No drift. Architecture compliant.

--- a/skills/cdocs/SKILL.md
+++ b/skills/cdocs/SKILL.md
@@ -113,6 +113,19 @@ Structure your output:
 
 ## After Documentation
 
+### Workflow History
+
+Before advancing the state machine, append a workflow summary to `docs/workflow-history.md`. This file is append-only — never rewrite or delete existing entries. If the file doesn't exist, create it with a `# Workflow History` header.
+
+Each entry is one paragraph:
+
+```
+### {date} — {feature name}
+Branch: {branch}. Rules: {count}. QA rounds: {N}. Findings fixed: {N}. {one-line description}.
+```
+
+Read the workflow state file (`.claude/artifacts/workflow-state-{branch-slug}.json`): use `.branch` for the branch name, `.qa_rounds` for QA round count, `.spec_file` for the spec path. Count rules from the spec file (count lines matching `R-[0-9]` or `INV-[0-9]`). Count fixed findings from `.claude/artifacts/qa-findings-{task-slug}.json` if it exists (count entries where `.status == "fixed"`). Use today's date and the feature name from the spec's `# Spec: {title}` heading.
+
 ### Convention Learning
 
 If this is the 3rd or more feature where the same architectural pattern has appeared (check docs/specs/ for recurring patterns), append to the `## Correctless Learnings` section of `CLAUDE.md`:

--- a/skills/chelp/SKILL.md
+++ b/skills/chelp/SKILL.md
@@ -57,6 +57,7 @@ Feature workflow:
   /cdocs        Update documentation
 
 Other:
+  /cquick       Quick fix with TDD — no spec/review for small changes
   /crefactor    Structured refactoring (tests must pass before + after)
   /cpr-review   Review someone else's PR
   /ccontribute  Contribute to someone else's project

--- a/skills/cquick/SKILL.md
+++ b/skills/cquick/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cquick
+description: Quick fix with TDD — no spec/review for small changes. Branch, test, implement, commit.
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
+---
+
+# /cquick — Quick Fix with TDD
+
+You are the quick-fix agent. Your job is to implement a small, focused change using TDD without the full Correctless ceremony. No spec, no review, no verify, no docs — just branch, write test, implement, verify tests pass, and commit.
+
+## Before You Start
+
+### Branch Guard
+
+Check the current branch:
+```bash
+git branch --show-current
+```
+
+If on `main` or `master`, stop immediately and tell the user: "You're on the main branch. Create a feature branch first: `git checkout -b fix/short-description`." Do not auto-create branches — the human decides the branch name.
+
+### Active Workflow Guard
+
+Check if a workflow is already active on this branch:
+```bash
+.claude/hooks/workflow-advance.sh status 2>/dev/null
+```
+
+If a workflow is active, stop and tell the user: "There's an active Correctless workflow on this branch. Use the workflow skills (`/ctdd`, `/cverify`, etc.) instead of `/cquick`. This skill is for standalone small fixes outside of an active workflow."
+
+## Scope Guard
+
+Before writing any code, assess the change:
+- If the change will exceed 50 LOC (lines of code) or touch more than 3 files, stop and say: "This is bigger than a quick fix — run `/cspec` to start the full workflow."
+- Re-evaluate during implementation. If you realize mid-way that the change is growing beyond 50 LOC or 3 files, stop and escalate to `/cspec`.
+
+## TDD Workflow
+
+Follow strict TDD — write at least one test before implementing the change.
+
+### 1. Write Test First
+
+Write at least one test that describes the expected behavior of the fix. The test must fail before implementation (RED phase). Run the test command and display the failure output. Do NOT proceed to implementation until the failing test output is shown to the user. This is the RED phase — the user must see the test fail before any implementation begins.
+
+```bash
+# Run the relevant test suite and show the failure output
+```
+
+### 2. Implement
+
+Write the minimal code to make the test pass (GREEN phase). Do not write more code than necessary.
+
+### 3. Verify
+
+Run the full relevant test suite to confirm:
+- The new test passes
+- No existing tests broke
+
+```bash
+# Run tests and verify all pass
+```
+
+### 4. Measure Scope
+
+Before committing, verify the change stayed within quick-fix limits:
+```bash
+git diff --stat
+```
+
+Count the actual LOC changed and files touched from the diff output. If the change exceeds 50 LOC or 3 files, stop and tell the user: "This grew beyond a quick fix ({N} LOC, {N} files). Consider running `/cspec` to formalize." Do not commit until the user acknowledges.
+
+### 5. Commit
+
+Stage and commit the change with a clear message explaining what was fixed and why:
+```bash
+git add <changed files>
+git commit -m "Fix: <description>"
+```
+
+## Constraints
+
+- **TDD is mandatory.** You must write test before implementing — no exceptions. This is TDD without the ceremony, not no-TDD.
+- **No spec, no review, no verify, no docs.** This is for small, obvious fixes.
+- **Scope limit:** 50 LOC, 3 files max. If the change grows beyond this, stop and tell the user to run `/cspec`.
+- **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
+- **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
+
+## If Something Goes Wrong
+
+- Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.
+- Scope creep: stop and escalate to `/cspec`. Don't try to force a large change through `/cquick`.
+- On wrong branch: tell the user to create a feature branch.

--- a/skills/crefactor/SKILL.md
+++ b/skills/crefactor/SKILL.md
@@ -323,6 +323,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when checking whether a dependency migration path exists during refactoring:
+
+- Use `resolve-library-id` + `get-library-docs` to check if the target library version has a migration guide
+- Useful when refactoring involves upgrading a dependency (e.g., "does library-x v3 have a codemod for v2 → v3?")
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes mid-refactor**: Re-run `/crefactor`. The refactor intent document (`.claude/artifacts/refactor-intent-{slug}.md`) and baseline (`.claude/artifacts/refactor-baseline-{slug}.json`) persist — the skill can pick up context from these. However, partially completed refactor phases may need manual review.

--- a/skills/creview/SKILL.md
+++ b/skills/creview/SKILL.md
@@ -274,6 +274,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, use Context7 to verify library-related claims in the spec (e.g., "bcrypt cost 12 is recommended", "use Zod for validation"):
+
+- Use `resolve-library-id` to find the library, then `get-library-docs` to fetch current docs
+- Compare the spec's claims against actual current documentation
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.

--- a/skills/cspec/SKILL.md
+++ b/skills/cspec/SKILL.md
@@ -179,6 +179,12 @@ After receiving the research subagent's output, **you** (the cspec agent) write 
 
 ### Step 3: Draft the Spec
 
+Before drafting, read the appropriate spec template file and use it as the skeleton:
+- Lite mode: read `templates/spec-lite.md` from the Correctless plugin directory
+- Full mode: read `templates/spec-full.md` from the Correctless plugin directory
+
+Use the template as the skeleton — fill in the placeholders with the feature-specific content rather than reconstructing the format from these instructions.
+
 Write the spec to `docs/specs/{task-slug}.md`.
 
 **Lite mode** — use 5 sections (What, Rules with R-xxx IDs, Won't Do, Risks, Open Questions). Keep it simple.

--- a/skills/cstatus/SKILL.md
+++ b/skills/cstatus/SKILL.md
@@ -39,6 +39,17 @@ If no active workflow, also run:
 - Start a new feature: `git checkout -b feature/my-feature` then `/cspec`
 - Check other branches: {show status-all output if there are active workflows elsewhere}"
 
+**When displaying the current phase, calculate and show the time spent in this phase.** Read `phase_entered_at` from the state file, compute the duration as `now - phase_entered_at`, and display in human-readable format:
+- Under 60 minutes: '{N} minutes' (e.g., '12 minutes')
+- 1-24 hours: '{N} hours' (e.g., '2 hours')
+- Over 24 hours: '{N} days' (e.g., '1 day')
+
+Format: 'Phase: {phase} ({duration})'
+
+Proactive warnings at thresholds:
+- After more than 1 hour in a phase: 'This phase has been active for {duration}. If you are stuck, try re-running the skill for this phase.'
+- After more than 24 hours: 'This workflow has been in {phase} for {duration}. The workflow may be stalled — re-run the skill or use `workflow-advance.sh override` if needed.'
+
 **If workflow is active, show a pipeline diagram with the current phase marked.** Use `▶` to indicate the active phase. For Lite mode:
 
 ```
@@ -117,10 +128,7 @@ Read `.claude/workflow-config.json`. If `workflow.intensity` is set, also show F
 
 After showing phase and commands, proactively check for issues:
 
-**Stale workflow**: Read `phase_entered_at` from the state file. Calculate how long the current phase has been active. If >24 hours: "This workflow has been in `{phase}` for {N} days. If you're stuck:
-- Re-run the skill for this phase (e.g., `/ctdd` for tdd-impl, `/cverify` for done)
-- If an agent crashed, the state machine is waiting for the next transition — re-running resumes
-- If truly stuck: `workflow-advance.sh override 'resuming after stall'`"
+**Stale workflow**: If >24 hours in a phase, this is already handled by the time-in-phase display in section 3 above — do not repeat the warning here. Only check for stale workflows if section 3 did not already display a >24h warning (e.g., if phase_entered_at was missing or unparsable).
 
 **Empty docs**: Check if ARCHITECTURE.md contains `{PROJECT_NAME}` or `{PLACEHOLDER}` markers, or if AGENT_CONTEXT.md contains `{PROJECT_NAME}` or `{PLACEHOLDERS}`. If either is still the template: "ARCHITECTURE.md / AGENT_CONTEXT.md is still the default template. Run `/csetup` to populate it from your codebase — this significantly improves spec and review quality."
 

--- a/skills/ctdd/SKILL.md
+++ b/skills/ctdd/SKILL.md
@@ -431,6 +431,15 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 
 **Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
+### Context7 — Library Documentation
+
+If `mcp.context7` is `true` in `workflow-config.json`, the test agent (RED phase) can use Context7 to understand a library's test utilities and assertion patterns:
+
+- Use `resolve-library-id` + `get-library-docs` to fetch testing docs for the libraries under test
+- Useful when the test agent needs to know how a library's test helpers work (e.g., testing hooks in React, test fixtures in pytest)
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
+
 ## If Something Goes Wrong
 
 - **Agent crashes or context overflow**: The state machine remembers your phase. Re-run this skill — it will resume from the current phase.

--- a/sync.sh
+++ b/sync.sh
@@ -87,23 +87,23 @@ else
   info "PBT helpers → correctless-full"
 fi
 
-# --- Lite skills ---
-for skill in csetup cspec creview ctdd cverify cdocs crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf; do
+# --- Lite skills: csetup cspec creview ctdd cverify cdocs crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick ---
+for skill in csetup cspec creview ctdd cverify cdocs crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick; do
   if [ "$CHECK_ONLY" = false ]; then
     mkdir -p "correctless-lite/skills/$skill"
   fi
   sync_file "skills/$skill/SKILL.md" "correctless-lite/skills/$skill/SKILL.md"
 done
-[ "$CHECK_ONLY" = false ] && info "Lite skills (16) → correctless-lite"
+[ "$CHECK_ONLY" = false ] && info "Lite skills (17) → correctless-lite"
 
-# --- Full skills (all) ---
-for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf; do
+# --- Full skills (all): csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick ---
+for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick; do
   if [ "$CHECK_ONLY" = false ]; then
     mkdir -p "correctless-full/skills/$skill"
   fi
   sync_file "skills/$skill/SKILL.md" "correctless-full/skills/$skill/SKILL.md"
 done
-[ "$CHECK_ONLY" = false ] && info "Full skills (23) → correctless-full"
+[ "$CHECK_ONLY" = false ] && info "Full skills (24) → correctless-full"
 
 if [ "$CHECK_ONLY" = true ]; then
   if [ "$DIRTY" = true ]; then

--- a/templates/spec-full.md
+++ b/templates/spec-full.md
@@ -1,0 +1,36 @@
+# Spec: {TITLE}
+
+## Metadata
+- **Created**: {ISO timestamp}
+- **Status**: draft
+- **Impacts**: {other spec slugs}
+- **Branch**: {branch name}
+- **Research**: {path or null}
+
+## Context
+
+{What this feature does and why. One paragraph.}
+
+## Scope
+
+{What this covers and what it does NOT.}
+
+## Invariants
+
+### INV-001: {short name}
+- **Type**: must
+- **Category**: functional
+- **Statement**: {testable statement}
+- **Violated when**: {condition}
+- **Test approach**: unit
+
+## Prohibitions
+
+### PRH-001: {short name}
+- **Statement**: {what must never happen}
+- **Detection**: {method}
+- **Consequence**: {impact}
+
+## Open Questions
+
+- **OQ-001**: {question} — {why it matters}

--- a/templates/spec-lite.md
+++ b/templates/spec-lite.md
@@ -1,0 +1,21 @@
+# Spec: {TITLE}
+
+## What
+
+{One paragraph describing what this feature does, who it's for, and why it matters.}
+
+## Rules
+
+- **R-001** [{test_level}]: {testable statement}
+
+## Won't Do
+
+- {out of scope item}
+
+## Risks
+
+- {risk} — {mitigation or "accepted"}
+
+## Open Questions
+
+- {question}

--- a/test-mcp.sh
+++ b/test-mcp.sh
@@ -52,8 +52,8 @@ file_contains_i() {
 # R-022: 14 skills that receive Serena integration
 SERENA_SKILLS="cspec creview creview-spec ctdd cverify caudit crefactor credteam cwtf cmaintain ccontribute cdebug cpr-review cdocs"
 
-# R-023: 2 skills that receive Context7 integration
-CONTEXT7_SKILLS="cspec cdebug"
+# R-023: 5 skills that receive Context7 integration
+CONTEXT7_SKILLS="cspec cdebug creview ctdd crefactor"
 
 # R-024: Skills that do NOT receive MCP integration (except cwtf which is in R-022)
 NO_MCP_SKILLS="chelp cstatus csummary cmetrics cpostmortem cdevadv"
@@ -461,8 +461,8 @@ test_r020() {
   local lite_total full_total
   lite_total=$(find "$REPO_DIR/correctless-lite/skills" -name "SKILL.md" | wc -l)
   full_total=$(find "$REPO_DIR/correctless-full/skills" -name "SKILL.md" | wc -l)
-  assert_eq "R-020: Lite has 16 skills total" "16" "$lite_total"
-  assert_eq "R-020: Full has 23 skills total" "23" "$full_total"
+  assert_eq "R-020: Lite has 17 skills total" "17" "$lite_total"
+  assert_eq "R-020: Full has 24 skills total" "24" "$full_total"
 }
 
 # ---------------------------------------------------------------------------
@@ -527,12 +527,12 @@ test_r023() {
       c7_count=$((c7_count + 1))
     fi
   done
-  assert_eq "R-023: 2 skills have Context7 blocks" "2" "$c7_count"
+  assert_eq "R-023: 5 skills have Context7 blocks" "5" "$c7_count"
 
-  # Serena-only skills (all SERENA_SKILLS minus cspec and cdebug) must NOT contain mcp.context7
+  # Serena-only skills (all SERENA_SKILLS minus Context7 skills) must NOT contain mcp.context7
   for skill in $SERENA_SKILLS; do
-    # Skip cspec and cdebug — they legitimately have Context7
-    if [ "$skill" = "cspec" ] || [ "$skill" = "cdebug" ]; then
+    # Skip Context7 skills — they legitimately have mcp.context7
+    if [ "$skill" = "cspec" ] || [ "$skill" = "cdebug" ] || [ "$skill" = "creview" ] || [ "$skill" = "ctdd" ] || [ "$skill" = "crefactor" ]; then
       continue
     fi
     local skill_file="$REPO_DIR/skills/$skill/SKILL.md"

--- a/test-qol.sh
+++ b/test-qol.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Correctless — QoL improvement tests
+# Tests spec rules R-001 through R-015
+# Run from repo root: bash test-qol.sh
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+file_exists() {
+  [ -f "$1" ]
+}
+
+file_contains() {
+  grep -q "$2" "$1" 2>/dev/null
+}
+
+file_contains_i() {
+  grep -qi "$2" "$1" 2>/dev/null
+}
+
+# ===========================================================================
+echo "=== /cquick — Lightweight Mode ==="
+# ===========================================================================
+
+# R-001: skills/cquick/SKILL.md exists with frontmatter containing name: cquick
+echo "--- R-001: /cquick skill file exists with correct frontmatter ---"
+CQUICK="$REPO_DIR/skills/cquick/SKILL.md"
+
+if file_exists "$CQUICK"; then
+  assert_eq "R-001a: skills/cquick/SKILL.md exists" "yes" "yes"
+else
+  assert_eq "R-001a: skills/cquick/SKILL.md exists" "yes" "no"
+fi
+
+if file_contains "$CQUICK" "^name: cquick"; then
+  assert_eq "R-001b: frontmatter contains name: cquick" "yes" "yes"
+else
+  assert_eq "R-001b: frontmatter contains name: cquick" "yes" "no"
+fi
+
+# R-002: SKILL.md contains TDD instruction and main/master branch guard
+echo "--- R-002: TDD instruction and branch guard ---"
+
+if file_contains "$CQUICK" "test.*implement.*verify\|write test.*implement"; then
+  assert_eq "R-002a: contains TDD instruction (test -> implement -> verify)" "yes" "yes"
+else
+  assert_eq "R-002a: contains TDD instruction (test -> implement -> verify)" "yes" "no"
+fi
+
+if file_contains "$CQUICK" "main\|master"; then
+  has_branch_guard="yes"
+else
+  has_branch_guard="no"
+fi
+if file_contains "$CQUICK" "branch"; then
+  : # additional check
+else
+  has_branch_guard="no"
+fi
+assert_eq "R-002b: contains main/master branch guard" "yes" "$has_branch_guard"
+
+# R-003: SKILL.md contains scope guard with 50 LOC and 3 files thresholds
+echo "--- R-003: Scope guard thresholds ---"
+
+if file_contains "$CQUICK" "50.*LOC\|50 LOC\|50 lines"; then
+  assert_eq "R-003a: contains 50 LOC threshold" "yes" "yes"
+else
+  assert_eq "R-003a: contains 50 LOC threshold" "yes" "no"
+fi
+
+if file_contains "$CQUICK" "3 files\|3.*files"; then
+  assert_eq "R-003b: contains 3 files threshold" "yes" "yes"
+else
+  assert_eq "R-003b: contains 3 files threshold" "yes" "no"
+fi
+
+if file_contains_i "$CQUICK" "cspec"; then
+  assert_eq "R-003c: scope guard references /cspec escalation" "yes" "yes"
+else
+  assert_eq "R-003c: scope guard references /cspec escalation" "yes" "no"
+fi
+
+# R-004: SKILL.md requires tests before implementing
+echo "--- R-004: Tests required before implementing ---"
+
+if file_contains_i "$CQUICK" "write.*test.*before\|test.*before.*implement\|at least one test"; then
+  assert_eq "R-004: requires writing tests before implementing" "yes" "yes"
+else
+  assert_eq "R-004: requires writing tests before implementing" "yes" "no"
+fi
+
+# R-005: sync.sh Lite and Full skill lists contain "cquick"
+echo "--- R-005: cquick in sync.sh skill lists ---"
+SYNC="$REPO_DIR/sync.sh"
+
+# Check Lite list (the first for-loop listing skills — does not contain cmodel)
+lite_line=$(grep "^for skill in" "$SYNC" | grep -v "cmodel" | head -1)
+if echo "$lite_line" | grep -q "cquick"; then
+  assert_eq "R-005a: cquick in Lite skill list" "yes" "yes"
+else
+  assert_eq "R-005a: cquick in Lite skill list" "yes" "no"
+fi
+
+# Check Full list (the for-loop listing skills — contains cmodel)
+full_line=$(grep "^for skill in.*cmodel" "$SYNC" | head -1)
+if echo "$full_line" | grep -q "cquick"; then
+  assert_eq "R-005b: cquick in Full skill list" "yes" "yes"
+else
+  assert_eq "R-005b: cquick in Full skill list" "yes" "no"
+fi
+
+# R-006: chelp SKILL.md lists /cquick in commands section
+echo "--- R-006: /cquick listed in /chelp ---"
+CHELP="$REPO_DIR/skills/chelp/SKILL.md"
+
+if file_contains "$CHELP" "/cquick"; then
+  assert_eq "R-006: /chelp lists /cquick command" "yes" "yes"
+else
+  assert_eq "R-006: /chelp lists /cquick command" "yes" "no"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Workflow History ==="
+# ===========================================================================
+
+# R-007: cdocs SKILL.md contains workflow-history instruction
+echo "--- R-007: /cdocs appends to workflow-history.md ---"
+CDOCS="$REPO_DIR/skills/cdocs/SKILL.md"
+
+if file_contains "$CDOCS" "workflow-history"; then
+  assert_eq "R-007a: /cdocs references workflow-history.md" "yes" "yes"
+else
+  assert_eq "R-007a: /cdocs references workflow-history.md" "yes" "no"
+fi
+
+# Check for required fields in the workflow history instruction
+r007_fields_found=0
+for field in "date" "feature name" "branch" "rules count" "QA rounds" "findings fixed"; do
+  if file_contains_i "$CDOCS" "$field"; then
+    r007_fields_found=$((r007_fields_found + 1))
+  fi
+done
+if [ "$r007_fields_found" -ge 5 ]; then
+  assert_eq "R-007b: workflow history includes required fields (date, feature, branch, rules, QA, findings)" "yes" "yes"
+else
+  assert_eq "R-007b: workflow history includes required fields (date, feature, branch, rules, QA, findings)" "yes" "no (found $r007_fields_found/6)"
+fi
+
+# R-008: cdocs SKILL.md contains append-only instruction
+echo "--- R-008: workflow history is append-only ---"
+
+if file_contains_i "$CDOCS" "append-only\|append only\|never rewrite\|never delete"; then
+  assert_eq "R-008: /cdocs has append-only instruction for workflow history" "yes" "yes"
+else
+  assert_eq "R-008: /cdocs has append-only instruction for workflow history" "yes" "no"
+fi
+
+# R-009: .gitignore does NOT contain workflow-history
+echo "--- R-009: workflow-history.md is not gitignored ---"
+GITIGNORE="$REPO_DIR/.gitignore"
+
+if file_contains "$GITIGNORE" "workflow-history"; then
+  assert_eq "R-009: workflow-history.md is NOT gitignored" "yes" "no"
+else
+  assert_eq "R-009: workflow-history.md is NOT gitignored" "yes" "yes"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Time-in-Phase Display ==="
+# ===========================================================================
+
+# R-010: cstatus SKILL.md contains duration calculation instruction
+echo "--- R-010: /cstatus calculates time in current phase ---"
+CSTATUS="$REPO_DIR/skills/cstatus/SKILL.md"
+
+# The spec requires display format: "Phase: {phase} ({duration})"
+if file_contains "$CSTATUS" 'Phase:.*{phase}.*{duration}\|Phase:.*({duration})'; then
+  assert_eq "R-010a: /cstatus shows phase with duration format" "yes" "yes"
+else
+  assert_eq "R-010a: /cstatus shows phase with duration format" "yes" "no"
+fi
+
+# Check for human-readable duration examples
+if file_contains_i "$CSTATUS" "minutes.*hours\|human-readable.*duration\|12 minutes\|2 hours\|1 day"; then
+  assert_eq "R-010b: /cstatus uses human-readable duration format" "yes" "yes"
+else
+  assert_eq "R-010b: /cstatus uses human-readable duration format" "yes" "no"
+fi
+
+# R-011: cstatus SKILL.md contains threshold warnings
+echo "--- R-011: /cstatus warns at time thresholds ---"
+
+# Check for >1 hour threshold
+if file_contains_i "$CSTATUS" '>.*1 hour\|more than.*1 hour\|exceeds.*1 hour\|1 hour.*re-run\|1 hour.*suggest'; then
+  assert_eq "R-011a: /cstatus warns at >1 hour threshold" "yes" "yes"
+else
+  assert_eq "R-011a: /cstatus warns at >1 hour threshold" "yes" "no"
+fi
+
+# Check for >24 hours threshold (already exists for stale, but spec wants it in new format)
+if file_contains_i "$CSTATUS" '>.*24 hour.*stall\|24 hour.*stalled\|workflow may be stalled'; then
+  assert_eq "R-011b: /cstatus warns at >24 hours (stalled)" "yes" "yes"
+else
+  assert_eq "R-011b: /cstatus warns at >24 hours (stalled)" "yes" "no"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Spec Templates ==="
+# ===========================================================================
+
+# R-012: templates/spec-lite.md exists with required sections
+echo "--- R-012: Lite spec template ---"
+SPEC_LITE="$REPO_DIR/templates/spec-lite.md"
+
+if file_exists "$SPEC_LITE"; then
+  assert_eq "R-012a: templates/spec-lite.md exists" "yes" "yes"
+else
+  assert_eq "R-012a: templates/spec-lite.md exists" "yes" "no"
+fi
+
+r012_sections=0
+for section in "What" "Rules" "Won't Do" "Risks" "Open Questions"; do
+  if file_contains "$SPEC_LITE" "^## *$section"; then
+    r012_sections=$((r012_sections + 1))
+  fi
+done
+if [ "$r012_sections" -ge 5 ]; then
+  assert_eq "R-012b: spec-lite.md has all 5 section headers" "yes" "yes"
+else
+  assert_eq "R-012b: spec-lite.md has all 5 section headers" "yes" "no (found $r012_sections/5)"
+fi
+
+# R-013: templates/spec-full.md exists with required sections
+echo "--- R-013: Full spec template ---"
+SPEC_FULL="$REPO_DIR/templates/spec-full.md"
+
+if file_exists "$SPEC_FULL"; then
+  assert_eq "R-013a: templates/spec-full.md exists" "yes" "yes"
+else
+  assert_eq "R-013a: templates/spec-full.md exists" "yes" "no"
+fi
+
+r013_sections=0
+for section in "Metadata" "Context" "Scope" "Invariants" "Prohibitions" "Open Questions"; do
+  if file_contains "$SPEC_FULL" "^## *$section"; then
+    r013_sections=$((r013_sections + 1))
+  fi
+done
+if [ "$r013_sections" -ge 6 ]; then
+  assert_eq "R-013b: spec-full.md has all 6 required section headers" "yes" "yes"
+else
+  assert_eq "R-013b: spec-full.md has all 6 required section headers" "yes" "no (found $r013_sections/6)"
+fi
+
+# R-014: cspec SKILL.md references template file
+echo "--- R-014: /cspec reads template file ---"
+CSPEC="$REPO_DIR/skills/cspec/SKILL.md"
+
+if file_contains "$CSPEC" "templates/spec-lite\|templates/spec-full\|template.*file\|read.*template"; then
+  assert_eq "R-014: /cspec references template file" "yes" "yes"
+else
+  assert_eq "R-014: /cspec references template file" "yes" "no"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Skill Registration ==="
+# ===========================================================================
+
+# R-015: docs/skills/cquick.md exists
+echo "--- R-015: /cquick documentation page ---"
+CQUICK_DOC="$REPO_DIR/docs/skills/cquick.md"
+
+if file_exists "$CQUICK_DOC"; then
+  assert_eq "R-015: docs/skills/cquick.md exists" "yes" "yes"
+else
+  assert_eq "R-015: docs/skills/cquick.md exists" "yes" "no"
+fi
+
+# ===========================================================================
+echo ""
+echo "==========================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "==========================================="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **`/cquick`**: Lightweight TDD for small changes (<50 LOC, <3 files). Post-implementation scope guard via `git diff --stat`. RED phase requires showing test failure before implementing.
- **Workflow history**: `/cdocs` appends a summary to `docs/workflow-history.md` (append-only, `merge=union`). Data persists across merges for `/cmetrics` and `/cpostmortem`.
- **Time-in-phase**: `/cstatus` shows duration from `phase_entered_at` with warnings at >1h and >24h.
- **Spec templates**: `templates/spec-lite.md` and `spec-full.md` — `/cspec` reads the skeleton instead of reconstructing from instructions.
- **Context7 expansion**: Added to `/creview`, `/ctdd`, `/crefactor` for library claim verification and test utility docs.
- **CONTRIBUTING.md**: Updated with current test suites, pre-commit info, `/cquick` reference.

## Type

- [ ] Bug fix
- [x] New skill
- [x] Skill enhancement
- [ ] Hook change
- [x] Documentation
- [x] CI/tooling

## Checklist

- [x] `bash test.sh` passes (57 tests)
- [x] `bash test-mcp.sh` passes (195 tests)
- [x] `bash test-bugfixes.sh` passes (15 tests)
- [x] `bash test-qol.sh` passes (25 tests)
- [x] `bash sync.sh --check` exits 0
- [x] Skill registered in all locations (sync.sh, chelp, docs/skills/)
- [x] Documentation page added for /cquick
- [x] README updated (skill count, /cquick in table)

## Testing

Correctless Lite workflow: /cspec (15 rules) → /creview (4 changes) → /ctdd (RED → GREEN → QA R1 → fix → QA R2 converged) → /cverify (PASS) → /cdocs.

292 total tests, all green. Pre-commit hooks pass.