### PR TITLE
Move test scripts to tests/ directory

### DIFF
--- a/.claude/workflow-config.json
+++ b/.claude/workflow-config.json
@@ -5,15 +5,15 @@
     "description": "Claude Code plugin framework: structured workflow skills for spec-driven development with TDD, auditing, and project health"
   },
   "commands": {
-    "test": "bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-decisions.sh && bash test-statusline.sh && bash test-consolidation.sh && bash test-crelease.sh && bash test-calm-resets.sh",
-    "test_new": "bash test-calm-resets.sh",
-    "test_verbose": "bash test.sh && bash test-mcp.sh",
+    "test": "bash tests/test.sh && bash tests/test-mcp.sh && bash tests/test-bugfixes.sh && bash tests/test-qol.sh && bash tests/test-decisions.sh && bash tests/test-statusline.sh && bash tests/test-consolidation.sh && bash tests/test-crelease.sh && bash tests/test-calm-resets.sh",
+    "test_new": "bash tests/test-calm-resets.sh",
+    "test_verbose": "bash tests/test.sh && bash tests/test-mcp.sh",
     "coverage": "",
-    "lint": "shellcheck hooks/*.sh test.sh sync.sh setup",
+    "lint": "shellcheck hooks/*.sh tests/test*.sh sync.sh setup",
     "build": ""
   },
   "patterns": {
-    "test_file": "test*.sh",
+    "test_file": "tests/test*.sh",
     "source_file": "*.sh,*.md",
     "test_fail_pattern": "FAIL:",
     "build_error_pattern": ""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 
 ## Checklist
 
-- [ ] All test scripts pass (`bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-decisions.sh && bash test-statusline.sh`)
+- [ ] All test scripts pass (`bash tests/test.sh && bash tests/test-mcp.sh && bash tests/test-bugfixes.sh && bash tests/test-qol.sh && bash tests/test-decisions.sh && bash tests/test-statusline.sh`)
 - [ ] `bash sync.sh` produces no changes
 - [ ] `shellcheck hooks/*.sh` passes (if hooks modified)
 - [ ] Skill registered in all locations (if new skill — see CONTRIBUTING.md)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
 
       - name: Run tests
         run: |
-          bash test.sh
-          bash test-mcp.sh
-          bash test-bugfixes.sh
-          bash test-qol.sh
-          bash test-decisions.sh
-          bash test-statusline.sh
+          bash tests/test.sh
+          bash tests/test-mcp.sh
+          bash tests/test-bugfixes.sh
+          bash tests/test-qol.sh
+          bash tests/test-decisions.sh
+          bash tests/test-statusline.sh
 
       - name: Verify sync
         run: |

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -17,7 +17,7 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 | Lite dist | `correctless-lite/` | 19-skill distribution target — never edit directly |
 | Full dist | `correctless-full/` | 26-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `test.sh`, `test-mcp.sh`, `test-bugfixes.sh`, `test-qol.sh`, `test-decisions.sh`, `test-statusline.sh`, `test-consolidation.sh`, `test-crelease.sh`, `test-cexplain.sh`, `test-calm-resets.sh` | 923 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets |
+| Tests | `tests/test*.sh` | 10 test suites, 923 shell tests covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets |
 | Sync | `sync.sh` | Propagates source edits to both distribution targets |
 
 ## Design Patterns
@@ -31,15 +31,15 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 ## Common Pitfalls
 
 - **Editing distribution targets directly**: changes in `correctless-lite/` or `correctless-full/` will be overwritten by `sync.sh` — **Instead**: edit in root `skills/`, `hooks/`, `templates/`, `helpers/` then run `bash sync.sh`
-- **Forgetting to sync after edits**: distribution targets go stale — **Instead**: always run `bash sync.sh` after editing source files, then `bash test.sh` to verify
+- **Forgetting to sync after edits**: distribution targets go stale — **Instead**: always run `bash sync.sh` after editing source files, then `bash tests/test.sh` to verify
 - **Adding a skill without updating sync.sh**: new skills won't appear in distributions — **Instead**: add the skill directory to the appropriate list in `sync.sh` (Lite list and/or Full list)
 
 ## Quick Reference
 
 | Need to... | Do this |
 |------------|---------|
-| Run tests | `bash test.sh && bash test-mcp.sh && bash test-bugfixes.sh && bash test-qol.sh && bash test-statusline.sh && bash test-consolidation.sh && bash test-crelease.sh && bash test-cexplain.sh && bash test-calm-resets.sh` |
-| Lint shell scripts | `shellcheck hooks/*.sh test.sh sync.sh setup` |
+| Run tests | `bash tests/test.sh && bash tests/test-mcp.sh` (or run all: see workflow-config.json `commands.test`) |
+| Lint shell scripts | `shellcheck hooks/*.sh tests/test*.sh sync.sh setup` |
 | Sync to distributions | `bash sync.sh` |
 | Find a skill | `skills/{name}/SKILL.md` |
 | Find skill docs | `docs/skills/{name}.md` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@
 | Docs | `docs/` | Per-skill user-facing documentation and feature docs. |
 | Design Specs | `docs/design/correctless.md`, `docs/design/correctless-lite.md` | Original design specifications for Full and Lite modes. |
 | Setup | `setup` | Bash script: detects stack, scaffolds config/hooks/templates, registers Claude Code hooks. Idempotent. |
-| Tests | `test*.sh` | 10 shell test suites: setup, state machine, gate, full mode, MCP, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets. |
+| Tests | `tests/test*.sh` | 10 shell test suites: setup, state machine, gate, full mode, MCP, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets. |
 | Sync | `sync.sh` | Copies source files into both distribution targets (`correctless-lite/`, `correctless-full/`). |
 
 ## Design Patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,8 @@ Thanks for your interest in contributing! Correctless is a set of Claude Code sk
 ```bash
 git clone https://github.com/joshft/correctless.git
 cd correctless
-bash test.sh              # 57 infrastructure tests
-bash test-mcp.sh          # 192 MCP integration tests
-bash test-bugfixes.sh     # 15 bug fix tests
-bash test-qol.sh          # 25 QoL improvement tests
+bash tests/test.sh        # Infrastructure tests
+bash tests/test-mcp.sh    # MCP integration tests
 bash sync.sh              # Propagate source → both plugins
 bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 ```
@@ -18,19 +16,17 @@ bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 ## Project Structure
 
 ```
-skills/               # Source skills (24 SKILL.md files)
+skills/               # Source skills (26 SKILL.md files)
 hooks/                # Bash hooks (gate, state machine, statusline, audit trail)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT helpers (Full mode only)
+tests/                # 10 test suites (923 assertions)
 setup                 # Install script
-test.sh               # Infrastructure tests (57)
-test-mcp.sh           # MCP integration tests (192)
-test-bugfixes.sh      # Bug fix tests (15)
-test-qol.sh           # QoL improvement tests (25)
 sync.sh               # Copies source → correctless-lite/ and correctless-full/
-correctless-lite/     # Lite plugin (17 skills)
-correctless-full/     # Full plugin (24 skills)
+correctless-lite/     # Lite plugin (19 skills)
+correctless-full/     # Full plugin (26 skills)
 docs/skills/          # Per-skill documentation pages
+docs/design/          # Original design specifications
 ```
 
 **Important:** Never edit files in `correctless-lite/` or `correctless-full/` directly. Edit in `skills/`, `hooks/`, or `templates/`, then run `bash sync.sh` to propagate.
@@ -42,7 +38,7 @@ docs/skills/          # Per-skill documentation pages
 1. Fork the repo and create a branch: `git checkout -b fix/description`
 2. Read the relevant hook or skill file
 3. Make the fix
-4. Run `bash test.sh` — all tests must pass
+4. Run `bash tests/test.sh` — all tests must pass
 5. Run `bash sync.sh` — plugins must be in sync
 6. Open a PR with: what was broken, why, and how you fixed it
 
@@ -64,7 +60,7 @@ docs/skills/          # Per-skill documentation pages
    - `README.md` — add to skill table, update counts
    - `.claude-plugin/marketplace.json` — update counts
    - `docs/design/correctless-lite.md` and `docs/design/correctless.md` — update evolution notes
-4. Run `bash sync.sh && bash test.sh`
+4. Run `bash sync.sh && bash tests/test.sh`
 5. Open a PR
 
 ### Modifying a Hook
@@ -83,17 +79,15 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 
 - **Skills:** Markdown with YAML frontmatter. Keep descriptions as trigger conditions ("Use when X"), not capability summaries.
 - **Hooks:** Bash with `set -euo pipefail`. Portable to macOS bash 3.2 + BSD tools.
-- **Tests:** Bash assertions in `test.sh`. Each test is a function that prints PASS/FAIL.
+- **Tests:** Bash assertions in `tests/test*.sh`. Each test is a function that prints PASS/FAIL.
 - **No emojis in skill files** unless the user explicitly requests them.
 - **No model overrides** in skill frontmatter (`model:` field). Removed early to avoid rate limits.
 
 ## Testing
 
 ```bash
-bash test.sh              # 57 infrastructure tests
-bash test-mcp.sh          # 192 MCP integration tests
-bash test-bugfixes.sh     # 15 bug fix tests
-bash test-qol.sh          # 25 QoL improvement tests
+bash tests/test.sh        # Infrastructure tests
+bash tests/test-mcp.sh    # MCP integration tests
 bash sync.sh --check      # Distributions must be in sync
 shellcheck hooks/*.sh     # Must pass with -S warning
 ```

--- a/tests/test-bugfixes.sh
+++ b/tests/test-bugfixes.sh
@@ -5,7 +5,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR="/tmp/correctless-bugfix-test-$$"
 PASS=0
 FAIL=0
@@ -26,7 +26,7 @@ setup_test_project() {
 
   # Install correctless (exclude .git to avoid nested repo confusion)
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup() {

--- a/tests/test-calm-resets.sh
+++ b/tests/test-calm-resets.sh
@@ -6,7 +6,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0
 FAIL=0
 

--- a/tests/test-cexplain.sh
+++ b/tests/test-cexplain.sh
@@ -6,7 +6,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR="/tmp/correctless-cexplain-test-$$"
 PASS=0
 FAIL=0
@@ -27,7 +27,7 @@ setup_test_project() {
 
   # Install correctless (exclude .git to avoid nested repo confusion)
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup() {

--- a/tests/test-consolidation.sh
+++ b/tests/test-consolidation.sh
@@ -6,7 +6,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR="/tmp/correctless-consolidation-test-$$"
 PASS=0
 FAIL=0
@@ -27,7 +27,7 @@ setup_test_project() {
 
   # Install correctless (exclude .git to avoid nested repo confusion)
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup() {
@@ -1033,7 +1033,7 @@ test_r016() {
 
   # Tests R-016 [integration]: existing tests updated to use new paths
   # Check that test.sh references .correctless/ paths instead of .claude/artifacts/ etc.
-  local test_file="$REPO_DIR/test.sh"
+  local test_file="$REPO_DIR/tests/test.sh"
 
   # The main test file should NOT reference .claude/artifacts/ for assertions
   # (It may reference .claude/settings.json which is fine — that stays)

--- a/tests/test-crelease.sh
+++ b/tests/test-crelease.sh
@@ -6,7 +6,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR="/tmp/correctless-crelease-test-$$"
 PASS=0
 FAIL=0
@@ -27,7 +27,7 @@ setup_test_project() {
 
   # Install correctless (exclude .git to avoid nested repo confusion)
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup() {

--- a/tests/test-decisions.sh
+++ b/tests/test-decisions.sh
@@ -5,7 +5,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0
 FAIL=0
 

--- a/tests/test-mcp.sh
+++ b/tests/test-mcp.sh
@@ -5,7 +5,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0
 FAIL=0
 

--- a/tests/test-qol.sh
+++ b/tests/test-qol.sh
@@ -5,7 +5,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PASS=0
 FAIL=0
 

--- a/tests/test-statusline.sh
+++ b/tests/test-statusline.sh
@@ -6,7 +6,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATUSLINE="$REPO_DIR/hooks/statusline.sh"
 TEST_DIR="/tmp/correctless-statusline-test-$$"
 PASS=0
@@ -795,7 +795,7 @@ setup_install_project() {
   git -c user.email="t@t.com" -c user.name="T" commit -q --allow-empty -m "init"
   git checkout -q -b main 2>/dev/null || true
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup_setup() {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,7 +5,7 @@
 
 set -uo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEST_DIR="/tmp/correctless-test-$$"
 PASS=0
 FAIL=0
@@ -26,7 +26,7 @@ setup_test_project() {
 
   # Install correctless (exclude .git to avoid nested repo confusion)
   mkdir -p .claude/skills/workflow
-  rsync -a --exclude='.git' "$REPO_DIR/" .claude/skills/workflow/
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
 }
 
 cleanup() {


### PR DESCRIPTION
## Summary

- Move all 10 test suites from project root to `tests/`
- Update all references: CI workflow, workflow-config, PR template, AGENT_CONTEXT, ARCHITECTURE, CONTRIBUTING
- Fix `REPO_DIR` in each test to resolve parent directory (`/..`)
- Exclude `tests/` from rsync in test helpers to prevent setup detecting plugin's test files

## Test plan

- [x] All 10 test suites pass from `tests/` (923 total assertions, 0 failures)
- [x] All pre-commit hooks pass (shellcheck, typos, sync check)