### PR TITLE
Fix 4 architectural findings from Devil's Advocate analysis

### DIFF
--- a/.claude/hooks/sensitive-file-guard.sh
+++ b/.claude/hooks/sensitive-file-guard.sh
@@ -29,12 +29,18 @@ command -v jq >/dev/null 2>&1 || { echo "BLOCKED [sensitive-file]: jq not found"
 
 INPUT="$(cat)"
 TOOL_NAME="" TOOL_INPUT_FILE="" TOOL_INPUT_COMMAND="" TOOL_INPUT_EDITS=""
-eval "$(echo "$INPUT" | jq -r '
+_PARSED="$(echo "$INPUT" | jq -r '
   @sh "TOOL_NAME=\(.tool_name // "")",
   @sh "TOOL_INPUT_FILE=\(.tool_input.file_path // "")",
   @sh "TOOL_INPUT_COMMAND=\(.tool_input.command // "")",
   @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path // empty] | join("\n"))"
-' 2>/dev/null)" || exit 0
+' 2>/dev/null)" || true
+# Fail-closed: if jq produced no output (parse failure), block the operation (DA-003)
+if [ -z "$_PARSED" ]; then
+  echo "BLOCKED [fail-closed]: failed to parse tool input JSON" >&2
+  exit 2
+fi
+eval "$_PARSED"
 
 # ============================================
 # STEP 3: Fast-path bail — only write tools (INV-010)

--- a/.correctless/ARCHITECTURE.md
+++ b/.correctless/ARCHITECTURE.md
@@ -8,7 +8,14 @@
 - **Data sensitivity change**: Trusted config values → shell arguments
 - **Invariant**: Config-sourced values must never be passed through eval, $(), or backtick execution. Commands validated via exact-match allowlist (auto-format.sh). Patterns matched via bash `case` glob only (sensitive-file-guard.sh).
 - **Violated when**: A config value is interpolated into a shell command string or passed to eval
-- **Test**: PRH-001 in sensitive-file-guard tests (canary file injection), INV-011 in auto-format tests (allowlist validation)
+- **Test**: PRH-001 in sensitive-file-guard tests (canary file injection), INV-011 in auto-format tests (allowlist validation), DA-001 eval-detection test
+
+#### TB-001a: Test runner exception (DA-001)
+- **Scoped exception**: `workflow-advance.sh` eval's `commands.test`, `commands.test_new`, and `commands.coverage` from workflow-config.json. This is required because test commands contain shell operators (`&&`, `|`) that need eval to execute.
+- **Trust model**: These values originate from the project owner via `/csetup` or manual edit. The config file is local and under the owner's control.
+- **Constraint**: If the trust model is ever extended (shared team configs, marketplace templates, CI-supplied configs), this exception MUST be revisited — eval of externally-supplied commands is arbitrary code execution.
+- **Spec review rule**: Every future spec that adds a config-consumed command must be flagged: "TB-001a: commands from config are eval'd. Sanitize or allowlist."
+- **Test**: DA-001 eval-detection test verifies no new eval sites appear in hooks/ or scripts/ beyond the documented exceptions.
 
 ### TB-002: Script-generated JSON → LLM agent context
 - **Crosses**: Deterministic scan output → agent reasoning context

--- a/correctless/hooks/audit-trail.sh
+++ b/correctless/hooks/audit-trail.sh
@@ -38,15 +38,28 @@ esac
 # Fast-path bail: no files identified = nothing to audit
 [ -n "$FILES" ] || exit 0
 
-# Compute branch slug and find state file (bash builtins instead of sed+cut)
-branch="$(git --no-optional-locks branch --show-current 2>/dev/null)" || exit 0
-[ -n "$branch" ] || exit 0
+# Source shared library for branch_slug() (ABS-001: single definition)
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd || true)"
+if [ -n "$_LIB_DIR" ] && [ -f "$_LIB_DIR/lib.sh" ]; then
+  # shellcheck source=../scripts/lib.sh
+  source "$_LIB_DIR/lib.sh"
+elif [ -f "scripts/lib.sh" ]; then
+  source "scripts/lib.sh"
+fi
+unset _LIB_DIR
 
