### PR TITLE
Extract universal skill constraints into shared file

### DIFF
--- a/correctless/skills/_shared/constraints.md
+++ b/correctless/skills/_shared/constraints.md
@@ -1,0 +1,51 @@
+# Shared Skill Constraints
+
+These constraints apply to every skill that references this file. They are universal — not skill-specific.
+
+## Skill Boundary
+
+- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.
+
+## Evidence Standard
+
+- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
+- **All files written inside the project directory.** Never /tmp.
+
+## Context Management
+
+- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to produce accurate results. Specific thresholds and recovery instructions may be defined per-skill.
+
+## Effective Intensity Computation
+
+Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
+
+1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
+2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
+3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
+
+**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The skill still runs — it does not require active workflow state.
+
+## Token Tracking
+
+After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the workflow state or spec file):
+
+```json
+{
+  "skill": "{skill-name}",
+  "phase": "{phase}",
+  "agent_role": "{agent-role}",
+  "total_tokens": N,
+  "duration_ms": N,
+  "timestamp": "ISO"
+}
+```
+
+If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+
+## MCP Degradation (Serena)
+
+**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
+
+## MCP Degradation (Context7)
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.

--- a/correctless/skills/caudit/SKILL.md
+++ b/correctless/skills/caudit/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /caudit — Olympics Audit System
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /caudit requires high minimum intensity to activate.
 
