### PR TITLE
Fix non-portable grep patterns in setup version detection

### DIFF
--- a/correctless-full/setup
+++ b/correctless-full/setup
@@ -565,7 +565,10 @@ detect_full_tools() {
 
 detect_version_file() {
   local config="$1"
-  command -v jq >/dev/null 2>&1 || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping version file detection (install jq for /crelease support)"
+    return 0
+  fi
 
   local version_file=""
   local version_pattern=""
@@ -575,15 +578,15 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="Cargo.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="pyproject.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^[[:space:]]*version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
     version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
@@ -604,13 +607,22 @@ detect_version_file() {
   fi
 
   if [ -n "$version_file" ]; then
-    jq --arg vf "$version_file" --arg vp "$version_pattern" \
+    if jq --arg vf "$version_file" --arg vp "$version_pattern" \
       '.release = { version_file: $vf, version_pattern: $vp }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
-    ok "Detected version file: $version_file"
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+      ok "Detected version file: $version_file"
+    else
+      rm -f "$config.$$"
+      warn "Failed to write release config — /crelease will ask on first run"
+    fi
   else
-    jq '.release = { version_file: null, version_pattern: null }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
+    if jq '.release = { version_file: null, version_pattern: null }' \
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+    else
+      rm -f "$config.$$"
+    fi
     info "No version file detected — /crelease will ask on first run"
   fi
 }

--- a/correctless-full/setup
+++ b/correctless-full/setup
@@ -575,22 +575,22 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="Cargo.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="pyproject.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -q '^version\s*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
-    version_pattern='version\s*=\s*[0-9]'
+    version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
-  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -l 'const Version\s*=\|var Version\s*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
+  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -El '(const|var) Version[[:space:]]*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
     # Store relative path from repo root
     version_file="${go_file#"$REPO_ROOT/"}"
-    version_pattern='(const|var) Version\s*=\s*"[^"]*"'
+    version_pattern='(const|var) Version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check CHANGELOG.md heading as fallback
   elif [ -f "$REPO_ROOT/CHANGELOG.md" ] && grep -q '## \[[0-9]' "$REPO_ROOT/CHANGELOG.md" 2>/dev/null; then
     version_file="CHANGELOG.md"

--- a/correctless-full/skills/crelease/SKILL.md
+++ b/correctless-full/skills/crelease/SKILL.md
@@ -151,7 +151,7 @@ Run these checks before creating the tag. All blockers must pass:
 4. **Tag doesn't already exist**: Verify no tag already exists with the proposed version (prevent tag collision)
 
 **Warnings** (non-blocking):
-- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. Continue?"
+- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. **This release only includes main.** Continue?"
 
 Each failed blocker produces a specific error identifying the check and how to fix it. The user can fix blockers and re-run, or abort.
 

--- a/correctless-full/skills/crelease/SKILL.md
+++ b/correctless-full/skills/crelease/SKILL.md
@@ -44,7 +44,7 @@ Then skip bump classification and proceed directly to changelog generation and t
 git rev-list v{last}..HEAD --count
 ```
 
-If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exits. Do not proceed further.
+If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exit. Do not proceed further.
 
 ### Dry-Run Option (R-011)
 

--- a/correctless-lite/setup
+++ b/correctless-lite/setup
@@ -565,7 +565,10 @@ detect_full_tools() {
 
 detect_version_file() {
   local config="$1"
-  command -v jq >/dev/null 2>&1 || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping version file detection (install jq for /crelease support)"
+    return 0
+  fi
 
   local version_file=""
   local version_pattern=""
@@ -575,15 +578,15 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="Cargo.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="pyproject.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^[[:space:]]*version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
     version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
@@ -604,13 +607,22 @@ detect_version_file() {
   fi
 
   if [ -n "$version_file" ]; then
-    jq --arg vf "$version_file" --arg vp "$version_pattern" \
+    if jq --arg vf "$version_file" --arg vp "$version_pattern" \
       '.release = { version_file: $vf, version_pattern: $vp }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
-    ok "Detected version file: $version_file"
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+      ok "Detected version file: $version_file"
+    else
+      rm -f "$config.$$"
+      warn "Failed to write release config — /crelease will ask on first run"
+    fi
   else
-    jq '.release = { version_file: null, version_pattern: null }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
+    if jq '.release = { version_file: null, version_pattern: null }' \
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+    else
+      rm -f "$config.$$"
+    fi
     info "No version file detected — /crelease will ask on first run"
   fi
 }

--- a/correctless-lite/setup
+++ b/correctless-lite/setup
@@ -575,22 +575,22 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="Cargo.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="pyproject.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -q '^version\s*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
-    version_pattern='version\s*=\s*[0-9]'
+    version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
-  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -l 'const Version\s*=\|var Version\s*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
+  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -El '(const|var) Version[[:space:]]*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
     # Store relative path from repo root
     version_file="${go_file#"$REPO_ROOT/"}"
-    version_pattern='(const|var) Version\s*=\s*"[^"]*"'
+    version_pattern='(const|var) Version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check CHANGELOG.md heading as fallback
   elif [ -f "$REPO_ROOT/CHANGELOG.md" ] && grep -q '## \[[0-9]' "$REPO_ROOT/CHANGELOG.md" 2>/dev/null; then
     version_file="CHANGELOG.md"

--- a/correctless-lite/skills/crelease/SKILL.md
+++ b/correctless-lite/skills/crelease/SKILL.md
@@ -151,7 +151,7 @@ Run these checks before creating the tag. All blockers must pass:
 4. **Tag doesn't already exist**: Verify no tag already exists with the proposed version (prevent tag collision)
 
 **Warnings** (non-blocking):
-- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. Continue?"
+- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. **This release only includes main.** Continue?"
 
 Each failed blocker produces a specific error identifying the check and how to fix it. The user can fix blockers and re-run, or abort.
 

--- a/correctless-lite/skills/crelease/SKILL.md
+++ b/correctless-lite/skills/crelease/SKILL.md
@@ -44,7 +44,7 @@ Then skip bump classification and proceed directly to changelog generation and t
 git rev-list v{last}..HEAD --count
 ```
 
-If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exits. Do not proceed further.
+If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exit. Do not proceed further.
 
 ### Dry-Run Option (R-011)
 

--- a/setup
+++ b/setup
@@ -565,7 +565,10 @@ detect_full_tools() {
 
 detect_version_file() {
   local config="$1"
-  command -v jq >/dev/null 2>&1 || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping version file detection (install jq for /crelease support)"
+    return 0
+  fi
 
   local version_file=""
   local version_pattern=""
@@ -575,15 +578,15 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="Cargo.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^[[:space:]]*version[[:space:]]*='; then
     version_file="pyproject.toml"
     version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^[[:space:]]*version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
     version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
@@ -604,13 +607,22 @@ detect_version_file() {
   fi
 
   if [ -n "$version_file" ]; then
-    jq --arg vf "$version_file" --arg vp "$version_pattern" \
+    if jq --arg vf "$version_file" --arg vp "$version_pattern" \
       '.release = { version_file: $vf, version_pattern: $vp }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
-    ok "Detected version file: $version_file"
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+      ok "Detected version file: $version_file"
+    else
+      rm -f "$config.$$"
+      warn "Failed to write release config — /crelease will ask on first run"
+    fi
   else
-    jq '.release = { version_file: null, version_pattern: null }' \
-      "$config" > "$config.$$" && mv "$config.$$" "$config"
+    if jq '.release = { version_file: null, version_pattern: null }' \
+      "$config" > "$config.$$"; then
+      mv "$config.$$" "$config"
+    else
+      rm -f "$config.$$"
+    fi
     info "No version file detected — /crelease will ask on first run"
   fi
 }

--- a/setup
+++ b/setup
@@ -575,22 +575,22 @@ detect_version_file() {
     version_file="package.json"
     version_pattern=".version"
   # Check Cargo.toml — section-aware: version must be under [package], not [workspace]
-  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/Cargo.toml" ] && sed -n '/^\[package\]/,/^\[/p' "$REPO_ROOT/Cargo.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="Cargo.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check pyproject.toml — section-aware: version must be under [project]
-  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -q '^version\s*='; then
+  elif [ -f "$REPO_ROOT/pyproject.toml" ] && sed -n '/^\[project\]/,/^\[/p' "$REPO_ROOT/pyproject.toml" 2>/dev/null | grep -Eq '^version[[:space:]]*='; then
     version_file="pyproject.toml"
-    version_pattern='version\s*=\s*"[^"]*"'
+    version_pattern='version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check setup.cfg
-  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -q '^version\s*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
+  elif [ -f "$REPO_ROOT/setup.cfg" ] && grep -Eq '^version[[:space:]]*=' "$REPO_ROOT/setup.cfg" 2>/dev/null; then
     version_file="setup.cfg"
-    version_pattern='version\s*=\s*[0-9]'
+    version_pattern='version[[:space:]]*=[[:space:]]*[0-9]'
   # Check Go version constants — capture find result once to avoid double traversal
-  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -l 'const Version\s*=\|var Version\s*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
+  elif go_file="$(find "$REPO_ROOT" -maxdepth 4 -name '*.go' -exec grep -El '(const|var) Version[[:space:]]*=' {} + 2>/dev/null | head -1)" && [ -n "$go_file" ]; then
     # Store relative path from repo root
     version_file="${go_file#"$REPO_ROOT/"}"
-    version_pattern='(const|var) Version\s*=\s*"[^"]*"'
+    version_pattern='(const|var) Version[[:space:]]*=[[:space:]]*"[^"]*"'
   # Check CHANGELOG.md heading as fallback
   elif [ -f "$REPO_ROOT/CHANGELOG.md" ] && grep -q '## \[[0-9]' "$REPO_ROOT/CHANGELOG.md" 2>/dev/null; then
     version_file="CHANGELOG.md"

--- a/skills/crelease/SKILL.md
+++ b/skills/crelease/SKILL.md
@@ -151,7 +151,7 @@ Run these checks before creating the tag. All blockers must pass:
 4. **Tag doesn't already exist**: Verify no tag already exists with the proposed version (prevent tag collision)
 
 **Warnings** (non-blocking):
-- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. Continue?"
+- If `.correctless/artifacts/workflow-state-*.json` files exist with phase other than `documented` on other branches, warn about active workflows: "{N} active workflows on other branches. **This release only includes main.** Continue?"
 
 Each failed blocker produces a specific error identifying the check and how to fix it. The user can fix blockers and re-run, or abort.
 

--- a/skills/crelease/SKILL.md
+++ b/skills/crelease/SKILL.md
@@ -44,7 +44,7 @@ Then skip bump classification and proceed directly to changelog generation and t
 git rev-list v{last}..HEAD --count
 ```
 
-If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exits. Do not proceed further.
+If there are no commits between the last tag and HEAD, report "No changes since v{last}. Nothing to release." and exit. Do not proceed further.
 
 ### Dry-Run Option (R-011)
 

--- a/test-crelease.sh
+++ b/test-crelease.sh
@@ -830,6 +830,89 @@ CL
 }
 
 # ---------------------------------------------------------------------------
+# Test: R-004 — Section-aware TOML parsing (negative tests)
+# ---------------------------------------------------------------------------
+
+test_r004_toml_wrong_section() {
+  echo ""
+  echo "=== R-004: Section-aware TOML parsing rejects wrong sections ==="
+
+  # Cargo.toml with version only under [workspace] (no [package]) → should NOT detect
+  setup_test_project
+  rm -f package.json
+  cat > Cargo.toml <<'TOML'
+[workspace]
+members = ["crates/*"]
+version = "1.0.0"
+TOML
+  git add -A && git commit -q -m "cargo workspace only"
+  .claude/skills/workflow/setup >/dev/null 2>&1
+
+  local config_file=".correctless/config/workflow-config.json"
+  local version_file
+  version_file="$(jq -r '.release.version_file' "$config_file" 2>/dev/null || echo "missing")"
+  assert_eq "R-004: Cargo.toml [workspace] version not detected as version file" "null" "$version_file"
+
+  # pyproject.toml with version only under [tool.poetry] (no [project]) → should NOT detect
+  setup_test_project
+  rm -f package.json
+  cat > pyproject.toml <<'TOML'
+[tool.poetry]
+name = "test-app"
+version = "2.0.0"
+TOML
+  git add -A && git commit -q -m "poetry only"
+  .claude/skills/workflow/setup >/dev/null 2>&1
+
+  version_file="$(jq -r '.release.version_file' "$config_file" 2>/dev/null || echo "missing")"
+  assert_eq "R-004: pyproject.toml [tool.poetry] version not detected" "null" "$version_file"
+}
+
+# ---------------------------------------------------------------------------
+# Test: R-004 — Version file priority ordering
+# ---------------------------------------------------------------------------
+
+test_r004_version_priority() {
+  echo ""
+  echo "=== R-004: Version file priority (package.json > Cargo.toml > pyproject.toml) ==="
+
+  # Project with both package.json and Cargo.toml → package.json wins
+  setup_test_project
+  cat > Cargo.toml <<'TOML'
+[package]
+name = "test-app"
+version = "0.5.1"
+edition = "2021"
+TOML
+  git add -A && git commit -q -m "dual project"
+  .claude/skills/workflow/setup >/dev/null 2>&1
+
+  local config_file=".correctless/config/workflow-config.json"
+  local version_file
+  version_file="$(jq -r '.release.version_file // empty' "$config_file" 2>/dev/null || echo "")"
+  assert_eq "R-004: package.json takes priority over Cargo.toml" "package.json" "$version_file"
+
+  # Project with both Cargo.toml and pyproject.toml → Cargo.toml wins
+  setup_test_project
+  rm -f package.json
+  cat > Cargo.toml <<'TOML'
+[package]
+name = "test-app"
+version = "0.5.1"
+TOML
+  cat > pyproject.toml <<'TOML'
+[project]
+name = "test-app"
+version = "2.0.0"
+TOML
+  git add -A && git commit -q -m "rust+python"
+  .claude/skills/workflow/setup >/dev/null 2>&1
+
+  version_file="$(jq -r '.release.version_file // empty' "$config_file" 2>/dev/null || echo "")"
+  assert_eq "R-004: Cargo.toml takes priority over pyproject.toml" "Cargo.toml" "$version_file"
+}
+
+# ---------------------------------------------------------------------------
 # Test: SKILL.md structural integrity (B-1: prevents keyword-stuffing)
 # ---------------------------------------------------------------------------
 
@@ -900,6 +983,8 @@ test_r019_skill_content
 test_r004_go_detection
 test_r004_setupcfg_detection
 test_r004_changelog_fallback
+test_r004_toml_wrong_section
+test_r004_version_priority
 test_skill_structure
 
 echo ""


### PR DESCRIPTION
## Summary

- Replace `\s` with `[[:space:]]` in all grep patterns in `detect_version_file()` — `\s` is not POSIX BRE/ERE and silently fails on many grep implementations, causing version detection to miss Cargo.toml, pyproject.toml, setup.cfg, and Go projects
- Fix Go version detection: use `grep -El` with ERE alternation `(const|var)` instead of `grep -l` with BRE `\|` alternation
- Fix minor grammar in crelease SKILL.md: "exits" → "exit" (imperative voice)

Found by: Copilot review on PR #12. The Rust `build_error_pattern` escaping was also flagged but is actually correct after tracing through the heredoc → JSON → jq -r → grep -E chain.

## Test plan

- [x] `bash test.sh` — 61 passed, 0 failed
- [x] `bash test-crelease.sh` — 99 passed, 0 failed  
- [x] Pre-commit hooks pass (shellcheck, typos, sync check)