-slug="${branch//[^a-zA-Z0-9]/-}"
-slug="${slug:0:80}"
-raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"
-hash="${raw_hash:0:6}"
-STATE_FILE=".correctless/artifacts/workflow-state-${slug}-${hash}.json"
+# Compute state file path using shared branch_slug (or inline fallback)
+if command -v branch_slug >/dev/null 2>&1; then
+  _slug="$(branch_slug 2>/dev/null)" || exit 0
+  [ -n "$_slug" ] || exit 0
+else
+  # Inline fallback if lib.sh not available (audit-trail must not fail-closed)
+  branch="$(git --no-optional-locks branch --show-current 2>/dev/null)" || exit 0
+  [ -n "$branch" ] || exit 0
+  slug="${branch//[^a-zA-Z0-9]/-}"; slug="${slug:0:80}"
+  raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"; _slug="${slug}-${raw_hash:0:6}"
+fi
+STATE_FILE=".correctless/artifacts/workflow-state-${_slug}.json"
 
 # Fast-path bail: no state file = no active workflow = nothing to audit
 [ -f "$STATE_FILE" ] || exit 0
@@ -57,7 +70,7 @@ CONFIG_FILE=".correctless/config/workflow-config.json"
 
 # --- Audit trail logging (batch all files in single jq call) ---
 
-TRAIL=".correctless/artifacts/audit-trail-${slug}-${hash}.jsonl"
+TRAIL=".correctless/artifacts/audit-trail-${_slug}.jsonl"
 TS="$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Truncate oldest half if audit trail exceeds 5MB
@@ -158,7 +171,7 @@ done <<< "$FILES"
 # IS_FULL was set from the bulk config read above
 
 if [ "$IS_FULL" = "true" ]; then
-  ADHERENCE=".correctless/artifacts/adherence-state-${slug}-${hash}.json"
+  ADHERENCE=".correctless/artifacts/adherence-state-${_slug}.json"
 
   # Initialize adherence state if missing or empty (REG-R2-002: -s catches 0-byte files)
   if [ ! -s "$ADHERENCE" ]; then

--- a/correctless/hooks/statusline.sh
+++ b/correctless/hooks/statusline.sh
@@ -169,10 +169,24 @@ fi
 sec4=""
 NOW_EPOCH=$(date +%s)
 if [ -n "$branch" ] && [ -d ".correctless/artifacts" ]; then
-  slug="${branch//[^a-zA-Z0-9]/-}"
-  slug="${slug:0:80}"
-  raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"
-  STATE_FILE=".correctless/artifacts/workflow-state-${slug}-${raw_hash:0:6}.json"
+  # Source shared library for branch_slug() (ABS-001)
+  if [ -z "${_LIBS_LOADED:-}" ]; then
+    _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd || true)"
+    if [ -n "$_LIB_DIR" ] && [ -f "$_LIB_DIR/lib.sh" ]; then
+      source "$_LIB_DIR/lib.sh"; _LIBS_LOADED=1
+    elif [ -f "scripts/lib.sh" ]; then
+      source "scripts/lib.sh"; _LIBS_LOADED=1
+    fi
+  fi
+
+  if command -v branch_slug >/dev/null 2>&1; then
+    _slug="$(branch_slug 2>/dev/null)" || _slug=""
+  else
+    # Inline fallback (statusline must never fail)
+    _s="${branch//[^a-zA-Z0-9]/-}"; _s="${_s:0:80}"
+    _h="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"; _slug="${_s}-${_h:0:6}"
+  fi
+  STATE_FILE=".correctless/artifacts/workflow-state-${_slug}.json"
 
   if [ -f "$STATE_FILE" ]; then
     eval "$(jq -r '

