### PR TITLE
Fix statusline not registered when settings.json partially exists

### DIFF
--- a/correctless-full/setup
+++ b/correctless-full/setup
@@ -348,9 +348,15 @@ HEOF
     return
   fi
 
-  # Check if hook already registered
-  if grep -q "workflow-gate" "$settings" 2>/dev/null; then
-    skip "Hook already registered in settings.json"
+  # Check if all components are registered — only skip if ALL are present
+  local has_gate has_audit has_statusline has_perms
+  has_gate=$(grep -q "workflow-gate" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_audit=$(grep -q "audit-trail" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_statusline=$(grep -q "statusLine" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_perms=$(grep -q "workflow-advance" "$settings" 2>/dev/null && echo "y" || echo "n")
+
+  if [ "$has_gate" = "y" ] && [ "$has_audit" = "y" ] && [ "$has_statusline" = "y" ] && [ "$has_perms" = "y" ]; then
+    skip "Hooks already registered in settings.json"
     return
   fi
 

--- a/correctless-lite/setup
+++ b/correctless-lite/setup
@@ -348,9 +348,15 @@ HEOF
     return
   fi
 
-  # Check if hook already registered
-  if grep -q "workflow-gate" "$settings" 2>/dev/null; then
-    skip "Hook already registered in settings.json"
+  # Check if all components are registered — only skip if ALL are present
+  local has_gate has_audit has_statusline has_perms
+  has_gate=$(grep -q "workflow-gate" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_audit=$(grep -q "audit-trail" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_statusline=$(grep -q "statusLine" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_perms=$(grep -q "workflow-advance" "$settings" 2>/dev/null && echo "y" || echo "n")
+
+  if [ "$has_gate" = "y" ] && [ "$has_audit" = "y" ] && [ "$has_statusline" = "y" ] && [ "$has_perms" = "y" ]; then
+    skip "Hooks already registered in settings.json"
     return
   fi
 

--- a/setup
+++ b/setup
@@ -348,9 +348,15 @@ HEOF
     return
   fi
 
-  # Check if hook already registered
-  if grep -q "workflow-gate" "$settings" 2>/dev/null; then
-    skip "Hook already registered in settings.json"
+  # Check if all components are registered — only skip if ALL are present
+  local has_gate has_audit has_statusline has_perms
+  has_gate=$(grep -q "workflow-gate" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_audit=$(grep -q "audit-trail" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_statusline=$(grep -q "statusLine" "$settings" 2>/dev/null && echo "y" || echo "n")
+  has_perms=$(grep -q "workflow-advance" "$settings" 2>/dev/null && echo "y" || echo "n")
+
+  if [ "$has_gate" = "y" ] && [ "$has_audit" = "y" ] && [ "$has_statusline" = "y" ] && [ "$has_perms" = "y" ]; then
+    skip "Hooks already registered in settings.json"
     return
   fi
 

--- a/test.sh
+++ b/test.sh
@@ -87,6 +87,8 @@ test_setup() {
   assert_eq "creates settings.json" "true" "$([ -f .claude/settings.json ] && echo true || echo false)"
   assert_eq "creates hooks dir" "true" "$([ -f .claude/hooks/workflow-gate.sh ] && echo true || echo false)"
   assert_contains "hooks reference .claude/hooks/" ".claude/hooks/workflow-gate.sh" "$(cat .claude/settings.json)"
+  assert_contains "settings has statusLine" "statusLine" "$(cat .claude/settings.json)"
+  assert_contains "settings has audit-trail hook" "audit-trail" "$(cat .claude/settings.json)"
   assert_eq "creates docs/specs" "true" "$([ -d docs/specs ] && echo true || echo false)"
   assert_eq "creates .claude/artifacts" "true" "$([ -d .claude/artifacts ] && echo true || echo false)"
 
@@ -94,6 +96,13 @@ test_setup() {
   local output2
   output2="$(.claude/skills/workflow/setup 2>&1)"
   assert_contains "idempotent — skips existing config" "already exists" "$output2"
+
+  # Partial settings — gate exists but statusLine missing (bug regression test)
+  local partial_settings='{"hooks":{"PreToolUse":[{"matcher":"Edit","command":".claude/hooks/workflow-gate.sh"}]}}'
+  echo "$partial_settings" > .claude/settings.json
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  assert_contains "partial settings: adds statusLine" "statusLine" "$(cat .claude/settings.json)"
+  assert_contains "partial settings: adds audit-trail" "audit-trail" "$(cat .claude/settings.json)"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`register_hooks()` in the setup script returned early when `workflow-gate` was found in `settings.json`, skipping statusLine, audit-trail, and permissions registration. Changed to check all 4 components — only skip when all are present.

## Type

- [x] Bug fix
- [ ] New skill
- [ ] Skill enhancement
- [x] Hook change
- [ ] Documentation
- [ ] CI/tooling

## Checklist

- [x] `bash test.sh` passes (61 tests — 4 new regression tests)
- [x] `bash sync.sh` produces no changes
- [x] `shellcheck hooks/*.sh` passes

## Testing

`/cdebug` investigation: reproduced, traced root cause to setup line 352, fixed with all-component check, added regression tests including partial-settings scenario.