### PR TITLE
Fix 4 stale path references in skill docs

### DIFF
--- a/docs/skills/chelp.md
+++ b/docs/skills/chelp.md
@@ -53,7 +53,7 @@ No active workflow. Start one: git checkout -b feature/my-feature then /cspec
 | Reads | Writes |
 |-------|--------|
 | `.correctless/config/workflow-config.json` | Nothing (read-only) |
-| `.claude/hooks/workflow-advance.sh` (status output) | |
+| `.correctless/hooks/workflow-advance.sh` (status output) | |
 
 ## Lite vs Full
 

--- a/docs/skills/cpostmortem.md
+++ b/docs/skills/cpostmortem.md
@@ -46,7 +46,7 @@ The PMB entry is written, phase effectiveness counters are updated (review-spec 
 |-------|--------|
 | `.correctless/meta/workflow-effectiveness.json` | `.correctless/meta/workflow-effectiveness.json` (PMB entry) |
 | `.correctless/antipatterns.md` | `.correctless/antipatterns.md` (new AP-xxx entry) |
-| Spec artifact (`.correctless/specs/{slug}.md`) | `.claude/templates/invariants/` (template updates) |
+| Spec artifact (`.correctless/specs/{slug}.md`) | `.correctless/templates/invariants/` (template updates) |
 | Verification report (`docs/verification/`) | `CLAUDE.md` (Correctless Learnings section) |
 | Debug investigations (`.correctless/artifacts/debug-investigation-*.md`) | Token log (`.correctless/artifacts/token-log-{slug}.json`) |
 

--- a/docs/skills/csetup.md
+++ b/docs/skills/csetup.md
@@ -127,7 +127,7 @@ Agent: Project Health Check — recipe-api (TypeScript/Express)
 | | `.gitignore` (additions, if accepted) |
 | | Linter/formatter config (if accepted) |
 | | PR template (if accepted) |
-| | `.claude/settings.json` (hook registration) |
+| | `.claude/settings.json` (Claude Code hook registration) |
 
 ## Lite vs Full
 

--- a/docs/skills/cstatus.md
+++ b/docs/skills/cstatus.md
@@ -50,7 +50,7 @@ No problems detected.
 | Reads | Writes |
 |-------|--------|
 | `.correctless/config/workflow-config.json` | Nothing (read-only) |
-| `.claude/hooks/workflow-advance.sh` (status output) | |
+| `.correctless/hooks/workflow-advance.sh` (status output) | |
 | `ARCHITECTURE.md` | |
 | `AGENT_CONTEXT.md` | |
 | Workflow state file | |


### PR DESCRIPTION
## Summary

- Remaining `.claude/` → `.correctless/` path fixes in skill docs that weren't caught by the consolidation migration
- These were originally part of the QA Olympics findings (f418244) which couldn't be cherry-picked cleanly after the Performance Olympics restructured the hooks

## Changes

- `docs/skills/cstatus.md`: `.claude/hooks/workflow-advance.sh` → `.correctless/hooks/`
- `docs/skills/chelp.md`: same
- `docs/skills/cpostmortem.md`: `.claude/templates/invariants/` → `.correctless/templates/`
- `docs/skills/csetup.md`: clarify `.claude/settings.json` is Claude Code config (not a stale ref)

## Test plan

- [x] No stale `.claude/` project refs remain in docs/skills/ (verified with grep)
- [x] `~/.claude/` refs (Claude Code user data) correctly left as-is
- [x] `.claude/settings.json` refs correctly left as-is (Claude Code config)