--- a/hooks/audit-trail.sh
+++ b/hooks/audit-trail.sh
@@ -38,15 +38,28 @@ esac
 # Fast-path bail: no files identified = nothing to audit
 [ -n "$FILES" ] || exit 0
 
-# Compute branch slug and find state file (bash builtins instead of sed+cut)
-branch="$(git --no-optional-locks branch --show-current 2>/dev/null)" || exit 0
-[ -n "$branch" ] || exit 0
+# Source shared library for branch_slug() (ABS-001: single definition)
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd || true)"
+if [ -n "$_LIB_DIR" ] && [ -f "$_LIB_DIR/lib.sh" ]; then
+  # shellcheck source=../scripts/lib.sh
+  source "$_LIB_DIR/lib.sh"
+elif [ -f "scripts/lib.sh" ]; then
+  source "scripts/lib.sh"
+fi
+unset _LIB_DIR
 
-slug="${branch//[^a-zA-Z0-9]/-}"
-slug="${slug:0:80}"
-raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"
-hash="${raw_hash:0:6}"
-STATE_FILE=".correctless/artifacts/workflow-state-${slug}-${hash}.json"
+# Compute state file path using shared branch_slug (or inline fallback)
+if command -v branch_slug >/dev/null 2>&1; then
+  _slug="$(branch_slug 2>/dev/null)" || exit 0
+  [ -n "$_slug" ] || exit 0
+else
+  # Inline fallback if lib.sh not available (audit-trail must not fail-closed)
+  branch="$(git --no-optional-locks branch --show-current 2>/dev/null)" || exit 0
+  [ -n "$branch" ] || exit 0
+  slug="${branch//[^a-zA-Z0-9]/-}"; slug="${slug:0:80}"
+  raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"; _slug="${slug}-${raw_hash:0:6}"
+fi
+STATE_FILE=".correctless/artifacts/workflow-state-${_slug}.json"
 
 # Fast-path bail: no state file = no active workflow = nothing to audit
 [ -f "$STATE_FILE" ] || exit 0
@@ -57,7 +70,7 @@ CONFIG_FILE=".correctless/config/workflow-config.json"
 
 # --- Audit trail logging (batch all files in single jq call) ---
 
-TRAIL=".correctless/artifacts/audit-trail-${slug}-${hash}.jsonl"
+TRAIL=".correctless/artifacts/audit-trail-${_slug}.jsonl"
 TS="$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Truncate oldest half if audit trail exceeds 5MB
@@ -158,7 +171,7 @@ done <<< "$FILES"
 # IS_FULL was set from the bulk config read above
 
 if [ "$IS_FULL" = "true" ]; then
