### PR TITLE
Add structured decision UX across all interactive skills

### DIFF
--- a/.claude/workflow-config.json
+++ b/.claude/workflow-config.json
@@ -5,7 +5,7 @@
     "description": "Claude Code plugin framework: structured workflow skills for spec-driven development with TDD, auditing, and project health"
   },
   "commands": {
-    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh",
+    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-decisions.sh",
     "test_verbose": "bash test.sh && bash test-mcp.sh",
     "coverage": "",
     "lint": "shellcheck hooks/*.sh test.sh sync.sh setup",

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -17,7 +17,7 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 | Lite dist | `correctless-lite/` | 16-skill distribution target — never edit directly |
 | Full dist | `correctless-full/` | 23-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh`, `test-qol.sh` | 289 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL improvements |
+| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh`, `test-qol.sh`, `test-decisions.sh` | 319 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL, decision UX |
 | Sync | `sync.sh` | Propagates source edits to both distribution targets |
 
 ## Design Patterns

--- a/correctless-full/skills/caudit/SKILL.md
+++ b/correctless-full/skills/caudit/SKILL.md
@@ -79,7 +79,17 @@ Clean up the checkpoint file when the audit converges and completes successfully
 2. Spawn parallel agents (4-6) with specialized hostile lenses
 3. Agents submit findings with confidence tiers (confirmed/probable/suspicious)
 4. Triage agent deduplicates, validates, rejects false positives
-5. Fix all confirmed findings on the audit branch
+5. Present validated findings to the human for triage:
+
+   ```
+     1. Fix now (recommended) — address in the current round
+     2. Defer — log for future resolution
+     3. Dispute — explain why this is not an issue
+
+     Or type your own: ___
+   ```
+
+   Fix all confirmed findings on the audit branch:
    - Non-trivial: TDD (tests first, separate impl agent)
    - Trivial one-liners: apply directly
 6. Commit fixes
@@ -103,6 +113,13 @@ Clean up the checkpoint file when the audit converges and completes successfully
 **Divergence**: if a round finds MORE issues than previous, check if fixes introduced regressions.
 
 **Cost visibility**: after each round, report: findings found, findings fixed, total rounds. Human decides whether to continue.
+
+After each round, present the convergence decision:
+
+  1. Continue to next round (recommended) — there are still actionable findings
+  2. Stop here — remaining findings are acceptable or diminishing returns
+
+  Or type your own: ___
 
 ## Confidence Tiers
 

--- a/correctless-full/skills/cdocs/SKILL.md
+++ b/correctless-full/skills/cdocs/SKILL.md
@@ -83,7 +83,16 @@ Reference the spec artifact for detailed rules — don't duplicate.
 
 If the feature introduced new patterns or conventions:
 - Suggest additions to ARCHITECTURE.md
-- Present each to the human for approval — one at a time
+- Present each to the human for approval — one at a time, with options:
+
+```
+  1. Add (recommended) — add this entry to ARCHITECTURE.md
+  2. Skip — not a pattern worth documenting
+  3. Modify — change the entry before adding
+
+  Or type your own: ___
+```
+
 - Don't auto-add without approval
 
 ### 6. Fact-Check
@@ -160,10 +169,12 @@ Full mode:
 ```
 
 Confirm: "Documentation complete. Your options:
-1. Create a PR: `gh pr create` (or `/cpr-review` on your own branch first)
+1. Create a PR (recommended): `gh pr create` (or `/cpr-review` on your own branch first)
 2. Merge locally: `git checkout main && git merge {branch}`
 3. Keep the branch as-is for later review
 4. Discard: `git checkout main && git branch -D {branch}`
+
+Or type your own: ___
 
 After merging to main:
 - If bugs escape to production from this feature → run `/cpostmortem` to trace which phase missed it

--- a/correctless-full/skills/cquick/SKILL.md
+++ b/correctless-full/skills/cquick/SKILL.md
@@ -85,6 +85,16 @@ git commit -m "Fix: <description>"
 - **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
 - **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
 
+## Decision Points
+
+When presenting choices to the user:
+
+1. Present numbered options with the recommended option first
+2. Mark the recommended option with "(recommended)"
+3. Include 2-4 options maximum
+4. Always end with: "Or type your own: ___"
+5. Accept the number, the option name, or a typed response
+
 ## If Something Goes Wrong
 
 - Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.

--- a/correctless-full/skills/crefactor/SKILL.md
+++ b/correctless-full/skills/crefactor/SKILL.md
@@ -204,7 +204,18 @@ If the verification agent detects a test file modification:
    - The refactor intentionally changes behavior — document why
    - The refactor accidentally broke something — fix it
 
-   Is this test change intentional? Provide a reason."
+   Is this test change intentional?"
+
+   Present the options:
+
+   ```
+     1. Approve behavioral change (recommended) — the test correctly reflects new behavior
+     2. Reject — revert this test change, find another approach
+     3. Split into separate PR — this behavioral change deserves its own review
+
+     Or type your own: ___
+   ```
+
 4. User must approve with a reason. Log the approval in the refactor intent artifact.
 5. Update the baseline with the new test checksums before proceeding.
 

--- a/correctless-full/skills/creview-spec/SKILL.md
+++ b/correctless-full/skills/creview-spec/SKILL.md
@@ -144,6 +144,17 @@ Organize findings by category:
 5. Design contract conflicts
 6. External model findings (if any)
 
+For each finding, present the disposition options:
+
+```
+  1. Accept finding (recommended) — add rule or update spec
+  2. Reject — explain why this doesn't apply
+  3. Modify — accept the concern but change the proposed rule
+  4. Defer — log as accepted risk for future feature
+
+  Or type your own: ___
+```
+
 Incorporate approved changes into the spec.
 
 ## Advance State

--- a/correctless-full/skills/creview/SKILL.md
+++ b/correctless-full/skills/creview/SKILL.md
@@ -203,6 +203,17 @@ Present findings to the human organized by category:
 6. Security rules missing (from the checklist)
 7. Self-assessment of the spec
 
+For each finding, present the disposition options:
+
+```
+  1. Accept finding (recommended) — add rule or update spec
+  2. Reject — explain why this doesn't apply
+  3. Modify — accept the concern but change the proposed rule
+  4. Defer — log as accepted risk for future feature
+
+  Or type your own: ___
+```
+
 Incorporate approved changes directly into the spec file. Preserve existing rule numbering — add new rules at the end (R-004, R-005, etc.).
 
 ## Advance State

--- a/correctless-full/skills/csetup/SKILL.md
+++ b/correctless-full/skills/csetup/SKILL.md
@@ -184,7 +184,19 @@ Check the following before presenting the offer:
 
 ### Offer
 
-When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with four options: **both**, **just Serena**, **just Context7**, or **skip**. When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
+When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with numbered options:
+
+```
+MCP server integration:
+  1. Both Serena + Context7 (recommended) — symbol analysis and library docs
+  2. Just Serena — symbol-level code analysis only
+  3. Just Context7 — up-to-date library documentation only
+  4. Skip — no MCP servers
+
+  Or type your own: ___
+```
+
+When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
 
 ### Tooling Prerequisites
 
@@ -979,8 +991,18 @@ Source Control — detected:
   ✗ PR template: none found → I can generate one
   ✗ Branch protection: not configured → recommend enabling
 
-Branching strategy: [feature branches / trunk-based]?
-Merge strategy: [squash / merge / rebase]?
+Branching strategy:
+  1. Feature branches (recommended) — branch per feature, merge via PR
+  2. Trunk-based — short-lived branches, commit to main frequently
+
+  Or type your own: ___
+
+Merge strategy:
+  1. Squash (recommended) — clean history, one commit per feature
+  2. Merge commit — preserves branch history
+  3. Rebase — linear history, no merge commits
+
+  Or type your own: ___
 ```
 
 **Where answers go:**

--- a/correctless-full/skills/cspec/SKILL.md
+++ b/correctless-full/skills/cspec/SKILL.md
@@ -86,7 +86,17 @@ Key questions:
 - What is the feature? (functional description — refined by brainstorm)
 - What does "correct" mean? (the answer becomes invariants/rules)
 - What must this feature NEVER do? (the answer becomes prohibitions/rules)
-- What happens when this fails? (failure mode — fail-open, fail-closed, passthrough, crash)
+- What happens when this fails? Present the failure mode options:
+
+```
+Failure mode:
+  1. Fail-closed (recommended) — reject the operation, return error
+  2. Fail-open — allow the operation, log the failure
+  3. Passthrough — forward to the next handler unchanged
+  4. Crash — terminate the process
+
+  Or type your own: ___
+```
 - **Full mode, if `require_stride` is true**: What is the adversary model? Who is trying to break this?
 - **Full mode**: What existing abstractions does this touch? (reference ARCHITECTURE.md ABS-xxx entries)
 
@@ -282,6 +292,14 @@ A unit test with hand-constructed mocks will not catch missing wiring.
 
 ## Risks
 - {risk} — {mitigation or "accepted"}
+
+For each identified risk, present the acceptance decision:
+
+  1. Mitigate (recommended) — add a rule or guard that addresses the risk
+  2. Accept — document why this risk is tolerable
+  3. Defer — log for a future feature to address
+
+  Or type your own: ___
 
 ## Open Questions
 - {question}

--- a/correctless-full/skills/ctdd/SKILL.md
+++ b/correctless-full/skills/ctdd/SKILL.md
@@ -203,7 +203,17 @@ After the test agent completes and tests exist, run the **test audit** before ad
 > Read: AGENT_CONTEXT.md, the spec, the test files, ARCHITECTURE.md, `.claude/antipatterns.md`.
 > Write: NOTHING. Return findings as your final text response.
 
-**If BLOCKING findings exist**: present to the human. The test agent must fix the tests (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
+**If BLOCKING findings exist**: present each finding to the human with disposition options:
+
+```
+  1. Fix now (recommended) — implement instance fix + class fix
+  2. Accept risk — document why this finding is acceptable
+  3. Dispute — explain why this is not actually an issue
+
+  Or type your own: ___
+```
+
+The test agent must fix the approved findings (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
 
 **If no BLOCKING findings**: advance to GREEN:
 
@@ -222,6 +232,14 @@ Spawn an **implementation agent** as a separate forked subagent:
 > Reference the failing test output and implement specifically to make tests pass. Each implementation decision should trace back to a spec rule.
 >
 > If you need to edit a test file (e.g., it has a bug — wrong assertion, incorrect setup), you may do so, but every test edit is logged with a reason. Acceptable: the test had a bug, needed an updated fixture. Unacceptable: weakening an assertion to make it pass, deleting a "too strict" test.
+>
+> When the implementation agent edits a test file, present the edit to the user:
+>
+>   1. Approve change (recommended) — the edit is a legitimate fix
+>   2. Reject — revert the test edit, find another implementation approach
+>   3. Modify — adjust the test edit before accepting
+>
+>   Or type your own: ___
 >
 > Before advancing, all tests must pass.
 >

--- a/correctless-full/skills/cverify/SKILL.md
+++ b/correctless-full/skills/cverify/SKILL.md
@@ -97,7 +97,17 @@ Compare the spec's rules against the implementation:
 - Are there code paths not covered by any spec rule?
 - For rules with `implemented_in` fields: do those files/functions still exist?
 
-**If drift is found**: Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
+**If drift is found**, present each drift item to the human with options:
+
+```
+  1. Fix (recommended) — update code or spec to resolve drift
+  2. Log as debt — create DRIFT-NNN entry for future resolution
+  3. Accept as intentional — document why the drift is correct
+
+  Or type your own: ___
+```
+
+For items where the user chooses "Log as debt": Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
 
 Drift debt entry format:
 ```json

--- a/correctless-lite/skills/cdocs/SKILL.md
+++ b/correctless-lite/skills/cdocs/SKILL.md
@@ -83,7 +83,16 @@ Reference the spec artifact for detailed rules — don't duplicate.
 
 If the feature introduced new patterns or conventions:
 - Suggest additions to ARCHITECTURE.md
-- Present each to the human for approval — one at a time
+- Present each to the human for approval — one at a time, with options:
+
+```
+  1. Add (recommended) — add this entry to ARCHITECTURE.md
+  2. Skip — not a pattern worth documenting
+  3. Modify — change the entry before adding
+
+  Or type your own: ___
+```
+
 - Don't auto-add without approval
 
 ### 6. Fact-Check
@@ -160,10 +169,12 @@ Full mode:
 ```
 
 Confirm: "Documentation complete. Your options:
-1. Create a PR: `gh pr create` (or `/cpr-review` on your own branch first)
+1. Create a PR (recommended): `gh pr create` (or `/cpr-review` on your own branch first)
 2. Merge locally: `git checkout main && git merge {branch}`
 3. Keep the branch as-is for later review
 4. Discard: `git checkout main && git branch -D {branch}`
+
+Or type your own: ___
 
 After merging to main:
 - If bugs escape to production from this feature → run `/cpostmortem` to trace which phase missed it

--- a/correctless-lite/skills/cquick/SKILL.md
+++ b/correctless-lite/skills/cquick/SKILL.md
@@ -85,6 +85,16 @@ git commit -m "Fix: <description>"
 - **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
 - **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
 
+## Decision Points
+
+When presenting choices to the user:
+
+1. Present numbered options with the recommended option first
+2. Mark the recommended option with "(recommended)"
+3. Include 2-4 options maximum
+4. Always end with: "Or type your own: ___"
+5. Accept the number, the option name, or a typed response
+
 ## If Something Goes Wrong
 
 - Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.

--- a/correctless-lite/skills/crefactor/SKILL.md
+++ b/correctless-lite/skills/crefactor/SKILL.md
@@ -204,7 +204,18 @@ If the verification agent detects a test file modification:
    - The refactor intentionally changes behavior — document why
    - The refactor accidentally broke something — fix it
 
-   Is this test change intentional? Provide a reason."
+   Is this test change intentional?"
+
+   Present the options:
+
+   ```
+     1. Approve behavioral change (recommended) — the test correctly reflects new behavior
+     2. Reject — revert this test change, find another approach
+     3. Split into separate PR — this behavioral change deserves its own review
+
+     Or type your own: ___
+   ```
+
 4. User must approve with a reason. Log the approval in the refactor intent artifact.
 5. Update the baseline with the new test checksums before proceeding.
 

--- a/correctless-lite/skills/creview/SKILL.md
+++ b/correctless-lite/skills/creview/SKILL.md
@@ -203,6 +203,17 @@ Present findings to the human organized by category:
 6. Security rules missing (from the checklist)
 7. Self-assessment of the spec
 
+For each finding, present the disposition options:
+
+```
+  1. Accept finding (recommended) — add rule or update spec
+  2. Reject — explain why this doesn't apply
+  3. Modify — accept the concern but change the proposed rule
+  4. Defer — log as accepted risk for future feature
+
+  Or type your own: ___
+```
+
 Incorporate approved changes directly into the spec file. Preserve existing rule numbering — add new rules at the end (R-004, R-005, etc.).
 
 ## Advance State

--- a/correctless-lite/skills/csetup/SKILL.md
+++ b/correctless-lite/skills/csetup/SKILL.md
@@ -184,7 +184,19 @@ Check the following before presenting the offer:
 
 ### Offer
 
-When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with four options: **both**, **just Serena**, **just Context7**, or **skip**. When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
+When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with numbered options:
+
+```
+MCP server integration:
+  1. Both Serena + Context7 (recommended) — symbol analysis and library docs
+  2. Just Serena — symbol-level code analysis only
+  3. Just Context7 — up-to-date library documentation only
+  4. Skip — no MCP servers
+
+  Or type your own: ___
+```
+
+When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
 
 ### Tooling Prerequisites
 
@@ -979,8 +991,18 @@ Source Control — detected:
   ✗ PR template: none found → I can generate one
   ✗ Branch protection: not configured → recommend enabling
 
-Branching strategy: [feature branches / trunk-based]?
-Merge strategy: [squash / merge / rebase]?
+Branching strategy:
+  1. Feature branches (recommended) — branch per feature, merge via PR
+  2. Trunk-based — short-lived branches, commit to main frequently
+
+  Or type your own: ___
+
+Merge strategy:
+  1. Squash (recommended) — clean history, one commit per feature
+  2. Merge commit — preserves branch history
+  3. Rebase — linear history, no merge commits
+
+  Or type your own: ___
 ```
 
 **Where answers go:**

--- a/correctless-lite/skills/cspec/SKILL.md
+++ b/correctless-lite/skills/cspec/SKILL.md
@@ -86,7 +86,17 @@ Key questions:
 - What is the feature? (functional description — refined by brainstorm)
 - What does "correct" mean? (the answer becomes invariants/rules)
 - What must this feature NEVER do? (the answer becomes prohibitions/rules)
-- What happens when this fails? (failure mode — fail-open, fail-closed, passthrough, crash)
+- What happens when this fails? Present the failure mode options:
+
+```
+Failure mode:
+  1. Fail-closed (recommended) — reject the operation, return error
+  2. Fail-open — allow the operation, log the failure
+  3. Passthrough — forward to the next handler unchanged
+  4. Crash — terminate the process
+
+  Or type your own: ___
+```
 - **Full mode, if `require_stride` is true**: What is the adversary model? Who is trying to break this?
 - **Full mode**: What existing abstractions does this touch? (reference ARCHITECTURE.md ABS-xxx entries)
 
@@ -282,6 +292,14 @@ A unit test with hand-constructed mocks will not catch missing wiring.
 
 ## Risks
 - {risk} — {mitigation or "accepted"}
+
+For each identified risk, present the acceptance decision:
+
+  1. Mitigate (recommended) — add a rule or guard that addresses the risk
+  2. Accept — document why this risk is tolerable
+  3. Defer — log for a future feature to address
+
+  Or type your own: ___
 
 ## Open Questions
 - {question}

--- a/correctless-lite/skills/ctdd/SKILL.md
+++ b/correctless-lite/skills/ctdd/SKILL.md
@@ -203,7 +203,17 @@ After the test agent completes and tests exist, run the **test audit** before ad
 > Read: AGENT_CONTEXT.md, the spec, the test files, ARCHITECTURE.md, `.claude/antipatterns.md`.
 > Write: NOTHING. Return findings as your final text response.
 
-**If BLOCKING findings exist**: present to the human. The test agent must fix the tests (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
+**If BLOCKING findings exist**: present each finding to the human with disposition options:
+
+```
+  1. Fix now (recommended) — implement instance fix + class fix
+  2. Accept risk — document why this finding is acceptable
+  3. Dispute — explain why this is not actually an issue
+
+  Or type your own: ___
+```
+
+The test agent must fix the approved findings (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
 
 **If no BLOCKING findings**: advance to GREEN:
 
@@ -222,6 +232,14 @@ Spawn an **implementation agent** as a separate forked subagent:
 > Reference the failing test output and implement specifically to make tests pass. Each implementation decision should trace back to a spec rule.
 >
 > If you need to edit a test file (e.g., it has a bug — wrong assertion, incorrect setup), you may do so, but every test edit is logged with a reason. Acceptable: the test had a bug, needed an updated fixture. Unacceptable: weakening an assertion to make it pass, deleting a "too strict" test.
+>
+> When the implementation agent edits a test file, present the edit to the user:
+>
+>   1. Approve change (recommended) — the edit is a legitimate fix
+>   2. Reject — revert the test edit, find another implementation approach
+>   3. Modify — adjust the test edit before accepting
+>
+>   Or type your own: ___
 >
 > Before advancing, all tests must pass.
 >

--- a/correctless-lite/skills/cverify/SKILL.md
+++ b/correctless-lite/skills/cverify/SKILL.md
@@ -97,7 +97,17 @@ Compare the spec's rules against the implementation:
 - Are there code paths not covered by any spec rule?
 - For rules with `implemented_in` fields: do those files/functions still exist?
 
-**If drift is found**: Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
+**If drift is found**, present each drift item to the human with options:
+
+```
+  1. Fix (recommended) — update code or spec to resolve drift
+  2. Log as debt — create DRIFT-NNN entry for future resolution
+  3. Accept as intentional — document why the drift is correct
+
+  Or type your own: ___
+```
+
+For items where the user chooses "Log as debt": Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
 
 Drift debt entry format:
 ```json

--- a/docs/specs/structured-decision-ux.md
+++ b/docs/specs/structured-decision-ux.md
@@ -1,0 +1,54 @@
+# Spec: Structured Decision UX
+
+## What
+
+Replace open-ended questions with numbered options across all Correctless skills. Every time the user needs to make a choice, present 2-4 numbered options with the recommended option first, marked "(recommended)", and an escape hatch "Or type your own: ___". This is a universal UX constraint added to the spec templates and applied to every skill that asks the user to decide something.
+
+## Rules
+
+### Universal Constraint
+
+- **R-001** [unit]: Both `templates/spec-lite.md` and `templates/spec-full.md` contain a "Decision Points" section with the structured decision format: numbered options, recommended first, 2-4 options max, "Or type your own" escape hatch.
+
+- **R-002** [unit]: The `/cquick` SKILL.md contains the "Decision Points" constraint (as the newest skill, it sets the pattern for future skills).
+
+### Per-Skill Decision Points
+
+Skills that ask the user to choose something must contain structured option patterns. Each rule verifies the SKILL.md has numbered options (grep for `1.` followed by `2.` in decision contexts) rather than open-ended questions.
+
+- **R-003** [unit]: `/csetup` SKILL.md contains structured options for all three of: MCP selection (both/Serena/Context7/skip), branching strategy (feature branches/trunk-based), and merge strategy (squash/merge/rebase). Test must verify all three decision points exist.
+
+- **R-004** [unit]: `/cspec` SKILL.md contains structured options for: failure mode decisions (fail-open/fail-closed/passthrough/crash) and risk acceptance (accept/mitigate/defer).
+
+- **R-005** [unit]: `/creview` SKILL.md contains structured options for: finding disposition (accept finding/reject/modify/defer).
+
+- **R-006** [unit]: `/ctdd` SKILL.md contains structured options for: QA finding response (fix now/accept risk/dispute) and test edit approval (approve/reject/modify).
+
+- **R-007** [unit]: `/cverify` SKILL.md contains structured options for: drift handling (fix/log as debt/accept as intentional).
+
+- **R-008** [unit]: `/cdocs` SKILL.md contains structured options for: architecture entry approval (add/skip/modify) and post-merge action (create PR/merge locally/keep branch/discard).
+
+- **R-009** [unit]: `/crefactor` SKILL.md contains structured options for: test change approval (approve behavioral change/reject/split into separate PR).
+
+- **R-010** [unit]: `/caudit` SKILL.md contains structured options for: finding triage (fix now/defer/dispute) and convergence decision (continue to next round/stop here).
+
+### Skills That Don't Need Changes
+
+- **R-011** [unit]: Read-only skills (`/chelp`, `/cstatus`, `/csummary`, `/cmetrics`, `/cwtf`) do not contain numbered decision option blocks (no `1.` + `(recommended)` pattern) because they don't present user decisions. This is a positive structural check, not a grep for open-ended questions.
+
+- **R-012** [unit]: `/creview-spec` SKILL.md contains structured options for: finding disposition (accept finding/reject/modify/defer) — same pattern as `/creview`.
+
+## Won't Do
+
+- Changing the AskUserQuestion tool behavior — that's a Claude Code feature, not a Correctless feature. The structured format is in the skill prompt text, not in tool parameters.
+- Adding options to every possible question — only decision points where the user is choosing between discrete alternatives. Socratic brainstorm questions in `/cspec` remain open-ended because they're exploratory, not decisional.
+- Standardizing the exact option text across skills — each skill's options are domain-specific. The format is standardized, the content is not.
+
+## Risks
+
+- Skills with many decision points (`/csetup` has ~8) could become verbose if every decision gets a full options block. Mitigation: batch related decisions where possible ("Branching: feature branches. Merge: squash. Look right, or change something?").
+- The "Or type your own" escape hatch means the agent still needs to handle free-form input gracefully. Not a new requirement — agents already handle this.
+
+## Open Questions
+
+- None.

--- a/docs/verification/structured-decision-ux-verification.md
+++ b/docs/verification/structured-decision-ux-verification.md
@@ -1,0 +1,30 @@
+# Verification: Structured Decision UX
+
+## Rule Coverage
+
+| Rule | Test | Status |
+|------|------|--------|
+| R-001 | template Decision Points + format checks (6 assertions) | covered |
+| R-002 | cquick Decision Points section | covered |
+| R-003 | csetup MCP + branching + merge options (3 assertions) | covered |
+| R-004 | cspec failure mode + risk acceptance (2 assertions) | covered |
+| R-005 | creview finding disposition | covered |
+| R-006 | ctdd QA finding + test edit approval (2 assertions) | covered |
+| R-007 | cverify drift handling | covered |
+| R-008 | cdocs architecture + post-merge (2 assertions) | covered |
+| R-009 | crefactor test change approval | covered |
+| R-010 | caudit finding triage + convergence (2 assertions) | covered |
+| R-011 | 5 read-only skills negative check | covered |
+| R-012 | creview-spec finding disposition | covered |
+
+12/12 rules covered. 0 uncovered.
+
+## QA Findings — All Fixed
+
+2 rounds, 6 findings: 3 missing decision blocks (ctdd test-edit, caudit convergence, cspec risk), 1 format violation (cdocs post-merge), 2 test gaps. All addressed.
+
+## Test Results
+
+319 total tests, 0 failures. Sync clean.
+
+## Overall: PASS

--- a/skills/caudit/SKILL.md
+++ b/skills/caudit/SKILL.md
@@ -79,7 +79,17 @@ Clean up the checkpoint file when the audit converges and completes successfully
 2. Spawn parallel agents (4-6) with specialized hostile lenses
 3. Agents submit findings with confidence tiers (confirmed/probable/suspicious)
 4. Triage agent deduplicates, validates, rejects false positives
-5. Fix all confirmed findings on the audit branch
+5. Present validated findings to the human for triage:
+
+   ```
+     1. Fix now (recommended) — address in the current round
+     2. Defer — log for future resolution
+     3. Dispute — explain why this is not an issue
+
+     Or type your own: ___
+   ```
+
+   Fix all confirmed findings on the audit branch:
    - Non-trivial: TDD (tests first, separate impl agent)
    - Trivial one-liners: apply directly
 6. Commit fixes
@@ -103,6 +113,13 @@ Clean up the checkpoint file when the audit converges and completes successfully
 **Divergence**: if a round finds MORE issues than previous, check if fixes introduced regressions.
 
 **Cost visibility**: after each round, report: findings found, findings fixed, total rounds. Human decides whether to continue.
+
+After each round, present the convergence decision:
+
+  1. Continue to next round (recommended) — there are still actionable findings
+  2. Stop here — remaining findings are acceptable or diminishing returns
+
+  Or type your own: ___
 
 ## Confidence Tiers
 

--- a/skills/cdocs/SKILL.md
+++ b/skills/cdocs/SKILL.md
@@ -83,7 +83,16 @@ Reference the spec artifact for detailed rules — don't duplicate.
 
 If the feature introduced new patterns or conventions:
 - Suggest additions to ARCHITECTURE.md
-- Present each to the human for approval — one at a time
+- Present each to the human for approval — one at a time, with options:
+
+```
+  1. Add (recommended) — add this entry to ARCHITECTURE.md
+  2. Skip — not a pattern worth documenting
+  3. Modify — change the entry before adding
+
+  Or type your own: ___
+```
+
 - Don't auto-add without approval
 
 ### 6. Fact-Check
@@ -160,10 +169,12 @@ Full mode:
 ```
 
 Confirm: "Documentation complete. Your options:
-1. Create a PR: `gh pr create` (or `/cpr-review` on your own branch first)
+1. Create a PR (recommended): `gh pr create` (or `/cpr-review` on your own branch first)
 2. Merge locally: `git checkout main && git merge {branch}`
 3. Keep the branch as-is for later review
 4. Discard: `git checkout main && git branch -D {branch}`
+
+Or type your own: ___
 
 After merging to main:
 - If bugs escape to production from this feature → run `/cpostmortem` to trace which phase missed it

--- a/skills/cquick/SKILL.md
+++ b/skills/cquick/SKILL.md
@@ -85,6 +85,16 @@ git commit -m "Fix: <description>"
 - **No workflow state.** This skill does not use `workflow-advance.sh` or create workflow state files.
 - **Never auto-invoke other skills.** If the change needs escalation, tell the user and stop.
 
+## Decision Points
+
+When presenting choices to the user:
+
+1. Present numbered options with the recommended option first
+2. Mark the recommended option with "(recommended)"
+3. Include 2-4 options maximum
+4. Always end with: "Or type your own: ___"
+5. Accept the number, the option name, or a typed response
+
 ## If Something Goes Wrong
 
 - Tests fail after implementation: debug and fix. If you can't fix within 3 attempts, suggest `/cdebug`.

--- a/skills/crefactor/SKILL.md
+++ b/skills/crefactor/SKILL.md
@@ -204,7 +204,18 @@ If the verification agent detects a test file modification:
    - The refactor intentionally changes behavior — document why
    - The refactor accidentally broke something — fix it
 
-   Is this test change intentional? Provide a reason."
+   Is this test change intentional?"
+
+   Present the options:
+
+   ```
+     1. Approve behavioral change (recommended) — the test correctly reflects new behavior
+     2. Reject — revert this test change, find another approach
+     3. Split into separate PR — this behavioral change deserves its own review
+
+     Or type your own: ___
+   ```
+
 4. User must approve with a reason. Log the approval in the refactor intent artifact.
 5. Update the baseline with the new test checksums before proceeding.
 

--- a/skills/creview-spec/SKILL.md
+++ b/skills/creview-spec/SKILL.md
@@ -144,6 +144,17 @@ Organize findings by category:
 5. Design contract conflicts
 6. External model findings (if any)
 
+For each finding, present the disposition options:
+
+```
+  1. Accept finding (recommended) — add rule or update spec
+  2. Reject — explain why this doesn't apply
+  3. Modify — accept the concern but change the proposed rule
+  4. Defer — log as accepted risk for future feature
+
+  Or type your own: ___
+```
+
 Incorporate approved changes into the spec.
 
 ## Advance State

--- a/skills/creview/SKILL.md
+++ b/skills/creview/SKILL.md
@@ -203,6 +203,17 @@ Present findings to the human organized by category:
 6. Security rules missing (from the checklist)
 7. Self-assessment of the spec
 
+For each finding, present the disposition options:
+
+```
+  1. Accept finding (recommended) — add rule or update spec
+  2. Reject — explain why this doesn't apply
+  3. Modify — accept the concern but change the proposed rule
+  4. Defer — log as accepted risk for future feature
+
+  Or type your own: ___
+```
+
 Incorporate approved changes directly into the spec file. Preserve existing rule numbering — add new rules at the end (R-004, R-005, etc.).
 
 ## Advance State

--- a/skills/csetup/SKILL.md
+++ b/skills/csetup/SKILL.md
@@ -184,7 +184,19 @@ Check the following before presenting the offer:
 
 ### Offer
 
-When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with four options: **both**, **just Serena**, **just Context7**, or **skip**. When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
+When **neither** server is configured and Serena passes the usefulness check, present MCP as a single decision with numbered options:
+
+```
+MCP server integration:
+  1. Both Serena + Context7 (recommended) — symbol analysis and library docs
+  2. Just Serena — symbol-level code analysis only
+  3. Just Context7 — up-to-date library documentation only
+  4. Skip — no MCP servers
+
+  Or type your own: ___
+```
+
+When Serena does not pass the usefulness check, present only: **Context7** or **skip**. When only one server is already configured, present a two-option offer for the missing one (as described in the Detection section above). The offer only appears when at least one server is not yet configured AND the required tooling is available.
 
 ### Tooling Prerequisites
 
@@ -979,8 +991,18 @@ Source Control — detected:
   ✗ PR template: none found → I can generate one
   ✗ Branch protection: not configured → recommend enabling
 
-Branching strategy: [feature branches / trunk-based]?
-Merge strategy: [squash / merge / rebase]?
+Branching strategy:
+  1. Feature branches (recommended) — branch per feature, merge via PR
+  2. Trunk-based — short-lived branches, commit to main frequently
+
+  Or type your own: ___
+
+Merge strategy:
+  1. Squash (recommended) — clean history, one commit per feature
+  2. Merge commit — preserves branch history
+  3. Rebase — linear history, no merge commits
+
+  Or type your own: ___
 ```
 
 **Where answers go:**

--- a/skills/cspec/SKILL.md
+++ b/skills/cspec/SKILL.md
@@ -86,7 +86,17 @@ Key questions:
 - What is the feature? (functional description — refined by brainstorm)
 - What does "correct" mean? (the answer becomes invariants/rules)
 - What must this feature NEVER do? (the answer becomes prohibitions/rules)
-- What happens when this fails? (failure mode — fail-open, fail-closed, passthrough, crash)
+- What happens when this fails? Present the failure mode options:
+
+```
+Failure mode:
+  1. Fail-closed (recommended) — reject the operation, return error
+  2. Fail-open — allow the operation, log the failure
+  3. Passthrough — forward to the next handler unchanged
+  4. Crash — terminate the process
+
+  Or type your own: ___
+```
 - **Full mode, if `require_stride` is true**: What is the adversary model? Who is trying to break this?
 - **Full mode**: What existing abstractions does this touch? (reference ARCHITECTURE.md ABS-xxx entries)
 
@@ -282,6 +292,14 @@ A unit test with hand-constructed mocks will not catch missing wiring.
 
 ## Risks
 - {risk} — {mitigation or "accepted"}
+
+For each identified risk, present the acceptance decision:
+
+  1. Mitigate (recommended) — add a rule or guard that addresses the risk
+  2. Accept — document why this risk is tolerable
+  3. Defer — log for a future feature to address
+
+  Or type your own: ___
 
 ## Open Questions
 - {question}

--- a/skills/ctdd/SKILL.md
+++ b/skills/ctdd/SKILL.md
@@ -203,7 +203,17 @@ After the test agent completes and tests exist, run the **test audit** before ad
 > Read: AGENT_CONTEXT.md, the spec, the test files, ARCHITECTURE.md, `.claude/antipatterns.md`.
 > Write: NOTHING. Return findings as your final text response.
 
-**If BLOCKING findings exist**: present to the human. The test agent must fix the tests (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
+**If BLOCKING findings exist**: present each finding to the human with disposition options:
+
+```
+  1. Fix now (recommended) — implement instance fix + class fix
+  2. Accept risk — document why this finding is acceptable
+  3. Dispute — explain why this is not actually an issue
+
+  Or type your own: ___
+```
+
+The test agent must fix the approved findings (add integration tests, strengthen assertions, remove mock gaps) before advancing. Re-run the test auditor after fixes.
 
 **If no BLOCKING findings**: advance to GREEN:
 
@@ -222,6 +232,14 @@ Spawn an **implementation agent** as a separate forked subagent:
 > Reference the failing test output and implement specifically to make tests pass. Each implementation decision should trace back to a spec rule.
 >
 > If you need to edit a test file (e.g., it has a bug — wrong assertion, incorrect setup), you may do so, but every test edit is logged with a reason. Acceptable: the test had a bug, needed an updated fixture. Unacceptable: weakening an assertion to make it pass, deleting a "too strict" test.
+>
+> When the implementation agent edits a test file, present the edit to the user:
+>
+>   1. Approve change (recommended) — the edit is a legitimate fix
+>   2. Reject — revert the test edit, find another implementation approach
+>   3. Modify — adjust the test edit before accepting
+>
+>   Or type your own: ___
 >
 > Before advancing, all tests must pass.
 >

--- a/skills/cverify/SKILL.md
+++ b/skills/cverify/SKILL.md
@@ -97,7 +97,17 @@ Compare the spec's rules against the implementation:
 - Are there code paths not covered by any spec rule?
 - For rules with `implemented_in` fields: do those files/functions still exist?
 
-**If drift is found**: Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
+**If drift is found**, present each drift item to the human with options:
+
+```
+  1. Fix (recommended) — update code or spec to resolve drift
+  2. Log as debt — create DRIFT-NNN entry for future resolution
+  3. Accept as intentional — document why the drift is correct
+
+  Or type your own: ___
+```
+
+For items where the user chooses "Log as debt": Read `.claude/meta/drift-debt.json` first, then APPEND new entries to the existing `drift_debt` array. Use `Edit` to add entries — do NOT overwrite the file with `Write`. Use the next sequential DRIFT-NNN ID.
 
 Drift debt entry format:
 ```json

--- a/templates/spec-full.md
+++ b/templates/spec-full.md
@@ -31,6 +31,16 @@
 - **Detection**: {method}
 - **Consequence**: {impact}
 
+## Decision Points
+
+When presenting choices to the user:
+
+1. Present numbered options with the recommended option first
+2. Mark the recommended option with "(recommended)"
+3. Include 2-4 options maximum
+4. Always end with: "Or type your own: ___"
+5. Accept the number, the option name, or a typed response
+
 ## Open Questions
 
 - **OQ-001**: {question} — {why it matters}

--- a/templates/spec-lite.md
+++ b/templates/spec-lite.md
@@ -16,6 +16,16 @@
 
 - {risk} — {mitigation or "accepted"}
 
+## Decision Points
+
+When presenting choices to the user:
+
+1. Present numbered options with the recommended option first
+2. Mark the recommended option with "(recommended)"
+3. Include 2-4 options maximum
+4. Always end with: "Or type your own: ___"
+5. Accept the number, the option name, or a typed response
+
 ## Open Questions
 
 - {question}

--- a/test-decisions.sh
+++ b/test-decisions.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Correctless — Structured Decision UX tests
+# Tests spec rules R-001 through R-012 from docs/specs/structured-decision-ux.md
+# Run from repo root: bash test-decisions.sh
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers (matching test.sh style)
+# ---------------------------------------------------------------------------
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Check if a file contains a pattern (returns 0 if found)
+file_contains() {
+  grep -q "$2" "$1" 2>/dev/null
+}
+
+# Check if a file contains a pattern (case-insensitive, returns 0 if found)
+file_contains_i() {
+  grep -qi "$2" "$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-001 — Templates have Decision Points section
+# ---------------------------------------------------------------------------
+
+test_r001() {
+  echo ""
+  echo "=== R-001: Templates have Decision Points section ==="
+
+  local lite="$REPO_DIR/templates/spec-lite.md"
+  local full="$REPO_DIR/templates/spec-full.md"
+
+  file_contains_i "$lite" "Decision Points" && local lite_dp="true" || local lite_dp="false"
+  assert_eq "R-001: spec-lite.md has Decision Points section" "true" "$lite_dp"
+
+  file_contains_i "$full" "Decision Points" && local full_dp="true" || local full_dp="false"
+  assert_eq "R-001: spec-full.md has Decision Points section" "true" "$full_dp"
+
+  file_contains_i "$full" "recommended)" && local full_rec="true" || local full_rec="false"
+  assert_eq "R-001: spec-full.md has recommended pattern" "true" "$full_rec"
+
+  file_contains_i "$full" "Or type your own" && local full_esc="true" || local full_esc="false"
+  assert_eq "R-001: spec-full.md has escape hatch" "true" "$full_esc"
+
+  file_contains_i "$lite" "recommended)" && local lite_rec="true" || local lite_rec="false"
+  assert_eq "R-001: spec-lite.md has recommended pattern" "true" "$lite_rec"
+
+  file_contains_i "$lite" "Or type your own" && local lite_esc="true" || local lite_esc="false"
+  assert_eq "R-001: spec-lite.md has escape hatch" "true" "$lite_esc"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-002 — /cquick has Decision Points
+# ---------------------------------------------------------------------------
+
+test_r002() {
+  echo ""
+  echo "=== R-002: /cquick has Decision Points ==="
+
+  local skill="$REPO_DIR/skills/cquick/SKILL.md"
+
+  file_contains_i "$skill" "Decision Points" && local found="true" || local found="false"
+  assert_eq "R-002: cquick SKILL.md has Decision Points section" "true" "$found"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-003 — /csetup has structured options for 3 decisions
+# ---------------------------------------------------------------------------
+
+test_r003() {
+  echo ""
+  echo "=== R-003: /csetup has structured options for 3 decisions ==="
+
+  local skill="$REPO_DIR/skills/csetup/SKILL.md"
+
+  # MCP selection: must have numbered options with (recommended) near MCP context
+  file_contains_i "$skill" "1\..*both.*(recommended)" && local mcp="true" || local mcp="false"
+  assert_eq "R-003: csetup has numbered MCP selection options" "true" "$mcp"
+
+  # Branching strategy: must have numbered options with (recommended) near branching context
+  file_contains_i "$skill" "1\..*feature.branch.*(recommended)\|1\..*trunk.based.*(recommended)" && local branch="true" || local branch="false"
+  assert_eq "R-003: csetup has numbered branching strategy options" "true" "$branch"
+
+  # Merge strategy: must have numbered options with (recommended) near merge context
+  file_contains_i "$skill" "1\..*squash.*(recommended)\|1\..*rebase.*(recommended)" && local merge="true" || local merge="false"
+  assert_eq "R-003: csetup has numbered merge strategy options" "true" "$merge"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-004 — /cspec has failure mode + risk options
+# ---------------------------------------------------------------------------
+
+test_r004() {
+  echo ""
+  echo "=== R-004: /cspec has failure mode + risk options ==="
+
+  local skill="$REPO_DIR/skills/cspec/SKILL.md"
+
+  # Must have numbered options with (recommended) for failure mode decision
+  file_contains_i "$skill" "1\..*fail.open.*(recommended)\|1\..*fail.closed.*(recommended)" && local found="true" || local found="false"
+  assert_eq "R-004: cspec has numbered failure mode options" "true" "$found"
+
+  # Must have risk acceptance options (mitigate/accept/defer)
+  file_contains_i "$skill" "mitigate.*(recommended)\|accept.*mitigate" && local risk="true" || local risk="false"
+  assert_eq "R-004: cspec has risk acceptance options" "true" "$risk"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-005 — /creview has finding disposition options
+# ---------------------------------------------------------------------------
+
+test_r005() {
+  echo ""
+  echo "=== R-005: /creview has finding disposition options ==="
+
+  local skill="$REPO_DIR/skills/creview/SKILL.md"
+
+  file_contains_i "$skill" "accept.*reject.*modify.*defer\|accept finding\|reject.*modify.*defer" && local found="true" || local found="false"
+  assert_eq "R-005: creview has finding disposition options" "true" "$found"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-006 — /ctdd has QA finding + test edit options
+# ---------------------------------------------------------------------------
+
+test_r006() {
+  echo ""
+  echo "=== R-006: /ctdd has QA finding + test edit options ==="
+
+  local skill="$REPO_DIR/skills/ctdd/SKILL.md"
+
+  file_contains_i "$skill" "fix now\|accept risk\|dispute" && local qa="true" || local qa="false"
+  assert_eq "R-006: ctdd has QA finding response options" "true" "$qa"
+
+  # Must have test edit approval options (approve/reject)
+  file_contains_i "$skill" "approve change.*(recommended)\|approve.*(recommended).*reject" && local testedit="true" || local testedit="false"
+  assert_eq "R-006: ctdd has test edit approval options" "true" "$testedit"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-007 — /cverify has drift options
+# ---------------------------------------------------------------------------
+
+test_r007() {
+  echo ""
+  echo "=== R-007: /cverify has drift options ==="
+
+  local skill="$REPO_DIR/skills/cverify/SKILL.md"
+
+  file_contains_i "$skill" "drift.*fix\|log as debt\|accept as intentional" && local found="true" || local found="false"
+  assert_eq "R-007: cverify has drift handling options" "true" "$found"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-008 — /cdocs has architecture + post-merge options
+# ---------------------------------------------------------------------------
+
+test_r008() {
+  echo ""
+  echo "=== R-008: /cdocs has architecture + post-merge options ==="
+
+  local skill="$REPO_DIR/skills/cdocs/SKILL.md"
+
+  # Must have numbered options with (recommended) for architecture entry
+  file_contains_i "$skill" "1\..*add.*(recommended)\|1\..*skip.*(recommended)" && local arch="true" || local arch="false"
+  assert_eq "R-008: cdocs has numbered architecture entry options" "true" "$arch"
+
+  # Must have post-merge options with (recommended)
+  file_contains_i "$skill" "Create a PR.*(recommended)\|1\..*PR.*(recommended)" && local postmerge="true" || local postmerge="false"
+  assert_eq "R-008: cdocs has post-merge options with recommended" "true" "$postmerge"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-009 — /crefactor has test change options
+# ---------------------------------------------------------------------------
+
+test_r009() {
+  echo ""
+  echo "=== R-009: /crefactor has test change options ==="
+
+  local skill="$REPO_DIR/skills/crefactor/SKILL.md"
+
+  file_contains_i "$skill" "approve behavioral\|reject.*split\|separate PR" && local found="true" || local found="false"
+  assert_eq "R-009: crefactor has test change approval options" "true" "$found"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-010 — /caudit has finding triage + convergence options
+# ---------------------------------------------------------------------------
+
+test_r010() {
+  echo ""
+  echo "=== R-010: /caudit has finding triage + convergence options ==="
+
+  local skill="$REPO_DIR/skills/caudit/SKILL.md"
+
+  # Must have numbered options with (recommended) for finding triage
+  file_contains_i "$skill" "1\..*fix now.*(recommended)\|1\..*fix.*(recommended).*triage" && local triage="true" || local triage="false"
+  assert_eq "R-010: caudit has numbered finding triage options" "true" "$triage"
+
+  # Must have convergence decision options (continue/stop)
+  file_contains_i "$skill" "continue to next round.*(recommended)\|continue.*(recommended).*stop" && local conv="true" || local conv="false"
+  assert_eq "R-010: caudit has convergence decision options" "true" "$conv"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-011 — Read-only skills do NOT have decision blocks
+# ---------------------------------------------------------------------------
+
+test_r011() {
+  echo ""
+  echo "=== R-011: Read-only skills do NOT have decision blocks ==="
+
+  local readonly_skills="chelp cstatus csummary cmetrics cwtf"
+
+  for skill_name in $readonly_skills; do
+    local skill_file="$REPO_DIR/skills/$skill_name/SKILL.md"
+    if [ -f "$skill_file" ]; then
+      file_contains "$skill_file" "recommended)" && local found="true" || local found="false"
+      assert_eq "R-011: $skill_name does NOT have decision options" "false" "$found"
+    else
+      echo "  SKIP: $skill_name SKILL.md not found"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-012 — /creview-spec has finding disposition options
+# ---------------------------------------------------------------------------
+
+test_r012() {
+  echo ""
+  echo "=== R-012: /creview-spec has finding disposition options ==="
+
+  local skill="$REPO_DIR/skills/creview-spec/SKILL.md"
+
+  file_contains_i "$skill" "accept.*reject.*modify.*defer\|accept finding\|reject.*modify.*defer" && local found="true" || local found="false"
+  assert_eq "R-012: creview-spec has finding disposition options" "true" "$found"
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+echo "Correctless Structured Decision UX Tests"
+echo "========================================="
+
+test_r001
+test_r002
+test_r003
+test_r004
+test_r005
+test_r006
+test_r007
+test_r008
+test_r009
+test_r010
+test_r011
+test_r012
+
+echo ""
+echo "========================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Replace open-ended questions with numbered options in every skill that presents user decisions. Universal format: recommended option first with "(recommended)" marker, 2-4 options max, "Or type your own: ___" escape hatch.

10 skills updated with structured decision blocks for their specific decision points. Templates include the universal constraint for future skills.

## Type

- [ ] Bug fix
- [ ] New skill
- [x] Skill enhancement
- [ ] Hook change
- [ ] Documentation
- [ ] CI/tooling

## Checklist

- [x] `bash test.sh` passes (57 tests)
- [x] `bash test-mcp.sh` passes (195 tests)
- [x] `bash test-bugfixes.sh` passes (15 tests)
- [x] `bash test-qol.sh` passes (25 tests)
- [x] `bash test-decisions.sh` passes (27 tests)
- [x] `bash sync.sh --check` exits 0

## Testing

Correctless Lite workflow: /cspec (12 rules) → /creview (3 changes) → /ctdd (RED → GREEN → QA R1 → fix → QA R2 converged) → /cverify (PASS) → /cdocs. 319 total tests.