### PR TITLE
fix: correct marketplace source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "correctless",
-      "source": "../correctless",
+      "source": "./correctless",
       "description": "Correctness workflow for structured development. 26 skills with configurable intensity levels: spec-before-code, skeptical review, enforced TDD, formal modeling, adversarial review, verification, documentation, and metrics. Intensity gates let you choose standard, high, or critical rigor per project.",
       "version": "3.0.0"
     }


### PR DESCRIPTION
## Summary
- Fix `source` path in `.claude-plugin/marketplace.json` from `"../correctless"` to `"./correctless"`
- The `../` prefix escapes the marketplace root directory, causing schema validation failure when installing via `plugin marketplace add joshft/correctless`

## Test plan
- [ ] Run `/plugin marketplace add joshft/correctless` after merge — should install without schema error

🤖 Generated with [Claude Code](https://claude.com/claude-code)