-  ADHERENCE=".correctless/artifacts/adherence-state-${slug}-${hash}.json"
+  ADHERENCE=".correctless/artifacts/adherence-state-${_slug}.json"
 
   # Initialize adherence state if missing or empty (REG-R2-002: -s catches 0-byte files)
   if [ ! -s "$ADHERENCE" ]; then

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -29,12 +29,18 @@ command -v jq >/dev/null 2>&1 || { echo "BLOCKED [sensitive-file]: jq not found"
 
 INPUT="$(cat)"
 TOOL_NAME="" TOOL_INPUT_FILE="" TOOL_INPUT_COMMAND="" TOOL_INPUT_EDITS=""
-eval "$(echo "$INPUT" | jq -r '
+_PARSED="$(echo "$INPUT" | jq -r '
   @sh "TOOL_NAME=\(.tool_name // "")",
   @sh "TOOL_INPUT_FILE=\(.tool_input.file_path // "")",
   @sh "TOOL_INPUT_COMMAND=\(.tool_input.command // "")",
   @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path // empty] | join("\n"))"
-' 2>/dev/null)" || exit 0
+' 2>/dev/null)" || true
+# Fail-closed: if jq produced no output (parse failure), block the operation (DA-003)
+if [ -z "$_PARSED" ]; then
+  echo "BLOCKED [fail-closed]: failed to parse tool input JSON" >&2
+  exit 2
+fi
+eval "$_PARSED"
 
 # ============================================
 # STEP 3: Fast-path bail — only write tools (INV-010)

--- a/hooks/statusline.sh
+++ b/hooks/statusline.sh
@@ -169,10 +169,24 @@ fi
 sec4=""
 NOW_EPOCH=$(date +%s)
 if [ -n "$branch" ] && [ -d ".correctless/artifacts" ]; then
-  slug="${branch//[^a-zA-Z0-9]/-}"
-  slug="${slug:0:80}"
-  raw_hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"
-  STATE_FILE=".correctless/artifacts/workflow-state-${slug}-${raw_hash:0:6}.json"
+  # Source shared library for branch_slug() (ABS-001)
+  if [ -z "${_LIBS_LOADED:-}" ]; then
+    _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd || true)"
+    if [ -n "$_LIB_DIR" ] && [ -f "$_LIB_DIR/lib.sh" ]; then
+      source "$_LIB_DIR/lib.sh"; _LIBS_LOADED=1
+    elif [ -f "scripts/lib.sh" ]; then
+      source "scripts/lib.sh"; _LIBS_LOADED=1
+    fi
+  fi
+
+  if command -v branch_slug >/dev/null 2>&1; then
+    _slug="$(branch_slug 2>/dev/null)" || _slug=""
+  else
+    # Inline fallback (statusline must never fail)
+    _s="${branch//[^a-zA-Z0-9]/-}"; _s="${_s:0:80}"
+    _h="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5))"; _slug="${_s}-${_h:0:6}"
+  fi
+  STATE_FILE=".correctless/artifacts/workflow-state-${_slug}.json"
 
   if [ -f "$STATE_FILE" ]; then
     eval "$(jq -r '

--- a/tests/test-sensitive-file-guard.sh
+++ b/tests/test-sensitive-file-guard.sh
@@ -1010,6 +1010,56 @@ test_qa004_all_default_patterns
 test_bnd005_symlink_accepted_limitation
 test_qa006_quoted_filenames_in_bash
 
+# ===========================================================================
+# DA-003: Fail-closed on jq parse failure
+# ===========================================================================
+
+test_da003_fail_closed_on_jq_failure() {
+  echo ""
+  echo "=== DA-003: Fail-closed on jq parse failure ==="
+
+  # Feed invalid JSON to the security hook — must exit 2 (block), not 0 (allow)
+  local exit_code
+  echo "NOT VALID JSON {{{" | bash "$HOOK" 2>/dev/null
+  exit_code=$?
+  assert_eq "DA-003: jq parse failure exits 2 (fail-closed)" "2" "$exit_code"
+}
+
+# ===========================================================================
+# DA-004: Hook allowlist sync — deterministic check
+# ===========================================================================
+
+test_da004_hook_allowlist_sync() {
+  echo ""
+  echo "=== DA-004: Hook command allowlist sync ==="
+
+  local gate="$REPO_DIR/hooks/workflow-gate.sh"
+  local guard="$REPO_DIR/hooks/sensitive-file-guard.sh"
+
+  # Extract the shared write-command list from each hook
+  # workflow-gate.sh: the case pattern in _has_write_pattern
+  local gate_cmds guard_cmds
+  gate_cmds="$(grep -A1 '_has_write_pattern' "$gate" | grep -oE 'cp\|mv\|[a-z|]+\) return' | head -1 | sed 's/) return//')"
+  guard_cmds="$(grep -A1 '_has_write_pattern' "$guard" | grep -oE 'cp\|mv\|[a-z|]+\) return' | head -1 | sed 's/) return//')"
+
+  # The guard has extra scripted-write commands (python|python3|node|ruby)
+  # that the gate doesn't need. Strip those for comparison.
+  local guard_shared
+  guard_shared="$(echo "$guard_cmds" | sed 's/|python3\?//g; s/|node//g; s/|ruby//g')"
+
+  assert_eq "DA-004: shared write commands match between gate and guard" "$gate_cmds" "$guard_shared"
+
+  # Extension regex sync between workflow-gate.sh and audit-trail.sh
+  local gate_ext trail_ext
+  gate_ext="$(grep -oE '\.\(go\|ts\|[a-z|]+\)' "$gate" | head -1)"
+  trail_ext="$(grep -oE '\.\(go\|ts\|[a-z|]+\)' "$REPO_DIR/hooks/audit-trail.sh" | head -1)"
+
+  assert_eq "DA-004: extension regex matches between gate and audit-trail" "$gate_ext" "$trail_ext"
+}
+
+test_da003_fail_closed_on_jq_failure
+test_da004_hook_allowlist_sync
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -464,6 +464,43 @@ test_utilities
 test_full_mode
 test_additional_coverage
 
