### PR TITLE
Add script comment convention to CLAUDE.md

### DIFF
--- a/.claude/workflow-config.json
+++ b/.claude/workflow-config.json
@@ -5,8 +5,8 @@
     "description": "Claude Code plugin framework: structured workflow skills for spec-driven development with TDD, auditing, and project health"
   },
   "commands": {
-    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-decisions.sh && bash test-statusline.sh && bash test-consolidation.sh",
-    "test_new": "bash test-consolidation.sh",
+    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-decisions.sh && bash test-statusline.sh && bash test-consolidation.sh && bash test-crelease.sh",
+    "test_new": "",
     "test_verbose": "bash test.sh && bash test-mcp.sh",
     "coverage": "",
     "lint": "shellcheck hooks/*.sh test.sh sync.sh setup",
@@ -32,13 +32,13 @@
     "context7": true
   },
   "paths": {
-    "architecture_doc": "ARCHITECTURE.md",
-    "agent_context": "AGENT_CONTEXT.md",
-    "antipatterns": ".claude/antipatterns.md",
+    "architecture_doc": ".correctless/ARCHITECTURE.md",
+    "agent_context": ".correctless/AGENT_CONTEXT.md",
+    "antipatterns": ".correctless/antipatterns.md",
     "docs": "docs/",
-    "specs": "docs/specs/",
-    "artifacts": ".claude/artifacts/",
-    "state": ".claude/artifacts/workflow-state-{branch-slug}.json"
+    "specs": ".correctless/specs/",
+    "artifacts": ".correctless/artifacts/",
+    "state": ".correctless/artifacts/workflow-state-{branch-slug}.json"
   },
   "setup": {
     "architecture_state": "existing",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,38 @@ Use `gh` for GitHub operations (PRs, issues, checks).
 
 Imperative mood, capitalized, no conventional commits prefix. Explain *why* when non-obvious.
 Examples: "Add mermaid diagrams to README for visual comprehension", "Fix shellcheck directive placement — must be before first statement"
+
+## Script Comments
+
+When writing bash scripts, make section headers visually distinct from inline comments.
+
+**For saved scripts** — use banner comments so the human can scan the flow:
+```bash
+# ============================================
+# STEP 1: Backup current state before migration
+# ============================================
+cp -r src/auth src/auth.bak
+git stash
+
+# ============================================
+# STEP 2: Run schema migration
+# ============================================
+cd packages/api && npx prisma migrate deploy
+
+# skip if no pending migrations
+if [ $? -eq 0 ]; then
+  echo "Migration complete"
+fi
+```
+
+**For interactive scripts** — use echo prefixes so the terminal output is the summary:
+```bash
+echo ">>> Step 1: Backup current state before migration"
+cp -r src/auth src/auth.bak
+git stash
+
+echo ">>> Step 2: Run schema migration"
+cd packages/api && npx prisma migrate deploy
+```
+
+Banner comments for scripts reviewed as files. Echo prefixes for scripts watched in real time. Inline `#` comments stay normal — only section headers get the visual treatment.


### PR DESCRIPTION
## Summary

- Add banner comments and echo prefix conventions to CLAUDE.md for script readability
- Banner comments (`# ====`) for saved scripts reviewed as files
- Echo prefixes (`>>> Step N`) for interactive scripts watched in real time
- Also updates workflow-config.json: adds test-crelease.sh to test command, clears stale test_new, fixes paths to .correctless/

## Test plan

- [x] CLAUDE.md contains "Script Comments" section
- [x] CLAUDE.md documents both banner and echo prefix patterns
- [x] Pre-commit hooks pass