@@ -464,20 +462,10 @@ See "Progress Visibility" section above — task creation and round-by-round nar
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the preset and date):
-
-```json
-{
-  "skill": "caudit",
-  "phase": "{round-N-{agent-role}|round-N-triage}",
-  "agent_role": "{specialist-role|triage}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "caudit"
+- `phase`: "{round-N-{agent-role}|round-N-triage}"
+- `agent_role`: "{specialist-role|triage}"
 
 After each round's agents complete and triage finishes, print: "Round {N} complete. {M} findings. Running token cost: ~{total}k tokens. Continue to round {N+1}?" This gives the user cost visibility to decide whether to continue.
 
@@ -508,8 +496,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Agent crashes mid-round**: Re-run `/caudit`. Prior round findings are persisted in `.correctless/artifacts/findings/` and provide context, but the skill restarts from Round 1. It will re-read prior findings and avoid re-reporting already-fixed issues, but there is no automatic round-level resume.
@@ -524,6 +510,5 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Every finding needs instance fix AND class fix.**
 - **Post-convergence regression tests are mandatory.**
 - **All files inside the project directory.** Never /tmp.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining rounds correctly.
 - **Cost visibility every round.** Human can stop the loop.
 - **Redact if sharing.** If this output will be shared externally, apply redaction rules from `templates/redaction-rules.md` first.

--- a/correctless/skills/ccontribute/SKILL.md
+++ b/correctless/skills/ccontribute/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(*), Edit, Write(*), WebSearch, WebFetch
 
 # /ccontribute — Open Source Contribution
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the contribution agent. Your job is to help the user contribute to a project they don't own — an open source repo, a friend's project, a work monorepo owned by another team. The key principle: **match, don't improve.** You are a guest. Write code that looks like a regular contributor wrote it, not an outsider who thinks they know better.
 
 Invoke with: `/ccontribute {issue number or description of what to change}`
@@ -177,7 +179,12 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After any subagent completes (research for unfamiliar patterns), capture `total_tokens` and `duration_ms`. Since this skill runs against external projects that may not have `.correctless/artifacts/`, skip token logging if the directory doesn't exist. Token data is still visible in the conversation for manual tracking via `/cmetrics`.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "ccontribute"
+- `phase`: "contribution"
+- `agent_role`: "contribution-agent"
+
+Since this skill runs against external projects that may not have `.correctless/artifacts/`, skip token logging if the directory doesn't exist.
 
 ## Code Analysis (MCP Integration)
 
@@ -198,8 +205,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/correctless/skills/cdebug/SKILL.md
+++ b/correctless/skills/cdebug/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cdebug — Structured Bug Investigation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the debugging agent. Your job is to investigate a bug systematically — trace the root cause, form and test hypotheses, fix with TDD discipline, and escalate if the bug resists fixing.
 
 **Do not guess-and-patch.** Understand the bug before touching code. A fix without root cause understanding is a new bug waiting to happen.
@@ -177,20 +179,10 @@ Run the test suite in the background while investigating the code path. Run git 
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the debug investigation slug):
-
-```json
-{
-  "skill": "cdebug",
-  "phase": "{fix|escalation}",
-  "agent_role": "{fix-agent|escalation-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cdebug"
+- `phase`: "{fix|escalation}"
+- `agent_role`: "{fix-agent|escalation-agent}"
 
 ### /btw
 When presenting the root cause analysis: "Use /btw if you need to check something about the codebase without interrupting this investigation."
@@ -217,16 +209,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when researching library behavior during root cause analysis:
 
 - Use `resolve-library-id` to find the canonical ID for a library before fetching docs
 - Use `get-library-docs` to retrieve current documentation, API references, and known issues
-
-When Context7 is unavailable, fall back to web search for library documentation. If Context7 was unavailable during this run, notify the user once at the end: "Note: Context7 was unavailable — fell back to web search for library docs."
 
 ## If Something Goes Wrong
 

--- a/correctless/skills/cdevadv/SKILL.md
+++ b/correctless/skills/cdevadv/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cdevadv — Devil's Advocate (10th Man Rule)
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cdevadv activates at standard minimum intensity (available to all).
 
@@ -252,20 +250,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the explorer subagent completes (signals mode only), capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the report date):
-
-```json
-{
-  "skill": "cdevadv",
-  "phase": "explorer",
-  "agent_role": "explorer-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Token logging applies to signals mode only (Layers mode does not spawn subagents). Skill-specific values:
+- `skill`: "cdevadv"
+- `phase`: "explorer"
+- `agent_role`: "explorer-agent"
 
 ### /context
 Check context usage before starting. Layers mode is context-efficient (cheap passes first). Signals mode loads more data. If context is above 50% before starting, suggest compacting first.

--- a/correctless/skills/cdocs/SKILL.md
+++ b/correctless/skills/cdocs/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Bash(git*), Bash(*workflow-advance.sh*), 
 
 # /cdocs — Update Project Documentation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the documentation agent. Your job is to keep project documentation current after features land. You update README, .correctless/AGENT_CONTEXT.md, feature docs, and suggest .correctless/ARCHITECTURE.md additions.
 
 ## Intensity Configuration
@@ -17,13 +19,7 @@ You are the documentation agent. Your job is to keep project documentation curre
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -232,8 +228,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.
@@ -247,4 +241,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Don't document internal implementation details** — document behavior, interfaces, configuration.
 - **Present changes for human approval** before writing. Documentation is the project's external face.
 - **Keep .correctless/AGENT_CONTEXT.md under 1500 words.** It's a briefing, not a novel.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/cexplain/SKILL.md
+++ b/correctless/skills/cexplain/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(*)
 
 # /cexplain — Guided Codebase Exploration
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the explain-agent. Your job is to provide interactive, guided exploration of a codebase using mermaid diagrams and prose walkthroughs. You do NOT modify code — you are a read-only analysis tool. Each invocation starts fresh with a full project scan. The exploration is stateless across sessions: no persistence of exploration state to disk between sessions. Within a session, maintain context of what has been explored so the user can say "back to overview" or "export what we covered."
 
 ## Before You Start
@@ -209,8 +211,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for code ana
 
 ### Fallback Behavior
 
-If Serena is unavailable or any Serena call fails, fall back silently to grep and read equivalents. Do not abort, do not retry, do not warn mid-operation — the fallback is silent. Serena MCP is an optimizer, not a dependency — this skill must produce useful output without it.
-
 | Serena Tool | Fallback |
 |-------------|----------|
 | `get_code_map` | Directory listing (glob for source files) + package manifest reading + directory structure analysis |
@@ -220,9 +220,7 @@ If Serena is unavailable or any Serena call fails, fall back silently to grep an
 | `search_for_pattern` | Grep with regex pattern |
 | `replace_symbol_body` | Not applicable (read-only skill) |
 
-If Serena was unavailable during the session, note it once at the end: "Note: Serena was unavailable — fell back to text-based analysis. Diagrams may be less precise."
-
-The skill must produce useful output without Serena — grep-based import tracing, directory structure analysis, and file reading are the baseline.
+When Serena is unavailable, diagrams may be less precise — grep-based import tracing and directory structure analysis are the baseline.
 
 ## HTML Export (R-005)
 
@@ -259,20 +257,10 @@ However, within a session, the skill maintains context of what has been explored
 
 ## Token Logging (R-012)
 
-Log token usage to `.correctless/artifacts/token-log-{slug}.json` with these fields:
-
-```json
-{
-  "skill": "cexplain",
-  "phase": "exploration",
-  "agent_role": "explain-agent",
-  "total_tokens": 0,
-  "duration_ms": 0,
-  "timestamp": "ISO-8601"
-}
-```
-
-Append to existing file or create it.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cexplain"
+- `phase`: "exploration"
+- `agent_role`: "explain-agent"
 
 ## Constraints
 

--- a/correctless/skills/chelp/SKILL.md
+++ b/correctless/skills/chelp/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Bash(*)
 
 # /chelp — Correctless Quick Help
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Show the user the workflow pipeline, available commands, and current status. Keep output under 50 lines.
 
 ## Behavior

--- a/correctless/skills/cmaintain/SKILL.md
+++ b/correctless/skills/cmaintain/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cmaintain — Maintainer Contribution Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the maintainer review agent. Your job is NOT to ask "is this code good?" — `/cpr-review` does that. Your job is to ask **"should I merge this?"** That's a different question. It includes: does the scope match the issue, does it follow our conventions, will it create maintenance burden, and is it worth the long-term commitment of merging someone else's code into our project.
 
 Invoke with: `/cmaintain {PR number}`
@@ -224,9 +226,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After any subagent completes, capture `total_tokens` and `duration_ms`. Append to `.correctless/artifacts/token-log-{slug}.json`. If `.correctless/artifacts/` doesn't exist, create it with `mkdir -p .correctless/artifacts/` first.
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). If `.correctless/artifacts/` doesn't exist, create it with `mkdir -p .correctless/artifacts/` first. Skill-specific values:
+- `skill`: "cmaintain"
+- `phase`: "review"
+- `agent_role`: "maintainer-agent"
 
 ## Code Analysis (MCP Integration)
 
@@ -247,8 +250,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/correctless/skills/cmetrics/SKILL.md
+++ b/correctless/skills/cmetrics/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Bash(wc*), Bash(find*), Bash(cat*),
 
 # /cmetrics — Workflow Metrics Dashboard
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Aggregate all accumulated workflow data into a project health dashboard. Shows the value the workflow has delivered over time.
 
 ## When to Run

--- a/correctless/skills/cmodel/SKILL.md
+++ b/correctless/skills/cmodel/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cmodel — Formal Alloy Modeling
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `critical` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `critical` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cmodel requires critical minimum intensity to activate.
 
@@ -142,20 +140,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the interpreter subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the task slug):
-
-```json
-{
-  "skill": "cmodel",
-  "phase": "interpreter",
-  "agent_role": "interpreter-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cmodel"
+- `phase`: "interpreter"
+- `agent_role`: "interpreter-agent"
 
 ### Background Tasks
 Run the Alloy Analyzer (`java -jar`) as a background task while preparing the counterexample interpretation context. The JAR can take 30+ seconds for complex state spaces.
@@ -173,7 +161,6 @@ Run the Alloy Analyzer (`java -jar`) as a background task while preparing the co
 - Keep the model readable with comments.
 - Every assertion references a spec invariant ID.
 - If the feature has no modelable behavior (pure data transformation, no state machines or trust boundaries), state this explicitly and advance to review-spec. This is the only valid reason to pass through /cmodel without producing a model.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.
 
 ## Limitations (Be Honest)
 

--- a/correctless/skills/cpostmortem/SKILL.md
+++ b/correctless/skills/cpostmortem/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cpostmortem — Post-Merge Bug Analysis
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cpostmortem activates at standard minimum intensity (available to all).
 
@@ -147,20 +145,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the analysis subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the feature slug):
-
-```json
-{
-  "skill": "cpostmortem",
-  "phase": "analysis",
-  "agent_role": "analysis-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cpostmortem"
+- `phase`: "analysis"
+- `agent_role`: "analysis-agent"
 
 ### /export
 After postmortem completes: "Export this postmortem conversation: `/export .correctless/decisions/{task-slug}-postmortem.md` — captures the full analysis of why the workflow missed this bug."

--- a/correctless/skills/cpr-review/SKILL.md
+++ b/correctless/skills/cpr-review/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(gh*), Bash(glab*), Bash(git*), Bash(*test*
 
 # /cpr-review — Multi-Lens PR Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the PR review agent. You review incoming pull requests using multiple focused lenses — each check has a single concern and is more thorough in its domain than a human reviewer doing one pass trying to catch everything.
 
 Invoke with: `/cpr-review {PR number or URL}`
@@ -350,8 +352,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/correctless/skills/cquick/SKILL.md
+++ b/correctless/skills/cquick/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
 
 # /cquick — Quick Fix with TDD
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the quick-fix agent. Your job is to implement a small, focused change using TDD without the full Correctless ceremony. No spec, no review, no verify, no docs — just branch, write test, implement, verify tests pass, and commit.
 
 ## Before You Start

--- a/correctless/skills/credteam/SKILL.md
+++ b/correctless/skills/credteam/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /credteam — Red Team Assessment
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `critical` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `critical` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /credteam requires critical minimum intensity to activate.
 
@@ -318,20 +316,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the report date):
-
-```json
-{
-  "skill": "credteam",
-  "phase": "{attack-{path-number}|team-{agent-role}}",
-  "agent_role": "{attack-agent|primary-interface|control-plane|resilience}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "credteam"
+- `phase`: "{attack-{path-number}|team-{agent-role}}"
+- `agent_role`: "{attack-agent|primary-interface|control-plane|resilience}"
 
 ### Background Tasks
 Run crafted payloads and network probes as background tasks where possible — prepare the next attack path while waiting for the response from the current one.
@@ -355,8 +343,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/correctless/skills/crefactor/SKILL.md
+++ b/correctless/skills/crefactor/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /crefactor — Structured Refactoring
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the refactor orchestrator. Refactoring has a fundamentally different risk model than new features. The spec isn't "build X" — it's "same behavior, different structure." The test suite IS the spec. If tests pass before and after, the refactor is correct. If a test had to change, that's a behavioral change disguised as a refactor — flag it.
 
 ## Philosophy
@@ -293,20 +295,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the refactor intent filename):
-
-```json
-{
-  "skill": "crefactor",
-  "phase": "{characterization-tests|phase-N-refactor|phase-N-verify|qa}",
-  "agent_role": "{test-agent|refactor-agent|verification-agent|qa-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "crefactor"
+- `phase`: "{characterization-tests|phase-N-refactor|phase-N-verify|qa}"
+- `agent_role`: "{test-agent|refactor-agent|verification-agent|qa-agent}"
 
 ### Background Tasks
 - Run coverage analysis in the background while the refactor agent works
@@ -332,16 +324,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when checking whether a dependency migration path exists during refactoring:
 
 - Use `resolve-library-id` + `get-library-docs` to check if the target library version has a migration guide
 - Useful when refactoring involves upgrading a dependency (e.g., "does library-x v3 have a codemod for v2 → v3?")
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -357,6 +345,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **Characterization tests capture reality, not intent.** A characterization test that asserts a bug is still correct — it tells you the refactor changed behavior.
 - **Phase by phase.** Large refactors must be broken into phases that leave tests passing. No "I'll fix the tests after I'm done restructuring."
 - **Agent separation is mandatory.** The refactor agent does not verify. The verification agent did not refactor. Same principle as RED/GREEN in TDD.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining phases correctly.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **All files inside the project directory.** Never /tmp.

--- a/correctless/skills/crelease/SKILL.md
+++ b/correctless/skills/crelease/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
 
 # /crelease — Version Bump, Changelog, and Release Tag
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the release agent. Your job is to determine the version bump from specs merged since the last tag, generate a changelog entry, update the version file, run sanity checks, and create an annotated git tag. You do NOT deploy — you version, document, and tag.
 
 ## Before You Start
@@ -185,15 +187,10 @@ If `gh` CLI is available, also offer to create a GitHub release from the tag usi
 
 ## Token Logging (R-016)
 
-Log token usage to `.correctless/artifacts/token-log-{slug}.json` with these fields:
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
 - `skill`: "crelease"
 - `phase`: "release"
 - `agent_role`: "release-agent"
-- `total_tokens`: estimated token count
-- `duration_ms`: elapsed time in milliseconds
-- `timestamp`: ISO 8601 timestamp
-
-Append to existing file or create it.
 
 ## Decision Points
 

--- a/correctless/skills/creview-spec/SKILL.md
+++ b/correctless/skills/creview-spec/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /creview-spec — Multi-Agent Adversarial Spec Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /creview-spec requires high minimum intensity to activate.
 
@@ -261,20 +259,10 @@ See "Progress Visibility" section above — task creation and agent announcement
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "creview-spec",
-  "phase": "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}",
-  "agent_role": "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "creview-spec"
+- `phase`: "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}"
+- `agent_role`: "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}"
 
 ### Context Enforcement
 **Context enforcement (mandatory):** Before spawning the agent team, check context usage. If above 70%: the agents run forked (clean context) but the orchestrator needs to synthesize findings. Warn: "Context at {N}%. Run `/compact` before I spawn the review team — synthesis quality degrades with full context." If above 85%: stop and require /compact.
@@ -302,8 +290,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Agent crashes or context overflow**: The workflow state still shows `review-spec` phase. Re-run `/creview-spec` — all agents will be re-spawned from scratch (completed agent work is NOT preserved across re-runs).
@@ -317,5 +303,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - Do NOT approve the spec uncritically. Your job is to find problems.
 - Preserve the spec author's intent — challenge weak invariants, don't redesign the feature.
 - Each team member receives: spec, .correctless/ARCHITECTURE.md, .correctless/AGENT_CONTEXT.md, antipatterns, and the self-assessment.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to synthesize findings correctly.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/creview/SKILL.md
+++ b/correctless/skills/creview/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /creview — Skeptical Spec Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 **When to use:** After `/cspec` produces a spec. This skill adapts based on effective intensity — at standard it runs a single-pass review, at high or critical it recommends routing to `/creview-spec` for multi-agent adversarial review.
 
 You are the review agent. You did NOT write this spec. Your job is to read it cold and find what the spec author missed. Your lens: **"this spec is incomplete — what's missing?"**
@@ -20,17 +22,9 @@ You are a separate agent from the spec author. Do not assume the spec is correct
 | Agents | 1 + security checklist | Routes to /creview-spec (4-agent adversarial) | Routes to /creview-spec + external model |
 | Finding threshold | Disposition required | All addressed | Zero unresolved |
 
-<!-- Canonical: this Effective Intensity section is the source of truth. Verbatim copies exist in cspec, ctdd, cverify, cdocs, cstatus. R-022 enforces identity. -->
-
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Intensity-Aware Behavior
 
@@ -344,20 +338,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the review agent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "creview",
-  "phase": "review",
-  "agent_role": "review-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "creview"
+- `phase`: "review"
+- `agent_role`: "review-agent"
 
 ### /btw
 When presenting findings, mention: "Use /btw if you need to check something about the codebase without interrupting this review."
@@ -385,16 +369,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 to verify library-related claims in the spec (e.g., "bcrypt cost 12 is recommended", "use Zod for validation"):
 
 - Use `resolve-library-id` to find the library, then `get-library-docs` to fetch current docs
 - Compare the spec's claims against actual current documentation
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -410,4 +390,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **Preserve the spec author's intent.** Challenge weak rules, don't rewrite the feature.
 - **This step is NEVER skipped.** The state machine enforces this. Even for small features, review always finds unstated assumptions or untestable rules.
 - **Security checklist fires automatically.** Don't ask the developer if they want security review. If the spec touches auth, user data, payments, or APIs, check it. Most developers who need this most will never ask for it.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/csetup/SKILL.md
+++ b/correctless/skills/csetup/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 
 # /csetup — Initialize Correctless
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the onboarding agent. Your job is to get a project from zero to ready-to-use in one interactive conversation. Don't just run a script and dump output — guide the human through each decision.
 
 **Setup is adaptive.** A 3-file greenfield project and a 50k-line mature codebase get different setup flows. Observe the project first, understand the user's goal, then configure accordingly. Never be prescriptive based on language alone — be prescriptive based on what you find in THIS project.

--- a/correctless/skills/cspec/SKILL.md
+++ b/correctless/skills/cspec/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Bash(git log*), Bash(git diff*), Bash(git
 
 # /cspec — Write a Feature Specification
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the spec agent. Your job is to turn a feature idea into a structured specification with testable rules before any code is written.
 
 ## Intensity Configuration
@@ -19,13 +21,7 @@ You are the spec agent. Your job is to turn a feature idea into a structured spe
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -426,20 +422,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the research subagent completes (when triggered), capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the task slug):
-
-```json
-{
-  "skill": "cspec",
-  "phase": "research",
-  "agent_role": "research-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed. Only logged when the research subagent is triggered.
+Log token usage following the shared constraints (`_shared/constraints.md`). Only logged when the research subagent is triggered. Skill-specific values:
+- `skill`: "cspec"
+- `phase`: "research"
+- `agent_role`: "research-agent"
 
 ### /btw
 When presenting the spec for review, mention: "If you need to check something about the codebase without interrupting this review, use /btw."
@@ -469,16 +455,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 for the research subagent's library documentation lookups:
 
 - Use `resolve-library-id` to find the canonical ID for a library before fetching docs
 - Use `get-library-docs` to retrieve current documentation and API references
-
-When Context7 is unavailable, fall back to web search for library documentation. If Context7 was unavailable during this run, notify the user once at the end: "Note: Context7 was unavailable — fell back to web search for library docs."
 
 ## Intensity Detection
 
@@ -609,4 +591,3 @@ If `workflow.allow_intensity_downgrade` is `false`, omit the "lower" option and 
 - **At high+ intensity**: NEVER skip STRIDE for features touching trust boundaries (unless `require_stride` is false).
 - **NEVER skip the Socratic Brainstorm (Step 0).** Even experienced developers benefit from 2-3 reframing questions. The brainstorm is sequential and not subject to question batching.
 - **NEVER skip review.** Do not advance directly to tests. Do not suggest skipping review because the feature is small. The review step is enforced by the state machine and always produces value.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/cstatus/SKILL.md
+++ b/correctless/skills/cstatus/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /cstatus — Workflow Status and Next Steps
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the status agent. Show the human where they are in the workflow and what to do next. Be concise and actionable.
 
 ## Intensity Configuration
@@ -16,13 +18,7 @@ You are the status agent. Show the human where they are in the workflow and what
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Behavior
 

--- a/correctless/skills/csummary/SKILL.md
+++ b/correctless/skills/csummary/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Write(.correctless/artifacts/summar
 
 # /csummary — Feature Workflow Summary
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Generate a one-page summary of everything the Correctless workflow caught during this feature. This is the "look what I saved you" report.
 
 ## When to Run

--- a/correctless/skills/ctdd/SKILL.md
+++ b/correctless/skills/ctdd/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /ctdd — Enforced Test-Driven Development
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the TDD orchestrator. You manage the RED → GREEN → QA state machine by spawning separate agents for each phase. **You do not write tests or code yourself.**
 
 ## Intensity Configuration
@@ -20,13 +22,7 @@ You are the TDD orchestrator. You manage the RED → GREEN → QA state machine 
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Philosophy
 
@@ -505,20 +501,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the workflow state or spec file):
-
-```json
-{
-  "skill": "ctdd",
-  "phase": "{red|test-audit|green|qa|fix-round-N}",
-  "agent_role": "{test-writer|test-auditor|implementation|qa-agent|fix-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "ctdd"
+- `phase`: "{red|test-audit|green|qa|fix-round-N}"
+- `agent_role`: "{test-writer|test-auditor|implementation|qa-agent|fix-agent}"
 
 ### /btw Reminder
 When presenting QA findings for the human to review, mention: "If you need to check something about the codebase without interrupting this review, use /btw."
@@ -546,16 +532,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, the test agent (RED phase) can use Context7 to understand a library's test utilities and assertion patterns:
 
 - Use `resolve-library-id` + `get-library-docs` to fetch testing docs for the libraries under test
 - Useful when the test agent needs to know how a library's test helpers work (e.g., testing hooks in React, test fixtures in pytest)
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -573,6 +555,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **If `workflow-advance.sh` fails**, read the error message and present it to the human. Common causes: wrong phase, missing precondition, not on a feature branch.
 - **All files created by any agent must be inside the project directory.** Never write to /tmp or external paths.
 - **Never skip workflow steps.** The full pipeline is: RED → test audit → GREEN → /simplify → QA → done → /cverify → /cdocs → merge. Every step runs, every time. No exceptions. "This feature is small" is not a reason to skip. Time is not the constraint — correctness is.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining phases correctly.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/cupdate-arch/SKILL.md
+++ b/correctless/skills/cupdate-arch/SKILL.md
@@ -6,13 +6,11 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Edit, Write(.correctless/ARCHITECTU
 
 # /cupdate-arch — Maintain Architecture Documentation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cupdate-arch requires high minimum intensity to activate.
 

--- a/correctless/skills/cverify/SKILL.md
+++ b/correctless/skills/cverify/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cverify — Post-Implementation Verification
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the verification agent. You did NOT participate in the implementation. Your job is to check that what was built matches what was specced. Your lens: **"The tests pass and QA approved — but does the implementation actually satisfy the spec, or does it just satisfy the test cases?"**
 
 ## Intensity Configuration
@@ -19,13 +21,7 @@ You are the verification agent. You did NOT participate in the implementation. Y
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -270,20 +266,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the verification agent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "cverify",
-  "phase": "verification",
-  "agent_role": "verification-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cverify"
+- `phase`: "verification"
+- `agent_role`: "verification-agent"
 
 ### Background Tasks
 - Run mutation testing in the background while doing rule coverage analysis, prohibition checks, and antipattern matching
@@ -310,8 +296,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.
@@ -326,7 +310,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Do NOT skip the rule coverage check.** Every rule must be accounted for.
 - **Do NOT approve a feature with uncovered rules.** Uncovered rules are BLOCKING.
 - **Be specific about weak tests.** "Weak" means: the test would still pass if the rule were violated.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to produce accurate verification results.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **All files written inside the project directory.** Never /tmp.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/correctless/skills/cwtf/SKILL.md
+++ b/correctless/skills/cwtf/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Bash(jq*), Bash(find*), Bash(grep*)
 
 # /cwtf — Workflow Accountability
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Every other skill watches the code. This skill watches the agents watching the code. It answers: **"Did the workflow actually do what the skill instructions said it should do?"**
 
 Invoke with: `/cwtf` (analyzes the most recent or current workflow) or `/cwtf {phase}` (analyzes a specific phase)
@@ -194,8 +196,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/skills/_shared/constraints.md
+++ b/skills/_shared/constraints.md
@@ -1,0 +1,51 @@
+# Shared Skill Constraints
+
+These constraints apply to every skill that references this file. They are universal — not skill-specific.
+
+## Skill Boundary
+
+- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.
+
+## Evidence Standard
+
+- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
+- **All files written inside the project directory.** Never /tmp.
+
+## Context Management
+
+- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to produce accurate results. Specific thresholds and recovery instructions may be defined per-skill.
+
+## Effective Intensity Computation
+
+Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
+
+1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
+2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
+3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
+
+**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The skill still runs — it does not require active workflow state.
+
+## Token Tracking
+
+After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the workflow state or spec file):
+
+```json
+{
+  "skill": "{skill-name}",
+  "phase": "{phase}",
+  "agent_role": "{agent-role}",
+  "total_tokens": N,
+  "duration_ms": N,
+  "timestamp": "ISO"
+}
+```
+
+If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+
+## MCP Degradation (Serena)
+
+**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
+
+## MCP Degradation (Context7)
+
+When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.

--- a/skills/caudit/SKILL.md
+++ b/skills/caudit/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /caudit — Olympics Audit System
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /caudit requires high minimum intensity to activate.
 
@@ -464,20 +462,10 @@ See "Progress Visibility" section above — task creation and round-by-round nar
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the preset and date):
-
-```json
-{
-  "skill": "caudit",
-  "phase": "{round-N-{agent-role}|round-N-triage}",
-  "agent_role": "{specialist-role|triage}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "caudit"
+- `phase`: "{round-N-{agent-role}|round-N-triage}"
+- `agent_role`: "{specialist-role|triage}"
 
 After each round's agents complete and triage finishes, print: "Round {N} complete. {M} findings. Running token cost: ~{total}k tokens. Continue to round {N+1}?" This gives the user cost visibility to decide whether to continue.
 
@@ -508,8 +496,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Agent crashes mid-round**: Re-run `/caudit`. Prior round findings are persisted in `.correctless/artifacts/findings/` and provide context, but the skill restarts from Round 1. It will re-read prior findings and avoid re-reporting already-fixed issues, but there is no automatic round-level resume.
@@ -524,6 +510,5 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Every finding needs instance fix AND class fix.**
 - **Post-convergence regression tests are mandatory.**
 - **All files inside the project directory.** Never /tmp.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining rounds correctly.
 - **Cost visibility every round.** Human can stop the loop.
 - **Redact if sharing.** If this output will be shared externally, apply redaction rules from `templates/redaction-rules.md` first.

--- a/skills/ccontribute/SKILL.md
+++ b/skills/ccontribute/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(*), Edit, Write(*), WebSearch, WebFetch
 
 # /ccontribute — Open Source Contribution
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the contribution agent. Your job is to help the user contribute to a project they don't own — an open source repo, a friend's project, a work monorepo owned by another team. The key principle: **match, don't improve.** You are a guest. Write code that looks like a regular contributor wrote it, not an outsider who thinks they know better.
 
 Invoke with: `/ccontribute {issue number or description of what to change}`
@@ -177,7 +179,12 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After any subagent completes (research for unfamiliar patterns), capture `total_tokens` and `duration_ms`. Since this skill runs against external projects that may not have `.correctless/artifacts/`, skip token logging if the directory doesn't exist. Token data is still visible in the conversation for manual tracking via `/cmetrics`.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "ccontribute"
+- `phase`: "contribution"
+- `agent_role`: "contribution-agent"
+
+Since this skill runs against external projects that may not have `.correctless/artifacts/`, skip token logging if the directory doesn't exist.
 
 ## Code Analysis (MCP Integration)
 
@@ -198,8 +205,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/skills/cdebug/SKILL.md
+++ b/skills/cdebug/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cdebug — Structured Bug Investigation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the debugging agent. Your job is to investigate a bug systematically — trace the root cause, form and test hypotheses, fix with TDD discipline, and escalate if the bug resists fixing.
 
 **Do not guess-and-patch.** Understand the bug before touching code. A fix without root cause understanding is a new bug waiting to happen.
@@ -177,20 +179,10 @@ Run the test suite in the background while investigating the code path. Run git 
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the debug investigation slug):
-
-```json
-{
-  "skill": "cdebug",
-  "phase": "{fix|escalation}",
-  "agent_role": "{fix-agent|escalation-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cdebug"
+- `phase`: "{fix|escalation}"
+- `agent_role`: "{fix-agent|escalation-agent}"
 
 ### /btw
 When presenting the root cause analysis: "Use /btw if you need to check something about the codebase without interrupting this investigation."
@@ -217,16 +209,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when researching library behavior during root cause analysis:
 
 - Use `resolve-library-id` to find the canonical ID for a library before fetching docs
 - Use `get-library-docs` to retrieve current documentation, API references, and known issues
-
-When Context7 is unavailable, fall back to web search for library documentation. If Context7 was unavailable during this run, notify the user once at the end: "Note: Context7 was unavailable — fell back to web search for library docs."
 
 ## If Something Goes Wrong
 

--- a/skills/cdevadv/SKILL.md
+++ b/skills/cdevadv/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cdevadv — Devil's Advocate (10th Man Rule)
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cdevadv activates at standard minimum intensity (available to all).
 
@@ -252,20 +250,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the explorer subagent completes (signals mode only), capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the report date):
-
-```json
-{
-  "skill": "cdevadv",
-  "phase": "explorer",
-  "agent_role": "explorer-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Token logging applies to signals mode only (Layers mode does not spawn subagents). Skill-specific values:
+- `skill`: "cdevadv"
+- `phase`: "explorer"
+- `agent_role`: "explorer-agent"
 
 ### /context
 Check context usage before starting. Layers mode is context-efficient (cheap passes first). Signals mode loads more data. If context is above 50% before starting, suggest compacting first.

--- a/skills/cdocs/SKILL.md
+++ b/skills/cdocs/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Bash(git*), Bash(*workflow-advance.sh*), 
 
 # /cdocs — Update Project Documentation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the documentation agent. Your job is to keep project documentation current after features land. You update README, .correctless/AGENT_CONTEXT.md, feature docs, and suggest .correctless/ARCHITECTURE.md additions.
 
 ## Intensity Configuration
@@ -17,13 +19,7 @@ You are the documentation agent. Your job is to keep project documentation curre
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -232,8 +228,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.
@@ -247,4 +241,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Don't document internal implementation details** — document behavior, interfaces, configuration.
 - **Present changes for human approval** before writing. Documentation is the project's external face.
 - **Keep .correctless/AGENT_CONTEXT.md under 1500 words.** It's a briefing, not a novel.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/cexplain/SKILL.md
+++ b/skills/cexplain/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(*)
 
 # /cexplain — Guided Codebase Exploration
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the explain-agent. Your job is to provide interactive, guided exploration of a codebase using mermaid diagrams and prose walkthroughs. You do NOT modify code — you are a read-only analysis tool. Each invocation starts fresh with a full project scan. The exploration is stateless across sessions: no persistence of exploration state to disk between sessions. Within a session, maintain context of what has been explored so the user can say "back to overview" or "export what we covered."
 
 ## Before You Start
@@ -209,8 +211,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for code ana
 
 ### Fallback Behavior
 
-If Serena is unavailable or any Serena call fails, fall back silently to grep and read equivalents. Do not abort, do not retry, do not warn mid-operation — the fallback is silent. Serena MCP is an optimizer, not a dependency — this skill must produce useful output without it.
-
 | Serena Tool | Fallback |
 |-------------|----------|
 | `get_code_map` | Directory listing (glob for source files) + package manifest reading + directory structure analysis |
@@ -220,9 +220,7 @@ If Serena is unavailable or any Serena call fails, fall back silently to grep an
 | `search_for_pattern` | Grep with regex pattern |
 | `replace_symbol_body` | Not applicable (read-only skill) |
 
-If Serena was unavailable during the session, note it once at the end: "Note: Serena was unavailable — fell back to text-based analysis. Diagrams may be less precise."
-
-The skill must produce useful output without Serena — grep-based import tracing, directory structure analysis, and file reading are the baseline.
+When Serena is unavailable, diagrams may be less precise — grep-based import tracing and directory structure analysis are the baseline.
 
 ## HTML Export (R-005)
 
@@ -259,20 +257,10 @@ However, within a session, the skill maintains context of what has been explored
 
 ## Token Logging (R-012)
 
-Log token usage to `.correctless/artifacts/token-log-{slug}.json` with these fields:
-
-```json
-{
-  "skill": "cexplain",
-  "phase": "exploration",
-  "agent_role": "explain-agent",
-  "total_tokens": 0,
-  "duration_ms": 0,
-  "timestamp": "ISO-8601"
-}
-```
-
-Append to existing file or create it.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cexplain"
+- `phase`: "exploration"
+- `agent_role`: "explain-agent"
 
 ## Constraints
 

--- a/skills/chelp/SKILL.md
+++ b/skills/chelp/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Bash(*)
 
 # /chelp — Correctless Quick Help
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Show the user the workflow pipeline, available commands, and current status. Keep output under 50 lines.
 
 ## Behavior

--- a/skills/cmaintain/SKILL.md
+++ b/skills/cmaintain/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cmaintain — Maintainer Contribution Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the maintainer review agent. Your job is NOT to ask "is this code good?" — `/cpr-review` does that. Your job is to ask **"should I merge this?"** That's a different question. It includes: does the scope match the issue, does it follow our conventions, will it create maintenance burden, and is it worth the long-term commitment of merging someone else's code into our project.
 
 Invoke with: `/cmaintain {PR number}`
@@ -224,9 +226,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After any subagent completes, capture `total_tokens` and `duration_ms`. Append to `.correctless/artifacts/token-log-{slug}.json`. If `.correctless/artifacts/` doesn't exist, create it with `mkdir -p .correctless/artifacts/` first.
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). If `.correctless/artifacts/` doesn't exist, create it with `mkdir -p .correctless/artifacts/` first. Skill-specific values:
+- `skill`: "cmaintain"
+- `phase`: "review"
+- `agent_role`: "maintainer-agent"
 
 ## Code Analysis (MCP Integration)
 
@@ -247,8 +250,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/skills/cmetrics/SKILL.md
+++ b/skills/cmetrics/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Bash(wc*), Bash(find*), Bash(cat*),
 
 # /cmetrics — Workflow Metrics Dashboard
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Aggregate all accumulated workflow data into a project health dashboard. Shows the value the workflow has delivered over time.
 
 ## When to Run

--- a/skills/cmodel/SKILL.md
+++ b/skills/cmodel/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cmodel — Formal Alloy Modeling
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `critical` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `critical` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cmodel requires critical minimum intensity to activate.
 
@@ -142,20 +140,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the interpreter subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the task slug):
-
-```json
-{
-  "skill": "cmodel",
-  "phase": "interpreter",
-  "agent_role": "interpreter-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cmodel"
+- `phase`: "interpreter"
+- `agent_role`: "interpreter-agent"
 
 ### Background Tasks
 Run the Alloy Analyzer (`java -jar`) as a background task while preparing the counterexample interpretation context. The JAR can take 30+ seconds for complex state spaces.
@@ -173,7 +161,6 @@ Run the Alloy Analyzer (`java -jar`) as a background task while preparing the co
 - Keep the model readable with comments.
 - Every assertion references a spec invariant ID.
 - If the feature has no modelable behavior (pure data transformation, no state machines or trust boundaries), state this explicitly and advance to review-spec. This is the only valid reason to pass through /cmodel without producing a model.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.
 
 ## Limitations (Be Honest)
 

--- a/skills/cpostmortem/SKILL.md
+++ b/skills/cpostmortem/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /cpostmortem — Post-Merge Bug Analysis
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `standard` or above (available to all projects). Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cpostmortem activates at standard minimum intensity (available to all).
 
@@ -147,20 +145,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the analysis subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the feature slug):
-
-```json
-{
-  "skill": "cpostmortem",
-  "phase": "analysis",
-  "agent_role": "analysis-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cpostmortem"
+- `phase`: "analysis"
+- `agent_role`: "analysis-agent"
 
 ### /export
 After postmortem completes: "Export this postmortem conversation: `/export .correctless/decisions/{task-slug}-postmortem.md` — captures the full analysis of why the workflow missed this bug."

--- a/skills/cpr-review/SKILL.md
+++ b/skills/cpr-review/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(gh*), Bash(glab*), Bash(git*), Bash(*test*
 
 # /cpr-review — Multi-Lens PR Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the PR review agent. You review incoming pull requests using multiple focused lenses — each check has a single concern and is more thorough in its domain than a human reviewer doing one pass trying to catch everything.
 
 Invoke with: `/cpr-review {PR number or URL}`
@@ -350,8 +352,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/skills/cquick/SKILL.md
+++ b/skills/cquick/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
 
 # /cquick — Quick Fix with TDD
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the quick-fix agent. Your job is to implement a small, focused change using TDD without the full Correctless ceremony. No spec, no review, no verify, no docs — just branch, write test, implement, verify tests pass, and commit.
 
 ## Before You Start

--- a/skills/credteam/SKILL.md
+++ b/skills/credteam/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /credteam — Red Team Assessment
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `critical` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `critical` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /credteam requires critical minimum intensity to activate.
 
@@ -318,20 +316,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the report date):
-
-```json
-{
-  "skill": "credteam",
-  "phase": "{attack-{path-number}|team-{agent-role}}",
-  "agent_role": "{attack-agent|primary-interface|control-plane|resilience}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "credteam"
+- `phase`: "{attack-{path-number}|team-{agent-role}}"
+- `agent_role`: "{attack-agent|primary-interface|control-plane|resilience}"
 
 ### Background Tasks
 Run crafted payloads and network probes as background tasks where possible — prepare the next attack path while waiting for the response from the current one.
@@ -355,8 +343,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/skills/crefactor/SKILL.md
+++ b/skills/crefactor/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /crefactor — Structured Refactoring
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the refactor orchestrator. Refactoring has a fundamentally different risk model than new features. The spec isn't "build X" — it's "same behavior, different structure." The test suite IS the spec. If tests pass before and after, the refactor is correct. If a test had to change, that's a behavioral change disguised as a refactor — flag it.
 
 ## Philosophy
@@ -293,20 +295,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the refactor intent filename):
-
-```json
-{
-  "skill": "crefactor",
-  "phase": "{characterization-tests|phase-N-refactor|phase-N-verify|qa}",
-  "agent_role": "{test-agent|refactor-agent|verification-agent|qa-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "crefactor"
+- `phase`: "{characterization-tests|phase-N-refactor|phase-N-verify|qa}"
+- `agent_role`: "{test-agent|refactor-agent|verification-agent|qa-agent}"
 
 ### Background Tasks
 - Run coverage analysis in the background while the refactor agent works
@@ -332,16 +324,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 when checking whether a dependency migration path exists during refactoring:
 
 - Use `resolve-library-id` + `get-library-docs` to check if the target library version has a migration guide
 - Useful when refactoring involves upgrading a dependency (e.g., "does library-x v3 have a codemod for v2 → v3?")
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -357,6 +345,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **Characterization tests capture reality, not intent.** A characterization test that asserts a bug is still correct — it tells you the refactor changed behavior.
 - **Phase by phase.** Large refactors must be broken into phases that leave tests passing. No "I'll fix the tests after I'm done restructuring."
 - **Agent separation is mandatory.** The refactor agent does not verify. The verification agent did not refactor. Same principle as RED/GREEN in TDD.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining phases correctly.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **All files inside the project directory.** Never /tmp.

--- a/skills/crelease/SKILL.md
+++ b/skills/crelease/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(*)
 
 # /crelease — Version Bump, Changelog, and Release Tag
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the release agent. Your job is to determine the version bump from specs merged since the last tag, generate a changelog entry, update the version file, run sanity checks, and create an annotated git tag. You do NOT deploy — you version, document, and tag.
 
 ## Before You Start
@@ -185,15 +187,10 @@ If `gh` CLI is available, also offer to create a GitHub release from the tag usi
 
 ## Token Logging (R-016)
 
-Log token usage to `.correctless/artifacts/token-log-{slug}.json` with these fields:
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
 - `skill`: "crelease"
 - `phase`: "release"
 - `agent_role`: "release-agent"
-- `total_tokens`: estimated token count
-- `duration_ms`: elapsed time in milliseconds
-- `timestamp`: ISO 8601 timestamp
-
-Append to existing file or create it.
 
 ## Decision Points
 

--- a/skills/creview-spec/SKILL.md
+++ b/skills/creview-spec/SKILL.md
@@ -7,13 +7,11 @@ context: fork
 
 # /creview-spec — Multi-Agent Adversarial Spec Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /creview-spec requires high minimum intensity to activate.
 
@@ -261,20 +259,10 @@ See "Progress Visibility" section above — task creation and agent announcement
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "creview-spec",
-  "phase": "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}",
-  "agent_role": "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "creview-spec"
+- `phase`: "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}"
+- `agent_role`: "{self-assessment|red-team|assumptions-auditor|testability-auditor|design-contract-checker|external-{model}}"
 
 ### Context Enforcement
 **Context enforcement (mandatory):** Before spawning the agent team, check context usage. If above 70%: the agents run forked (clean context) but the orchestrator needs to synthesize findings. Warn: "Context at {N}%. Run `/compact` before I spawn the review team — synthesis quality degrades with full context." If above 85%: stop and require /compact.
@@ -302,8 +290,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Agent crashes or context overflow**: The workflow state still shows `review-spec` phase. Re-run `/creview-spec` — all agents will be re-spawned from scratch (completed agent work is NOT preserved across re-runs).
@@ -317,5 +303,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - Do NOT approve the spec uncritically. Your job is to find problems.
 - Preserve the spec author's intent — challenge weak invariants, don't redesign the feature.
 - Each team member receives: spec, .correctless/ARCHITECTURE.md, .correctless/AGENT_CONTEXT.md, antipatterns, and the self-assessment.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to synthesize findings correctly.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/creview/SKILL.md
+++ b/skills/creview/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /creview — Skeptical Spec Review
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 **When to use:** After `/cspec` produces a spec. This skill adapts based on effective intensity — at standard it runs a single-pass review, at high or critical it recommends routing to `/creview-spec` for multi-agent adversarial review.
 
 You are the review agent. You did NOT write this spec. Your job is to read it cold and find what the spec author missed. Your lens: **"this spec is incomplete — what's missing?"**
@@ -20,17 +22,9 @@ You are a separate agent from the spec author. Do not assume the spec is correct
 | Agents | 1 + security checklist | Routes to /creview-spec (4-agent adversarial) | Routes to /creview-spec + external model |
 | Finding threshold | Disposition required | All addressed | Zero unresolved |
 
-<!-- Canonical: this Effective Intensity section is the source of truth. Verbatim copies exist in cspec, ctdd, cverify, cdocs, cstatus. R-022 enforces identity. -->
-
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Intensity-Aware Behavior
 
@@ -344,20 +338,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the review agent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "creview",
-  "phase": "review",
-  "agent_role": "review-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "creview"
+- `phase`: "review"
+- `agent_role`: "review-agent"
 
 ### /btw
 When presenting findings, mention: "Use /btw if you need to check something about the codebase without interrupting this review."
@@ -385,16 +369,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 to verify library-related claims in the spec (e.g., "bcrypt cost 12 is recommended", "use Zod for validation"):
 
 - Use `resolve-library-id` to find the library, then `get-library-docs` to fetch current docs
 - Compare the spec's claims against actual current documentation
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -410,4 +390,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **Preserve the spec author's intent.** Challenge weak rules, don't rewrite the feature.
 - **This step is NEVER skipped.** The state machine enforces this. Even for small features, review always finds unstated assumptions or untestable rules.
 - **Security checklist fires automatically.** Don't ask the developer if they want security review. If the spec touches auth, user data, payments, or APIs, check it. Most developers who need this most will never ask for it.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/csetup/SKILL.md
+++ b/skills/csetup/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 
 # /csetup — Initialize Correctless
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the onboarding agent. Your job is to get a project from zero to ready-to-use in one interactive conversation. Don't just run a script and dump output — guide the human through each decision.
 
 **Setup is adaptive.** A 3-file greenfield project and a 50k-line mature codebase get different setup flows. Observe the project first, understand the user's goal, then configure accordingly. Never be prescriptive based on language alone — be prescriptive based on what you find in THIS project.

--- a/skills/cspec/SKILL.md
+++ b/skills/cspec/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Edit, Bash(git log*), Bash(git diff*), Bash(git
 
 # /cspec — Write a Feature Specification
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the spec agent. Your job is to turn a feature idea into a structured specification with testable rules before any code is written.
 
 ## Intensity Configuration
@@ -19,13 +21,7 @@ You are the spec agent. Your job is to turn a feature idea into a structured spe
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -426,20 +422,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the research subagent completes (when triggered), capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the task slug):
-
-```json
-{
-  "skill": "cspec",
-  "phase": "research",
-  "agent_role": "research-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed. Only logged when the research subagent is triggered.
+Log token usage following the shared constraints (`_shared/constraints.md`). Only logged when the research subagent is triggered. Skill-specific values:
+- `skill`: "cspec"
+- `phase`: "research"
+- `agent_role`: "research-agent"
 
 ### /btw
 When presenting the spec for review, mention: "If you need to check something about the codebase without interrupting this review, use /btw."
@@ -469,16 +455,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, use Context7 for the research subagent's library documentation lookups:
 
 - Use `resolve-library-id` to find the canonical ID for a library before fetching docs
 - Use `get-library-docs` to retrieve current documentation and API references
-
-When Context7 is unavailable, fall back to web search for library documentation. If Context7 was unavailable during this run, notify the user once at the end: "Note: Context7 was unavailable — fell back to web search for library docs."
 
 ## Intensity Detection
 
@@ -609,4 +591,3 @@ If `workflow.allow_intensity_downgrade` is `false`, omit the "lower" option and 
 - **At high+ intensity**: NEVER skip STRIDE for features touching trust boundaries (unless `require_stride` is false).
 - **NEVER skip the Socratic Brainstorm (Step 0).** Even experienced developers benefit from 2-3 reframing questions. The brainstorm is sequential and not subject to question batching.
 - **NEVER skip review.** Do not advance directly to tests. Do not suggest skipping review because the feature is small. The review step is enforced by the state machine and always produces value.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/cstatus/SKILL.md
+++ b/skills/cstatus/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # /cstatus — Workflow Status and Next Steps
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the status agent. Show the human where they are in the workflow and what to do next. Be concise and actionable.
 
 ## Intensity Configuration
@@ -16,13 +18,7 @@ You are the status agent. Show the human where they are in the workflow and what
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Behavior
 

--- a/skills/csummary/SKILL.md
+++ b/skills/csummary/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Write(.correctless/artifacts/summar
 
 # /csummary — Feature Workflow Summary
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Generate a one-page summary of everything the Correctless workflow caught during this feature. This is the "look what I saved you" report.
 
 ## When to Run

--- a/skills/ctdd/SKILL.md
+++ b/skills/ctdd/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /ctdd — Enforced Test-Driven Development
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the TDD orchestrator. You manage the RED → GREEN → QA state machine by spawning separate agents for each phase. **You do not write tests or code yourself.**
 
 ## Intensity Configuration
@@ -20,13 +22,7 @@ You are the TDD orchestrator. You manage the RED → GREEN → QA state machine 
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Philosophy
 
@@ -505,20 +501,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After each subagent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the workflow state or spec file):
-
-```json
-{
-  "skill": "ctdd",
-  "phase": "{red|test-audit|green|qa|fix-round-N}",
-  "agent_role": "{test-writer|test-auditor|implementation|qa-agent|fix-agent}",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "ctdd"
+- `phase`: "{red|test-audit|green|qa|fix-round-N}"
+- `agent_role`: "{test-writer|test-auditor|implementation|qa-agent|fix-agent}"
 
 ### /btw Reminder
 When presenting QA findings for the human to review, mention: "If you need to check something about the codebase without interrupting this review, use /btw."
@@ -546,16 +532,12 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ### Context7 — Library Documentation
 
 If `mcp.context7` is `true` in `workflow-config.json`, the test agent (RED phase) can use Context7 to understand a library's test utilities and assertion patterns:
 
 - Use `resolve-library-id` + `get-library-docs` to fetch testing docs for the libraries under test
 - Useful when the test agent needs to know how a library's test helpers work (e.g., testing hooks in React, test fixtures in pytest)
-
-When Context7 is unavailable, fall back to web search. If Context7 was unavailable during this run, notify the user once at the end.
 
 ## If Something Goes Wrong
 
@@ -573,6 +555,3 @@ When Context7 is unavailable, fall back to web search. If Context7 was unavailab
 - **If `workflow-advance.sh` fails**, read the error message and present it to the human. Common causes: wrong phase, missing precondition, not on a feature branch.
 - **All files created by any agent must be inside the project directory.** Never write to /tmp or external paths.
 - **Never skip workflow steps.** The full pipeline is: RED → test audit → GREEN → /simplify → QA → done → /cverify → /cdocs → merge. Every step runs, every time. No exceptions. "This feature is small" is not a reason to skip. Time is not the constraint — correctness is.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to manage remaining phases correctly.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/cupdate-arch/SKILL.md
+++ b/skills/cupdate-arch/SKILL.md
@@ -6,13 +6,11 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Edit, Write(.correctless/ARCHITECTU
 
 # /cupdate-arch — Maintain Architecture Documentation
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 ## Intensity Gate
 
-This skill requires effective intensity `high` or above. Compute effective intensity as `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. Read `workflow.intensity` from `.correctless/config/workflow-config.json` (project_intensity). If absent, default to `standard`.
-2. Run `.correctless/hooks/workflow-advance.sh status` and read the `Intensity:` line (feature_intensity). If absent, use project_intensity alone.
-3. Effective intensity = `max(project_intensity, feature_intensity)`.
+This skill requires effective intensity `high` or above. Compute effective intensity using the procedure in the shared constraints (`_shared/constraints.md`).
 
 **Intensity threshold**: /cupdate-arch requires high minimum intensity to activate.
 

--- a/skills/cverify/SKILL.md
+++ b/skills/cverify/SKILL.md
@@ -7,6 +7,8 @@ context: fork
 
 # /cverify — Post-Implementation Verification
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 You are the verification agent. You did NOT participate in the implementation. Your job is to check that what was built matches what was specced. Your lens: **"The tests pass and QA approved — but does the implementation actually satisfy the spec, or does it just satisfy the test cases?"**
 
 ## Intensity Configuration
@@ -19,13 +21,7 @@ You are the verification agent. You did NOT participate in the implementation. Y
 
 ## Effective Intensity
 
-Determine the effective intensity before starting the review. The effective intensity is `max(project_intensity, feature_intensity)` using the ordering `standard < high < critical`.
-
-1. **Read project intensity**: Read `workflow.intensity` from `.correctless/config/workflow-config.json`. If the field is absent, default to `standard`.
-2. **Read feature intensity**: Run `.correctless/hooks/workflow-advance.sh status` and look for the `Intensity:` line. If the Intensity line is absent in the status output (feature_intensity is absent), use the project intensity alone.
-3. **Compute effective intensity**: Take the max of project_intensity and feature_intensity.
-
-**Fallback chain**: feature_intensity -> workflow.intensity -> standard. If both feature_intensity and `workflow.intensity` are absent, the effective intensity defaults to `standard`. If there is no active workflow state (no state file), effective intensity falls back to `workflow.intensity` from config, then to `standard`. The review still runs — it does not require active workflow state.
+Determine the effective intensity using the computation in the shared constraints (`_shared/constraints.md`).
 
 ## Progress Visibility (MANDATORY)
 
@@ -270,20 +266,10 @@ See "Progress Visibility" section above — task creation and narration are mand
 
 ### Token Tracking
 
-After the verification agent completes, capture `total_tokens` and `duration_ms` from the completion result. Append an entry to `.correctless/artifacts/token-log-{slug}.json` (derive slug from the spec file basename):
-
-```json
-{
-  "skill": "cverify",
-  "phase": "verification",
-  "agent_role": "verification-agent",
-  "total_tokens": N,
-  "duration_ms": N,
-  "timestamp": "ISO"
-}
-```
-
-If the file doesn't exist, create it with the first entry. `/cmetrics` aggregates from raw entries — no totals field needed.
+Log token usage following the shared constraints (`_shared/constraints.md`). Skill-specific values:
+- `skill`: "cverify"
+- `phase`: "verification"
+- `agent_role`: "verification-agent"
 
 ### Background Tasks
 - Run mutation testing in the background while doing rule coverage analysis, prohibition checks, and antipattern matching
@@ -310,8 +296,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
 
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
-
 ## If Something Goes Wrong
 
 - **Skill interrupted**: Re-run the skill. It reads the current state and resumes where possible.
@@ -326,7 +310,3 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 - **Do NOT skip the rule coverage check.** Every rule must be accounted for.
 - **Do NOT approve a feature with uncovered rules.** Uncovered rules are BLOCKING.
 - **Be specific about weak tests.** "Weak" means: the test would still pass if the rule were violated.
-- **Context is a reliability constraint.** Above 70%, warn and recommend /compact. Above 85%, stop — instruction adherence degrades and the orchestrator cannot be trusted to produce accurate verification results.
-- **Evidence before claims.** Never say "tests pass" or "checks out" without running the command fresh in this message and showing the output. "Should pass" is not evidence.
-- **All files written inside the project directory.** Never /tmp.
-- **Never auto-invoke the next skill.** Tell the human what comes next and let them decide when to run it. The boundary between skills is the human's decision point.

--- a/skills/cwtf/SKILL.md
+++ b/skills/cwtf/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Grep, Glob, Bash(git*), Bash(jq*), Bash(find*), Bash(grep*)
 
 # /cwtf — Workflow Accountability
 
+> **Shared constraints apply.** Before executing, read `_shared/constraints.md` from the parent of this skill's base directory. All constraints there apply to this skill.
+
 Every other skill watches the code. This skill watches the agents watching the code. It answers: **"Did the workflow actually do what the skill instructions said it should do?"**
 
 Invoke with: `/cwtf` (analyzes the most recent or current workflow) or `/cwtf {phase}` (analyzes a specific phase)
@@ -194,8 +196,6 @@ If `mcp.serena` is `true` in `workflow-config.json`, use Serena MCP for symbol-l
 | `get_symbols_overview` | Read directory + read index files |
 | `replace_symbol_body` | Edit tool |
 | `search_for_pattern` | Grep tool |
-
-**Graceful degradation**: If a Serena tool call fails, fall back to the text-based equivalent silently. Do not abort, do not retry, do not warn the user mid-operation. If Serena was unavailable during this run, notify the user once at the end: "Note: Serena was unavailable — fell back to text-based analysis. If this persists, check that the Serena MCP server is running (`uvx serena-mcp-server`)." Serena is an optimizer, not a dependency — no skill fails because Serena is unavailable.
 
 ## If Something Goes Wrong
 

--- a/sync.sh
+++ b/sync.sh
@@ -79,6 +79,13 @@ done
 sync_dir "helpers" "correctless/helpers"
 [ "$CHECK_ONLY" = false ] && info "PBT helpers → correctless/"
 
+# --- Shared skill constraints ---
+if [ "$CHECK_ONLY" = false ]; then
+  mkdir -p "correctless/skills/_shared"
+fi
+sync_file "skills/_shared/constraints.md" "correctless/skills/_shared/constraints.md"
+[ "$CHECK_ONLY" = false ] && info "Shared constraints → correctless/"
+
 # --- All 26 skills ---
 for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick crelease cexplain; do
   if [ "$CHECK_ONLY" = false ]; then

--- a/tests/test-cexplain.sh
+++ b/tests/test-cexplain.sh
@@ -505,15 +505,16 @@ test_r006_serena_mcp() {
     && local has_searchpat="true" || local has_searchpat="false"
   assert_eq "R-006: SKILL.md mentions search_for_pattern" "true" "$has_searchpat"
 
-  # A-4 fix: silent fallback behavior
-  file_contains "$skill" "[Ss]ilent\|[Dd]o not warn\|[Dd]o not abort" \
+  # A-4 fix: silent fallback behavior (now in shared constraints)
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains "$shared" "[Ss]ilent\|[Dd]o not warn\|[Dd]o not abort" \
     && local has_silent="true" || local has_silent="false"
-  assert_eq "R-006: SKILL.md specifies silent fallback (no warnings mid-operation)" "true" "$has_silent"
+  assert_eq "R-006: shared constraints specifies silent fallback (no warnings mid-operation)" "true" "$has_silent"
 
-  # QA-003 fix: do not retry instruction
-  file_contains "$skill" "do not retry" \
+  # QA-003 fix: do not retry instruction (now in shared constraints)
+  file_contains "$shared" "do not retry" \
     && local has_no_retry="true" || local has_no_retry="false"
-  assert_eq "R-006: SKILL.md specifies do not retry on Serena failure" "true" "$has_no_retry"
+  assert_eq "R-006: shared constraints specifies do not retry on Serena failure" "true" "$has_no_retry"
 }
 
 # ---------------------------------------------------------------------------
@@ -680,10 +681,11 @@ test_r012_token_logging() {
 
   local skill="$REPO_DIR/skills/cexplain/SKILL.md"
 
-  # Tests R-012 [unit]: token log path
-  file_contains "$skill" "\.correctless/artifacts/token-log" \
+  # Tests R-012 [unit]: token log path (now in shared constraints)
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains "$shared" "\.correctless/artifacts/token-log" \
     && local has_path="true" || local has_path="false"
-  assert_eq "R-012: SKILL.md mentions .correctless/artifacts/token-log path" "true" "$has_path"
+  assert_eq "R-012: shared constraints mentions .correctless/artifacts/token-log path" "true" "$has_path"
 
   # Tests R-012: skill field set to cexplain
   file_contains "$skill" '"cexplain"\|skill.*cexplain\|cexplain.*skill' \
@@ -700,20 +702,20 @@ test_r012_token_logging() {
     && local has_role="true" || local has_role="false"
   assert_eq "R-012: SKILL.md specifies agent_role: explain-agent" "true" "$has_role"
 
-  # Tests R-012: total_tokens field
-  file_contains "$skill" "total_tokens" \
+  # Tests R-012: total_tokens field (now in shared constraints)
+  file_contains "$shared" "total_tokens" \
     && local has_tokens="true" || local has_tokens="false"
-  assert_eq "R-012: SKILL.md specifies total_tokens field" "true" "$has_tokens"
+  assert_eq "R-012: shared constraints specifies total_tokens field" "true" "$has_tokens"
 
-  # Tests R-012: duration_ms field
-  file_contains "$skill" "duration_ms" \
+  # Tests R-012: duration_ms field (now in shared constraints)
+  file_contains "$shared" "duration_ms" \
     && local has_duration="true" || local has_duration="false"
-  assert_eq "R-012: SKILL.md specifies duration_ms field" "true" "$has_duration"
+  assert_eq "R-012: shared constraints specifies duration_ms field" "true" "$has_duration"
 
-  # Tests R-012: timestamp field
-  file_contains "$skill" "timestamp" \
+  # Tests R-012: timestamp field (now in shared constraints)
+  file_contains "$shared" "timestamp" \
     && local has_timestamp="true" || local has_timestamp="false"
-  assert_eq "R-012: SKILL.md specifies timestamp field" "true" "$has_timestamp"
+  assert_eq "R-012: shared constraints specifies timestamp field" "true" "$has_timestamp"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test-crelease.sh
+++ b/tests/test-crelease.sh
@@ -627,15 +627,16 @@ test_r016_skill_content() {
 
   local skill="$REPO_DIR/skills/crelease/SKILL.md"
 
-  # Tests R-016 [unit]: logs token usage to token-log-{slug}.json
-  file_contains "$skill" "token.*log\|token-log" \
+  # Tests R-016 [unit]: logs token usage (references shared constraints)
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains "$skill" "token.*log\|token-log\|shared constraints\|Token Logging" \
     && local has_token_log="true" || local has_token_log="false"
   assert_eq "R-016: SKILL.md mentions token logging" "true" "$has_token_log"
 
-  # Tests R-016: correct artifact path
-  file_contains "$skill" "\.correctless/artifacts/token-log" \
+  # Tests R-016: correct artifact path (now in shared constraints)
+  file_contains "$shared" "\.correctless/artifacts/token-log" \
     && local has_path="true" || local has_path="false"
-  assert_eq "R-016: SKILL.md specifies .correctless/artifacts/ token log path" "true" "$has_path"
+  assert_eq "R-016: shared constraints specifies .correctless/artifacts/ token log path" "true" "$has_path"
 
   # Tests R-016: skill field is crelease
   file_contains "$skill" '"crelease"\|skill.*crelease\|crelease.*skill' \
@@ -651,17 +652,17 @@ test_r016_skill_content() {
     && local has_role="true" || local has_role="false"
   assert_eq "R-016: SKILL.md specifies agent_role field" "true" "$has_role"
 
-  file_contains "$skill" "total_tokens" \
+  file_contains "$shared" "total_tokens" \
     && local has_tokens="true" || local has_tokens="false"
-  assert_eq "R-016: SKILL.md specifies total_tokens field" "true" "$has_tokens"
+  assert_eq "R-016: shared constraints specifies total_tokens field" "true" "$has_tokens"
 
-  file_contains "$skill" "duration_ms" \
+  file_contains "$shared" "duration_ms" \
     && local has_duration="true" || local has_duration="false"
-  assert_eq "R-016: SKILL.md specifies duration_ms field" "true" "$has_duration"
+  assert_eq "R-016: shared constraints specifies duration_ms field" "true" "$has_duration"
 
-  file_contains "$skill" "timestamp" \
+  file_contains "$shared" "timestamp" \
     && local has_timestamp="true" || local has_timestamp="false"
-  assert_eq "R-016: SKILL.md specifies timestamp field" "true" "$has_timestamp"
+  assert_eq "R-016: shared constraints specifies timestamp field" "true" "$has_timestamp"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test-dynamic-rigor.sh
+++ b/tests/test-dynamic-rigor.sh
@@ -106,7 +106,7 @@ test_r001_sync_single_dist() {
   # R-001: correctless/ must have all 26 skills
   local skill_count=0
   if [ -d "$REPO_DIR/correctless/skills" ]; then
-    skill_count="$(ls -d "$REPO_DIR/correctless/skills/"*/ 2>/dev/null | wc -l)"
+    skill_count="$(find "$REPO_DIR/correctless/skills" -name "SKILL.md" | wc -l)"
   fi
   assert_eq "R-001: correctless/ has 26 skills" "26" "$skill_count"
 
@@ -350,6 +350,13 @@ test_r006_intensity_gates() {
   echo ""
   echo "=== R-006: Full-only skills contain intensity gate ==="
 
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+
+  # R-006: shared constraints defaults to standard when intensity is absent (check once)
+  file_contains_i "$shared" "default.*standard\|absent.*standard\|not set.*standard\|missing.*standard" \
+    && local shared_has_default="true" || local shared_has_default="false"
+  assert_eq "R-006: shared constraints defaults to standard when intensity absent" "true" "$shared_has_default"
+
   local full_only_skills="caudit cmodel creview-spec cupdate-arch cpostmortem cdevadv credteam"
 
   for skill in $full_only_skills; do
@@ -370,10 +377,10 @@ test_r006_intensity_gates() {
         && local has_gate="true" || local has_gate="false"
       assert_eq "R-006: $skill has intensity gate language" "true" "$has_gate"
 
-      # R-006: gate defaults to standard when intensity is absent
-      file_contains_i "$skill_file" "default.*standard\|absent.*standard\|not set.*standard\|missing.*standard" \
-        && local has_default="true" || local has_default="false"
-      assert_eq "R-006: $skill defaults to standard when intensity absent" "true" "$has_default"
+      # R-006: skill references shared constraints (where default-to-standard lives)
+      file_contains "$skill_file" "_shared/constraints.md" \
+        && local has_shared_ref="true" || local has_shared_ref="false"
+      assert_eq "R-006: $skill references shared constraints" "true" "$has_shared_ref"
 
       # R-006: Intensity Gate section uses full config path
       # Extract lines around "Intensity Gate" and check for full path
@@ -449,8 +456,8 @@ test_r008_below_threshold_message() {
       && local has_required="true" || local has_required="false"
     assert_eq "R-008: $skill gate mentions required intensity" "true" "$has_required"
 
-    # R-008: gate message includes current intensity
-    file_contains_i "$skill_file" "current.*intensity\|project.*intensity\|configured.*intensity" \
+    # R-008: gate message includes effective/current intensity
+    file_contains_i "$skill_file" "current.*intensity\|project.*intensity\|configured.*intensity\|effective intensity" \
       && local has_current="true" || local has_current="false"
     assert_eq "R-008: $skill gate mentions current intensity" "true" "$has_current"
 

--- a/tests/test-mcp.sh
+++ b/tests/test-mcp.sh
@@ -311,11 +311,17 @@ test_r014() {
   echo ""
   echo "=== R-014: Silent fallback on Serena failure ==="
 
+  # Degradation instruction now lives in shared constraints
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains_i "$shared" "serena.*fall.back\|fall.back.*text-based" && local shared_found="true" || local shared_found="false"
+  assert_eq "R-014: shared constraints has Serena fallback instruction" "true" "$shared_found"
+
+  # Each Serena skill must reference the shared constraints
   for skill in $SERENA_SKILLS; do
     local skill_file="$REPO_DIR/skills/$skill/SKILL.md"
     if [ -f "$skill_file" ]; then
-      file_contains_i "$skill_file" "serena.*fall.back\|serena.*fallback\|fall.back.*serena\|fallback.*grep\|fall back.*text-based" && local found="true" || local found="false"
-      assert_eq "R-014: $skill has Serena fallback instruction" "true" "$found"
+      file_contains "$skill_file" "_shared/constraints.md" && local found="true" || local found="false"
+      assert_eq "R-014: $skill references shared constraints" "true" "$found"
     fi
   done
 }
@@ -328,11 +334,17 @@ test_r015() {
   echo ""
   echo "=== R-015: End-of-run Serena failure notification ==="
 
+  # End-of-run notification now lives in shared constraints
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains_i "$shared" "serena was unavailable\|notify.*once.*end" && local shared_found="true" || local shared_found="false"
+  assert_eq "R-015: shared constraints has end-of-run notification" "true" "$shared_found"
+
+  # Each Serena skill must reference the shared constraints
   for skill in $SERENA_SKILLS; do
     local skill_file="$REPO_DIR/skills/$skill/SKILL.md"
     if [ -f "$skill_file" ]; then
-      file_contains_i "$skill_file" "serena was unavailable\|end.*of.*run.*notif\|notify.*once.*end\|single.*notification.*end" && local found="true" || local found="false"
-      assert_eq "R-015: $skill has end-of-run notification" "true" "$found"
+      file_contains "$skill_file" "_shared/constraints.md" && local found="true" || local found="false"
+      assert_eq "R-015: $skill references shared constraints" "true" "$found"
     fi
   done
 }
@@ -345,12 +357,17 @@ test_r016() {
   echo ""
   echo "=== R-016: Context7 failure fallback pattern ==="
 
+  # Context7 degradation instruction now lives in shared constraints
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains_i "$shared" "context7.*unavailable\|context7.*fall.back.*web.*search" && local shared_found="true" || local shared_found="false"
+  assert_eq "R-016: shared constraints has Context7 fallback instruction" "true" "$shared_found"
+
+  # Each Context7 skill must reference the shared constraints
   for skill in $CONTEXT7_SKILLS; do
     local skill_file="$REPO_DIR/skills/$skill/SKILL.md"
     if [ -f "$skill_file" ]; then
-      # Context7 fallback to web search
-      file_contains_i "$skill_file" "context7.*fallback\|context7.*web.*search\|web.*search.*context7\|context7.*unavailable" && local found="true" || local found="false"
-      assert_eq "R-016: $skill has Context7 fallback instruction" "true" "$found"
+      file_contains "$skill_file" "_shared/constraints.md" && local found="true" || local found="false"
+      assert_eq "R-016: $skill references shared constraints" "true" "$found"
     fi
   done
 }
@@ -363,11 +380,17 @@ test_r017() {
   echo ""
   echo "=== R-017: MCP servers are optimizers, not dependencies ==="
 
+  # Optimizer-not-dependency instruction now lives in shared constraints
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+  file_contains_i "$shared" "optimizer.*not.*dependenc\|not.*dependenc.*MCP" && local shared_found="true" || local shared_found="false"
+  assert_eq "R-017: shared constraints has optimizer-not-dependency instruction" "true" "$shared_found"
+
+  # Each Serena skill must reference the shared constraints
   for skill in $SERENA_SKILLS; do
     local skill_file="$REPO_DIR/skills/$skill/SKILL.md"
     if [ -f "$skill_file" ]; then
-      file_contains_i "$skill_file" "MCP.*not.*dependenc\|serena.*not.*dependenc\|optimizer.*not.*dependenc\|not.*dependenc.*MCP\|MCP.*optimizer" && local found="true" || local found="false"
-      assert_eq "R-017: $skill treats MCP as optimizer not dependency" "true" "$found"
+      file_contains "$skill_file" "_shared/constraints.md" && local found="true" || local found="false"
+      assert_eq "R-017: $skill references shared constraints" "true" "$found"
     fi
   done
 }

--- a/tests/test-wire-intensity-creview.sh
+++ b/tests/test-wire-intensity-creview.sh
@@ -190,38 +190,43 @@ test_r002_effective_intensity_section() {
   echo "=== R-002: /creview SKILL.md has Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/creview/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-002: section header exists
+  # R-002: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-002: creview SKILL.md has '## Effective Intensity' section"
 
-  # R-002: max computation documented
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-002: documents max(project_intensity, feature_intensity) computation"
+  # R-002: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-002: creview SKILL.md references shared constraints"
 
-  # R-002: ordering documented
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-002: documents ordering standard < high < critical"
+  # R-002: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-002: shared constraints documents max(project_intensity, feature_intensity) computation"
 
-  # R-002: references workflow.intensity from config
-  file_contains "$skill_file" "workflow.intensity" \
-    "R-002: references workflow.intensity from config"
+  # R-002: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-002: shared constraints documents ordering standard < high < critical"
 
-  # R-002: references reading project intensity from workflow-config.json
-  file_contains_i "$skill_file" "workflow.intensity.*workflow-config.json\|workflow-config.json.*workflow.intensity\|project.*intensity.*config" \
-    "R-002: references reading project intensity from workflow-config.json"
+  # R-002: shared constraints references workflow.intensity from config
+  file_contains "$shared" "workflow.intensity" \
+    "R-002: shared constraints references workflow.intensity from config"
 
-  # R-002: references feature_intensity from workflow state
-  file_contains "$skill_file" "feature_intensity" \
-    "R-002: references feature_intensity"
+  # R-002: shared constraints references reading project intensity from workflow-config.json
+  file_contains_i "$shared" "workflow.intensity.*workflow-config.json\|workflow-config.json.*workflow.intensity\|project.*intensity.*config" \
+    "R-002: shared constraints references reading project intensity from workflow-config.json"
 
-  # R-002: references workflow-advance.sh status as the interface
-  file_contains "$skill_file" "workflow-advance.sh status" \
-    "R-002: instructs reading via workflow-advance.sh status"
+  # R-002: shared constraints references feature_intensity
+  file_contains "$shared" "feature_intensity" \
+    "R-002: shared constraints references feature_intensity"
 
-  # R-002: absent feature_intensity defaults to project intensity alone
-  file_contains_i "$skill_file" "feature_intensity.*absent.*project\|absent.*feature_intensity.*project\|feature_intensity is absent" \
-    "R-002: absent feature_intensity falls back to project intensity"
+  # R-002: shared constraints references workflow-advance.sh status as the interface
+  file_contains "$shared" "workflow-advance.sh status" \
+    "R-002: shared constraints instructs reading via workflow-advance.sh status"
+
+  # R-002: shared constraints handles absent feature_intensity
+  file_contains_i "$shared" "feature_intensity.*absent\|absent.*feature_intensity\|feature_intensity is absent" \
+    "R-002: shared constraints handles absent feature_intensity"
 }
 
 # ============================================
@@ -385,20 +390,20 @@ test_r006_status_outputs_feature_intensity() {
 
   cleanup
 
-  # R-006 [unit]: SKILL.md instructs reading from status output
+  # R-006 [unit]: shared constraints instruct reading from status output
   local skill_file="$REPO_DIR/skills/creview/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  file_contains "$skill_file" "workflow-advance.sh status" \
-    "R-006: SKILL.md instructs reading feature_intensity from status output"
+  file_contains "$shared" "workflow-advance.sh status" \
+    "R-006: shared constraints instructs reading feature_intensity from status output"
 
-  # R-006: SKILL.md instructs NOT parsing state file directly
-  # (the instruction should reference status, not direct JSON parsing)
-  file_not_contains "$skill_file" "workflow-state-.*json" \
-    "R-006: SKILL.md does not instruct parsing state file directly"
+  # R-006: shared constraints instructs NOT parsing state file directly
+  file_not_contains "$shared" "workflow-state-.*json" \
+    "R-006: shared constraints does not instruct parsing state file directly"
 
-  # R-006: SKILL.md handles absent Intensity line gracefully
-  file_contains_i "$skill_file" "no.*Intensity line\|Intensity.*absent\|absent.*feature_intensity\|Intensity line.*absent" \
-    "R-006: SKILL.md handles absent Intensity line in status output"
+  # R-006: shared constraints handles absent Intensity line gracefully
+  file_contains_i "$shared" "no.*Intensity line\|Intensity.*absent\|absent.*feature_intensity\|Intensity line.*absent" \
+    "R-006: shared constraints handles absent Intensity line in status output"
 }
 
 # ============================================
@@ -440,6 +445,14 @@ test_r008_gated_skills_effective_intensity() {
   echo ""
   echo "=== R-008: All 7 gated skills use effective intensity ==="
 
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+
+  # R-008: shared constraints has max computation and both intensity sources
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-008: shared constraints has max(project_intensity, feature_intensity)"
+  file_contains "$shared" "feature_intensity" \
+    "R-008: shared constraints references feature_intensity"
+
   local gated_skills=(
     "$REPO_DIR/skills/caudit/SKILL.md"
     "$REPO_DIR/skills/cdevadv/SKILL.md"
@@ -454,15 +467,13 @@ test_r008_gated_skills_effective_intensity() {
     local skill_name
     skill_name="$(basename "$(dirname "$skill_file")")"
 
-    # R-008: each gated skill references max(project_intensity, feature_intensity)
-    file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-      "R-008: $skill_name references max(project_intensity, feature_intensity)"
+    # R-008: each gated skill references shared constraints
+    file_contains "$skill_file" "_shared/constraints.md" \
+      "R-008: $skill_name references shared constraints"
 
-    # R-008: each gated skill references both workflow.intensity AND feature_intensity
+    # R-008: each gated skill still references workflow.intensity (in override instructions)
     file_contains "$skill_file" "workflow.intensity" \
       "R-008: $skill_name references workflow.intensity"
-    file_contains "$skill_file" "feature_intensity" \
-      "R-008: $skill_name references feature_intensity"
   done
 }
 
@@ -474,6 +485,14 @@ test_r008_gated_skills_effective_intensity() {
 test_r009_consistent_max_computation() {
   echo ""
   echo "=== R-009: Consistent max(project_intensity, feature_intensity) across all skills ==="
+
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+
+  # R-009: shared constraints contains the max computation and ordering (check once)
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-009: shared constraints contains max(project_intensity, feature_intensity)"
+  file_contains "$shared" "standard < high < critical" \
+    "R-009: shared constraints contains ordering standard < high < critical"
 
   local all_skills=(
     "$REPO_DIR/skills/creview/SKILL.md"
@@ -490,13 +509,9 @@ test_r009_consistent_max_computation() {
     local skill_name
     skill_name="$(basename "$(dirname "$skill_file")")"
 
-    # R-009: each skill contains the max computation string
-    file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-      "R-009: $skill_name contains max(project_intensity, feature_intensity)"
-
-    # R-009: each skill contains the ordering string
-    file_contains "$skill_file" "standard < high < critical" \
-      "R-009: $skill_name contains ordering standard < high < critical"
+    # R-009: each skill references shared constraints
+    file_contains "$skill_file" "_shared/constraints.md" \
+      "R-009: $skill_name references shared constraints"
   done
 
   # R-009: max computation is NOT in workflow-advance.sh (LLM instruction only)
@@ -543,22 +558,23 @@ test_r011_fallback_chain() {
   echo "=== R-011: Fallback chain documented ==="
 
   local skill_file="$REPO_DIR/skills/creview/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-011: fallback chain documented
-  file_contains_i "$skill_file" "feature_intensity.*workflow.intensity.*standard\|fallback.*chain\|falls back" \
-    "R-011: documents fallback chain"
+  # R-011: shared constraints documents fallback chain
+  file_contains_i "$shared" "feature_intensity.*workflow.intensity.*standard\|fallback.*chain\|falls back" \
+    "R-011: shared constraints documents fallback chain"
 
-  # R-011: default is standard when both absent
-  file_contains_i "$skill_file" "default.*standard\|defaults to.*standard" \
-    "R-011: defaults to standard when config absent"
+  # R-011: shared constraints defaults to standard when both absent
+  file_contains_i "$shared" "default.*standard\|defaults to.*standard" \
+    "R-011: shared constraints defaults to standard when config absent"
 
-  # R-011: no active workflow handled gracefully — review still runs
-  file_contains_i "$skill_file" "no active workflow\|no.*state file\|no.*workflow state" \
-    "R-011: handles no active workflow gracefully"
+  # R-011: shared constraints handles no active workflow gracefully
+  file_contains_i "$shared" "no active workflow\|no.*state file\|no.*workflow state" \
+    "R-011: shared constraints handles no active workflow gracefully"
 
-  # R-011: review still runs without active workflow state
-  file_contains_i "$skill_file" "review still runs\|still runs\|does not require.*workflow" \
-    "R-011: review still runs without active workflow state"
+  # R-011: shared constraints says skill still runs without active workflow state
+  file_contains_i "$shared" "still runs\|does not require.*workflow" \
+    "R-011: shared constraints says skill still runs without active workflow state"
 
   # R-011 [integration]: test that status with no feature_intensity omits the line
   setup_test_project

--- a/tests/test-wire-intensity-pipeline.sh
+++ b/tests/test-wire-intensity-pipeline.sh
@@ -178,33 +178,38 @@ test_r002_cspec_effective_intensity() {
   echo "=== R-002: /cspec SKILL.md has verbatim Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/cspec/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-002: section header exists
+  # R-002: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-002: cspec SKILL.md has '## Effective Intensity' section"
 
-  # R-002: max computation
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-002: documents max(project_intensity, feature_intensity)"
+  # R-002: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-002: cspec SKILL.md references shared constraints"
 
-  # R-002: ordering
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-002: documents ordering standard < high < critical"
+  # R-002: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-002: shared constraints documents max(project_intensity, feature_intensity)"
 
-  # R-002: 3-step process
-  file_contains "$skill_file" "Read project intensity" \
+  # R-002: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-002: shared constraints documents ordering standard < high < critical"
+
+  # R-002: shared constraints has 3-step process
+  file_contains "$shared" "Read project intensity" \
     "R-002: step 1 — Read project intensity"
-  file_contains "$skill_file" "Read feature intensity" \
+  file_contains "$shared" "Read feature intensity" \
     "R-002: step 2 — Read feature intensity"
-  file_contains "$skill_file" "Compute effective intensity" \
+  file_contains "$shared" "Compute effective intensity" \
     "R-002: step 3 — Compute effective intensity"
 
-  # R-002: fallback chain
-  file_contains "$skill_file" "feature_intensity -> workflow.intensity -> standard" \
+  # R-002: shared constraints has fallback chain
+  file_contains "$shared" "feature_intensity -> workflow.intensity -> standard" \
     "R-002: fallback chain documented"
 
-  # R-002: no-active-workflow handling
-  file_contains_i "$skill_file" "no active workflow state\|no state file" \
+  # R-002: shared constraints handles no-active-workflow
+  file_contains_i "$shared" "no active workflow state\|no state file" \
     "R-002: handles no active workflow state"
 }
 
@@ -343,25 +348,30 @@ test_r006_ctdd_effective_intensity() {
   echo "=== R-006: /ctdd SKILL.md has verbatim Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/ctdd/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-006: section header exists
+  # R-006: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-006: ctdd SKILL.md has '## Effective Intensity' section"
 
-  # R-006: max computation
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-006: documents max(project_intensity, feature_intensity)"
+  # R-006: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-006: ctdd SKILL.md references shared constraints"
 
-  # R-006: ordering
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-006: documents ordering standard < high < critical"
+  # R-006: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-006: shared constraints documents max(project_intensity, feature_intensity)"
 
-  # R-006: fallback chain
-  file_contains "$skill_file" "feature_intensity -> workflow.intensity -> standard" \
+  # R-006: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-006: shared constraints documents ordering standard < high < critical"
+
+  # R-006: shared constraints has fallback chain
+  file_contains "$shared" "feature_intensity -> workflow.intensity -> standard" \
     "R-006: fallback chain documented"
 
-  # R-006: no-active-workflow handling
-  file_contains_i "$skill_file" "no active workflow state\|no state file" \
+  # R-006: shared constraints handles no-active-workflow
+  file_contains_i "$shared" "no active workflow state\|no state file" \
     "R-006: handles no active workflow state"
 }
 
@@ -481,25 +491,30 @@ test_r010_cverify_effective_intensity() {
   echo "=== R-010: /cverify SKILL.md has verbatim Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/cverify/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-010: section header exists
+  # R-010: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-010: cverify SKILL.md has '## Effective Intensity' section"
 
-  # R-010: max computation
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-010: documents max(project_intensity, feature_intensity)"
+  # R-010: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-010: cverify SKILL.md references shared constraints"
 
-  # R-010: ordering
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-010: documents ordering standard < high < critical"
+  # R-010: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-010: shared constraints documents max(project_intensity, feature_intensity)"
 
-  # R-010: fallback chain
-  file_contains "$skill_file" "feature_intensity -> workflow.intensity -> standard" \
+  # R-010: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-010: shared constraints documents ordering standard < high < critical"
+
+  # R-010: shared constraints has fallback chain
+  file_contains "$shared" "feature_intensity -> workflow.intensity -> standard" \
     "R-010: fallback chain documented"
 
-  # R-010: no-active-workflow handling
-  file_contains_i "$skill_file" "no active workflow state\|no state file" \
+  # R-010: shared constraints handles no-active-workflow
+  file_contains_i "$shared" "no active workflow state\|no state file" \
     "R-010: handles no active workflow state"
 }
 
@@ -607,25 +622,30 @@ test_r014_cdocs_effective_intensity() {
   echo "=== R-014: /cdocs SKILL.md has verbatim Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/cdocs/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-014: section header exists
+  # R-014: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-014: cdocs SKILL.md has '## Effective Intensity' section"
 
-  # R-014: max computation
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-014: documents max(project_intensity, feature_intensity)"
+  # R-014: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-014: cdocs SKILL.md references shared constraints"
 
-  # R-014: ordering
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-014: documents ordering standard < high < critical"
+  # R-014: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-014: shared constraints documents max(project_intensity, feature_intensity)"
 
-  # R-014: fallback chain
-  file_contains "$skill_file" "feature_intensity -> workflow.intensity -> standard" \
+  # R-014: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-014: shared constraints documents ordering standard < high < critical"
+
+  # R-014: shared constraints has fallback chain
+  file_contains "$shared" "feature_intensity -> workflow.intensity -> standard" \
     "R-014: fallback chain documented"
 
-  # R-014: no-active-workflow handling
-  file_contains_i "$skill_file" "no active workflow state\|no state file" \
+  # R-014: shared constraints handles no-active-workflow
+  file_contains_i "$shared" "no active workflow state\|no state file" \
     "R-014: handles no active workflow state"
 }
 
@@ -723,25 +743,30 @@ test_r018_cstatus_effective_intensity() {
   echo "=== R-018: /cstatus SKILL.md has verbatim Effective Intensity section ==="
 
   local skill_file="$REPO_DIR/skills/cstatus/SKILL.md"
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
 
-  # R-018: section header exists
+  # R-018: section header exists in SKILL.md
   file_contains "$skill_file" "## Effective Intensity" \
     "R-018: cstatus SKILL.md has '## Effective Intensity' section"
 
-  # R-018: max computation
-  file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-    "R-018: documents max(project_intensity, feature_intensity)"
+  # R-018: SKILL.md references shared constraints
+  file_contains "$skill_file" "_shared/constraints.md" \
+    "R-018: cstatus SKILL.md references shared constraints"
 
-  # R-018: ordering
-  file_contains "$skill_file" "standard < high < critical" \
-    "R-018: documents ordering standard < high < critical"
+  # R-018: shared constraints has max computation
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-018: shared constraints documents max(project_intensity, feature_intensity)"
 
-  # R-018: fallback chain
-  file_contains "$skill_file" "feature_intensity -> workflow.intensity -> standard" \
+  # R-018: shared constraints has ordering
+  file_contains "$shared" "standard < high < critical" \
+    "R-018: shared constraints documents ordering standard < high < critical"
+
+  # R-018: shared constraints has fallback chain
+  file_contains "$shared" "feature_intensity -> workflow.intensity -> standard" \
     "R-018: fallback chain documented"
 
-  # R-018: no-active-workflow handling
-  file_contains_i "$skill_file" "no active workflow state\|no state file" \
+  # R-018: shared constraints handles no-active-workflow
+  file_contains_i "$shared" "no active workflow state\|no state file" \
     "R-018: handles no active workflow state"
 }
 
@@ -801,6 +826,14 @@ test_r021_cross_cutting_consistency() {
   echo ""
   echo "=== R-021: All 6 pipeline skills have max() and ordering ==="
 
+  local shared="$REPO_DIR/skills/_shared/constraints.md"
+
+  # R-021: shared constraints contains the computation and ordering (check once)
+  file_contains "$shared" "max(project_intensity, feature_intensity)" \
+    "R-021: shared constraints contains max(project_intensity, feature_intensity)"
+  file_contains "$shared" "standard < high < critical" \
+    "R-021: shared constraints contains ordering standard < high < critical"
+
   local pipeline_skills=(
     "$REPO_DIR/skills/cspec/SKILL.md"
     "$REPO_DIR/skills/ctdd/SKILL.md"
@@ -814,13 +847,9 @@ test_r021_cross_cutting_consistency() {
     local skill_name
     skill_name="$(basename "$(dirname "$skill_file")")"
 
-    # R-021: each skill contains max(project_intensity, feature_intensity)
-    file_contains "$skill_file" "max(project_intensity, feature_intensity)" \
-      "R-021: $skill_name contains max(project_intensity, feature_intensity)"
-
-    # R-021: each skill contains ordering standard < high < critical
-    file_contains "$skill_file" "standard < high < critical" \
-      "R-021: $skill_name contains ordering standard < high < critical"
+    # R-021: each skill references shared constraints
+    file_contains "$skill_file" "_shared/constraints.md" \
+      "R-021: $skill_name references shared constraints"
   done
 }
 


### PR DESCRIPTION
## Summary

- Extract ~125 instances of 7 duplicated constraint patterns from 26 SKILL.md files into `skills/_shared/constraints.md`
- Each skill now references the shared file instead of inlining identical boilerplate — one place to update conventions instead of 14-26 files
- Net reduction: 215 lines across 52 SKILL.md files (61 files changed total including tests and sync.sh)

### Extracted patterns
1. **Skill boundary** — "never auto-invoke the next skill" (was in 8 skills)
2. **Evidence standard** — "evidence before claims" + "all files inside project directory" (was in 3 skills)
3. **Context management** — 70%/85% thresholds (was in 5 skills)
4. **Effective intensity computation** — 3-step max(project, feature) + fallback chain (was in 13 skills)
5. **Token tracking** — JSON schema for token-log artifacts (was in 16 skills)
6. **Serena graceful degradation** — silent fallback, end-of-run notification, optimizer-not-dependency (was in 15 skills)
7. **Context7 fallback** — web search fallback + notification (was in 5 skills)

### Test changes
7 test files adapted to follow the reference chain (SKILL.md → shared file → constraint text). Same invariants tested, structurally different assertions. All 1,996 tests pass across 17 test files.

### QA findings
4 non-blocking findings caught and fixed: 3 skill-specific qualifiers accidentally lost during token tracking extraction (cmaintain mkdir, cspec conditional logging, cdevadv signals-mode-only), 1 accidental test pass (cexplain timestamp matched HTML export instead of token schema).

## Test plan
- [x] All 17 test files pass with 0 failures
- [x] `sync.sh --check` passes (distribution mirrors source)
- [x] Pre-commit hooks pass (shellcheck, sync check, typos)
- [x] QA agent reviewed for behavioral drift — 4 findings fixed
- [x] No skill-specific content lost (verified by QA)