+# ===========================================================================
+# DA-001: Eval detection — no unexpected eval of config values
+# ===========================================================================
+
+echo ""
+echo "=== DA-001: eval-detection ==="
+
+# workflow-advance.sh is the ONLY hook/script allowed to eval config commands (TB-001a).
+# All other hooks and scripts must not eval config-sourced values.
+# This test detects new eval sites outside the documented exception.
+_da001_fail=0
+for f in "$REPO_DIR"/hooks/workflow-gate.sh \
+         "$REPO_DIR"/hooks/sensitive-file-guard.sh \
+         "$REPO_DIR"/hooks/audit-trail.sh \
+         "$REPO_DIR"/hooks/statusline.sh \
+         "$REPO_DIR"/scripts/antipattern-scan.sh; do
+  if [ -f "$f" ] && grep -qE 'eval "\$\(.*read_config|eval "\$.*_cmd|eval "\$test_cmd|eval "\$cov_cmd' "$f" 2>/dev/null; then
+    bname="$(basename "$f")"
+    echo "  FAIL: DA-001: $bname contains eval of config-sourced values (TB-001a violation)"
+    _da001_fail=1
+    FAIL=$((FAIL + 1))
+  fi
+done
+if [ "$_da001_fail" -eq 0 ]; then
+  echo "  PASS: DA-001: no unexpected eval of config values in hooks/scripts"
+  PASS=$((PASS + 1))
+fi
+
+# workflow-advance.sh IS allowed (TB-001a exception) — verify it exists there
+if grep -qE 'eval "\$' "$REPO_DIR/hooks/workflow-advance.sh" 2>/dev/null; then
+  echo "  PASS: DA-001: workflow-advance.sh eval sites present (TB-001a exception, documented)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: DA-001: workflow-advance.sh has no eval sites — test may need updating"
+  FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "======================"
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- **DA-003**: sensitive-file-guard.sh now **fail-closed** on jq parse failure — previously silently allowed blocked operations when JSON parsing failed
- **DA-002**: audit-trail.sh and statusline.sh now source `scripts/lib.sh` for `branch_slug()` — eliminates 4x implementation duplication (ABS-001 compliance)
- **DA-001**: Documented TB-001a scoped exception for `eval` of config test commands in ARCHITECTURE.md + eval-detection test
- **DA-004**: Deterministic hook allowlist sync test — replaces prompt-based CLAUDE.md learning with a bash test that verifies command lists match across hooks

### Why this matters
The Devil's Advocate (`/cdevadv layers`) found 4 architectural issues that QA, audit, and the test suite all missed — because those tools validate code against spec, not assumptions against reality. DA-003 (fail-open security hook) was the most urgent: a jq parse error silently bypassed the sensitive file guard.

## Test plan
- [ ] `bash tests/test-sensitive-file-guard.sh` — 101 assertions (DA-003 fail-closed + DA-004 allowlist sync)
- [ ] `bash tests/test.sh` — 63 assertions (DA-001 eval-detection)
- [ ] `bash tests/test-antipattern-scan.sh` — 224 assertions (no regressions)
- [ ] `echo "INVALID JSON" | bash hooks/sensitive-file-guard.sh` — exits 2 (not 0)