### PR TITLE
Replace stale Lite/Full terminology with intensity levels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,10 +20,11 @@ assignees: ''
 
 <!-- e.g., /ctdd, /cverify, workflow-gate.sh, statusline -->
 
-## Mode
+## Intensity Level
 
-- [ ] Lite
-- [ ] Full
+- [ ] Standard
+- [ ] High
+- [ ] Critical
 
 ## Environment
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,11 +18,12 @@ assignees: ''
 
 <!-- Did you consider other approaches? Why is this one better? -->
 
-## Which version?
+## Which intensity level?
 
-- [ ] Lite (everyday development)
-- [ ] Full (security-critical)
-- [ ] Both
+- [ ] Standard (everyday development)
+- [ ] High (complex/security-sensitive)
+- [ ] Critical (highest rigor)
+- [ ] All levels
 
 ## Additional context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 
-## Correctless Lite
+## Correctless
 
-This project uses Correctless Lite for structured development.
+This project uses Correctless for structured development.
 Read .correctless/AGENT_CONTEXT.md before starting any work.
 Available commands: /csetup, /cspec, /creview, /ctdd, /cverify, /cdocs, /crefactor, /cpr-review, /cstatus, /csummary, /cmetrics, /cdebug, /chelp
 

--- a/docs/skills/caudit.md
+++ b/docs/skills/caudit.md
@@ -14,7 +14,7 @@
 
 Runs independently of the main spec-to-merge pipeline. The TDD cycle catches "does this feature work?" bugs. The Olympics catch "how does this feature break everything else?" and "how does an attacker abuse this feature?" bugs. Operates on a dedicated audit branch; fixes never go directly to main.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 

--- a/docs/skills/ccontribute.md
+++ b/docs/skills/ccontribute.md
@@ -65,9 +65,9 @@ User: They prefer small PRs, one concern each.
 | 5 recently merged PRs (for calibration) | |
 | Linked issue (via `gh issue view`) | |
 
-## Lite vs Full
+## Intensity Levels
 
-Same in both modes. This skill operates on the target project's conventions, not the Correctless workflow intensity.
+Same at all intensity levels. This skill operates on the target project's conventions, not the Correctless workflow intensity.
 
 ## Common Issues
 

--- a/docs/skills/cdebug.md
+++ b/docs/skills/cdebug.md
@@ -78,9 +78,9 @@ Agent: Bisect found commit `a3f2c91`: "refactor: reorganize middleware"
 | `.correctless/meta/drift-debt.json` | Test and source files (fix) |
 | Git history and blame | |
 
-## Lite vs Full
+## Intensity Levels
 
-Both modes run the same investigation workflow. There is no difference in `/cdebug` behavior between Lite and Full — bug investigation follows the same systematic process regardless of workflow intensity.
+Same at all intensity levels. There is no difference in `/cdebug` behavior — bug investigation follows the same systematic process regardless of intensity.
 
 ## Common Issues
 

--- a/docs/skills/cdevadv.md
+++ b/docs/skills/cdevadv.md
@@ -15,7 +15,7 @@
 
 Runs periodically, not per-feature. Every other agent in the pipeline (spec author, reviewer, test writer, QA, auditor) operates within the frame of "this project's design is fundamentally sound." The devil's advocate questions whether the frame itself is correct. It checks whether the spec is pointing in the wrong direction, not whether the code matches the spec.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 

--- a/docs/skills/cdocs.md
+++ b/docs/skills/cdocs.md
@@ -59,9 +59,9 @@ Agent: Diff analysis complete — 1 new feature (login rate limiting),
 | Git diff against main | `CLAUDE.md` (convention learning, if 3+ features share a pattern) |
 | | Workflow state (advances to documented) |
 
-## Lite vs Full
+## Intensity Levels
 
-Both modes run the same documentation checks. Full mode includes convention learning — if the same architectural pattern has appeared in 3+ features, it appends a "Convention confirmed" entry to `CLAUDE.md` so future agents treat it as an established project convention.
+Same at all intensity levels for documentation checks. At high/critical intensity, convention learning is included — if the same architectural pattern has appeared in 3+ features, it appends a "Convention confirmed" entry to `CLAUDE.md` so future agents treat it as an established project convention.
 
 ## Common Issues
 

--- a/docs/skills/cexplain.md
+++ b/docs/skills/cexplain.md
@@ -69,9 +69,9 @@ Agent: [sequenceDiagram showing request flow]
        4. Export to HTML
 ```
 
-## Lite vs Full
+## Intensity Levels
 
-`/cexplain` works the same in both Lite and Full. When Serena MCP is available (Full mode with MCP configured), symbol tracing is more precise. Without Serena, the skill uses grep-based analysis.
+`/cexplain` works the same at all intensity levels. When Serena MCP is available (with MCP configured), symbol tracing is more precise. Without Serena, the skill uses grep-based analysis.
 
 ## Common Issues
 

--- a/docs/skills/chelp.md
+++ b/docs/skills/chelp.md
@@ -10,13 +10,13 @@
 
 ## How It Fits in the Workflow
 
-This skill can be invoked at any time. It is a read-only reference card that detects whether you are in Lite or Full mode and shows the relevant commands.
+This skill can be invoked at any time. It is a read-only reference card that detects the current intensity level and shows the relevant commands.
 
 ## What It Does
 
-- Detects the current mode (not set up / Lite / Full) from `.correctless/config/workflow-config.json`.
+- Detects the current intensity level (not set up / standard / high / critical) from `.correctless/config/workflow-config.json`.
 - Prints the pipeline diagram for your mode.
-- Lists all available commands grouped by category (feature workflow, standalone tools, Full-mode additions).
+- Lists all available commands grouped by category (feature workflow, standalone tools, high+ intensity additions).
 - Shows a quick-reference table mapping common tasks to commands.
 
 ## Example
@@ -24,7 +24,7 @@ This skill can be invoked at any time. It is a read-only reference card that det
 ```
 User: /chelp
 
-Correctless Lite — Workflow Pipeline:
+Correctless — Workflow Pipeline:
   /cspec -> /creview -> /ctdd [RED -> test audit -> GREEN -> /simplify -> QA] -> /cverify -> /cdocs -> merge
 
 Feature workflow:
@@ -55,7 +55,7 @@ No active workflow. Start one: git checkout -b feature/my-feature then /cspec
 | `.correctless/config/workflow-config.json` | Nothing (read-only) |
 | `.correctless/hooks/workflow-advance.sh` (status output) | |
 
-## Lite vs Full
+## Intensity Levels
 
-- **Lite mode**: Shows the Lite pipeline and Lite commands only.
-- **Full mode**: Adds the Full pipeline diagram and Full-only commands (`/cmodel`, `/creview-spec`, `/caudit`, `/cupdate-arch`, `/cpostmortem`, `/cdevadv`, `/credteam`).
+- **Standard intensity**: Shows the standard pipeline and standard commands only.
+- **High/critical intensity**: Adds the extended pipeline diagram and high+ intensity commands (`/cmodel`, `/creview-spec`, `/caudit`, `/cupdate-arch`, `/cpostmortem`, `/cdevadv`, `/credteam`).

--- a/docs/skills/cmaintain.md
+++ b/docs/skills/cmaintain.md
@@ -73,9 +73,9 @@ Recommendation: ask contributor to split the refactor into a separate PR.
 | Contributor's merged PR history | |
 | Linked issue | |
 
-## Lite vs Full
+## Intensity Levels
 
-Same in both modes. The maintainer review applies regardless of workflow intensity.
+Same at all intensity levels. The maintainer review applies regardless of intensity.
 
 ## Common Issues
 

--- a/docs/skills/cmetrics.md
+++ b/docs/skills/cmetrics.md
@@ -6,7 +6,7 @@
 
 - Monthly, to track how the workflow is performing over time.
 - Before presenting to stakeholders, to justify the workflow investment with data.
-- When deciding whether to upgrade from Lite to Full mode.
+- When deciding whether to increase workflow intensity.
 - When something feels off — metrics reveal which phases are pulling weight and which are not.
 - **Not for:** Single-feature summaries (use `/csummary`), or checking current workflow state (use `/cstatus`).
 
@@ -81,10 +81,10 @@ User: /cmetrics
 | `docs/decisions/*.md` | |
 | Git log | |
 
-## Lite vs Full
+## Intensity Levels
 
-- **Lite mode**: Omits Olympics convergence analysis and Olympics history table (those features are Full-only).
-- **Full mode**: Adds Olympics history, convergence speed analysis, and audit-specific metrics.
+- **Standard intensity**: Omits Olympics convergence analysis and Olympics history table (those features require high+ intensity).
+- **High/critical intensity**: Adds Olympics history, convergence speed analysis, and audit-specific metrics.
 
 ## Common Issues
 

--- a/docs/skills/cmodel.md
+++ b/docs/skills/cmodel.md
@@ -13,7 +13,7 @@
 
 Runs after `/cspec` (spec phase) and before `/creview-spec`. The modeling phase sits between "what should the system do" and "is the spec actually correct." Finds design bugs while they are still cheap to fix.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 
@@ -48,9 +48,9 @@ You revise the spec to require atomic check-and-consume, then advance to `/crevi
 - **Temporal operators.** Claude's reliability with `always`, `after`, and `until` in Alloy is inconsistent for complex formulas. Review temporal assertions carefully.
 - **Wrong model, correct analysis.** A correct analysis of a wrong model creates false confidence. The human review step is load-bearing — always verify the model represents the real system.
 
-## Lite vs Full
+## Intensity Levels
 
-This skill is **Full mode only**. In Lite mode, formal modeling is skipped entirely. Features go directly from `/cspec` to `/creview` (the single-pass review). If your feature involves state machines or trust boundaries and you are in Lite mode, consider upgrading to Full for this feature.
+This skill **requires high intensity or above**. At standard intensity, formal modeling is skipped entirely. Features go directly from `/cspec` to `/creview` (the single-pass review). If your feature involves state machines or trust boundaries and you are at standard intensity, consider increasing workflow intensity for this feature.
 
 ## Limitations
 

--- a/docs/skills/cpostmortem.md
+++ b/docs/skills/cpostmortem.md
@@ -13,7 +13,7 @@
 
 Runs outside the normal pipeline, triggered by a production bug or post-merge discovery. Does not touch code. Analyzes the gap in the process (spec, review, TDD, QA, audit) and produces class-level corrective actions that prevent the entire category of bug from recurring. Feeds learnings back into CLAUDE.md so every future agent session benefits.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 
@@ -59,9 +59,9 @@ The PMB entry is written, phase effectiveness counters are updated (review-spec 
 | Invariant template update | Adds a rule to spec templates so future specs include it | The spec domain template should have required this invariant |
 | Drift debt (DRIFT-xxx) | Tracks unresolved architectural drift | The bug reveals a gap between docs and reality |
 
-## Lite vs Full
+## Intensity Levels
 
-This skill is **Full mode only**. In Lite mode, post-merge bug analysis is done manually. The structured tracing across workflow phases and automatic learning propagation require the full agent pipeline.
+This skill **requires high intensity or above**. At standard intensity, post-merge bug analysis is done manually. The structured tracing across workflow phases and automatic learning propagation require the extended agent pipeline.
 
 ## Common Issues
 

--- a/docs/skills/cpr-review.md
+++ b/docs/skills/cpr-review.md
@@ -18,7 +18,7 @@ This skill is standalone — it does not require an active Correctless workflow.
 - Fetches PR info and diff via `gh` (GitHub) or `glab` (GitLab). Falls back to manual diff paste if neither CLI is available.
 - **Auto-detects dependency bump PRs** by checking the PR author (Dependabot, Renovate, etc.), changed files, and title patterns. When detected, it switches to a dependency-specific lens: runs the test suite, analyzes project usage of the bumped package, fetches changelog/release notes, checks CVEs, and assesses breaking changes.
 - For code PRs, runs focused checks in sequence: architecture compliance, security checklist, test coverage analysis, antipattern scan, convention compliance, and spec alignment (if a spec is linked).
-- In Full mode, adds concurrency analysis, trust boundary checks, cross-spec impact, drift detection, performance implications, and dependency risk.
+- At high/critical intensity, adds concurrency analysis, trust boundary checks, cross-spec impact, drift detection, performance implications, and dependency risk.
 - Groups all findings by severity (CRITICAL / HIGH / MEDIUM / LOW) with file:line references, explanations, and suggested fixes. Always includes a "What Looks Good" section.
 
 ## Example
@@ -58,10 +58,10 @@ User: /cpr-review 42
 | `.correctless/config/workflow-config.json` | |
 | `.correctless/specs/*.md` (if referenced) | |
 
-## Lite vs Full
+## Intensity Levels
 
-- **Lite mode**: Runs architecture, security, test coverage, antipattern, convention, and spec alignment checks.
-- **Full mode** (any `workflow.intensity` set): Adds concurrency analysis, trust boundary analysis, cross-spec impact, drift detection, performance implications, and dependency risk assessment.
+- **Standard intensity**: Runs architecture, security, test coverage, antipattern, convention, and spec alignment checks.
+- **High/critical intensity** (any `workflow.intensity` set): Adds concurrency analysis, trust boundary analysis, cross-spec impact, drift detection, performance implications, and dependency risk assessment.
 
 ## Common Issues
 

--- a/docs/skills/cquick.md
+++ b/docs/skills/cquick.md
@@ -38,9 +38,9 @@ Agent: Checking branch... on fix/typo-in-readme. Good.
        Committed: "Fix typo in configuration example"
 ```
 
-## Lite vs Full
+## Intensity Levels
 
-`/cquick` works the same in both modes. It deliberately skips all ceremony — that's the point.
+`/cquick` works the same at all intensity levels. It deliberately skips all ceremony — that's the point.
 
 ## Common Issues
 

--- a/docs/skills/credteam.md
+++ b/docs/skills/credteam.md
@@ -13,7 +13,7 @@
 
 Runs after Hacker Olympics fixes are applied. The recommended sequence is: Hacker Olympics (static, finds code-level flaws) then Red Team (live, proves exploitability) then Devil's Advocate (periodic, challenges the security approach itself). The red team finds integration gaps, runtime behavior, and defense chain failures that no amount of code reading can surface.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 

--- a/docs/skills/crefactor.md
+++ b/docs/skills/crefactor.md
@@ -78,9 +78,9 @@ Agent: Approved. Resuming...
 | `.correctless/config/workflow-config.json` | Characterization test files (if needed) |
 | | `ARCHITECTURE.md` (if patterns changed, with approval) |
 
-## Lite vs Full
+## Intensity Levels
 
-Both modes run the full behavioral equivalence pipeline with agent separation and test-change gating. Full mode adds mutation testing on refactored code, cross-spec impact analysis (checks whether structural changes affect other features' invariants), and drift debt updates.
+Same at all intensity levels for the behavioral equivalence pipeline with agent separation and test-change gating. At high/critical intensity, mutation testing on refactored code, cross-spec impact analysis (checks whether structural changes affect other features' invariants), and drift debt updates are added.
 
 ## Common Issues
 

--- a/docs/skills/crelease.md
+++ b/docs/skills/crelease.md
@@ -53,9 +53,9 @@ Agent: Checking working tree... clean.
        Push? (1) Tag + commit (2) Tag only (3) Don't push
 ```
 
-## Lite vs Full
+## Intensity Levels
 
-`/crelease` works the same in both modes. It reads specs from `.correctless/specs/` regardless of mode.
+`/crelease` works the same at all intensity levels. It reads specs from `.correctless/specs/` regardless of intensity.
 
 ## Common Issues
 

--- a/docs/skills/creview-spec.md
+++ b/docs/skills/creview-spec.md
@@ -4,7 +4,7 @@
 
 ## When to Use
 
-- After `/cspec` or `/cmodel` on any feature going through the Full pipeline
+- After `/cspec` or `/cmodel` on any feature going through the high+ intensity pipeline
 - When a spec has security-relevant invariants, trust boundaries, or cross-cutting concerns
 - **Not for:** quick, low-risk features — use `/creview` (single-pass, 3 min) instead
 
@@ -12,7 +12,7 @@
 
 Sits between spec/model and TDD. This is the last gate before code gets written. Four hostile reviewers examine the spec simultaneously, each looking through a different lens. The goal is to find problems in the design, not in code that does not exist yet.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 

--- a/docs/skills/creview.md
+++ b/docs/skills/creview.md
@@ -4,8 +4,8 @@
 
 ## When to Use
 
-- After `/cspec` produces an approved spec — this is the mandatory next step in Lite mode
-- In Full mode, for a quick single-pass review on low-risk features (use `/creview-spec` for the full 4-agent adversarial review)
+- After `/cspec` produces an approved spec — this is the mandatory next step at standard intensity
+- At high/critical intensity, for a quick single-pass review on low-risk features (use `/creview-spec` for the full 4-agent adversarial review)
 - **Not for:** reviewing code or pull requests (use `/cpr-review`), reviewing implementation after TDD (use `/cverify`)
 
 ## How It Fits in the Workflow
@@ -56,15 +56,15 @@ Agent: Assumptions check complete — found 2 unstated assumptions.
 | `AGENT_CONTEXT.md` | `.correctless/artifacts/reviews/{slug}-review.md` |
 | `ARCHITECTURE.md` | `.correctless/artifacts/token-log-{slug}.json` |
 | `.correctless/antipatterns.md` | Workflow state (advances to tests phase) |
-| `.correctless/meta/workflow-effectiveness.json` (Full) | |
+| `.correctless/meta/workflow-effectiveness.json` (high+ intensity) | |
 | `.correctless/artifacts/qa-findings-*.json` | |
 | Relevant source code | |
 
-## Lite vs Full
+## Intensity Levels
 
-In **Lite** mode, `/creview` is the standard review — a single-agent skeptical pass covering assumptions, testability, edge cases, antipatterns, integration test levels, and security. This is what most projects use.
+At **standard** intensity, `/creview` is the standard review — a single-agent skeptical pass covering assumptions, testability, edge cases, antipatterns, integration test levels, and security. This is what most projects use.
 
-In **Full** mode, `/creview` is available as a quick 3-minute review for low-risk features. For higher-risk features, use `/creview-spec` instead, which runs a 4-agent adversarial review team. Full mode users can choose either based on the feature's risk profile.
+At **high/critical** intensity, `/creview` is available as a quick 3-minute review for low-risk features. For higher-risk features, use `/creview-spec` instead, which runs a 4-agent adversarial review team. Users at high/critical intensity can choose either based on the feature's risk profile.
 
 ## Common Issues
 

--- a/docs/skills/csetup.md
+++ b/docs/skills/csetup.md
@@ -129,7 +129,7 @@ Agent: Project Health Check — recipe-api (TypeScript/Express)
 | | PR template (if accepted) |
 | | `.claude/settings.json` (Claude Code hook registration) |
 
-## Lite vs Full
+## Intensity Levels
 
 The adaptive flow and health check run at all intensity levels. At high+ intensity, the setup additionally surfaces the workflow intensity setting (standard/high/critical) during config confirmation. Intensity configures STRIDE analysis, formal modeling, and stricter QA rounds.
 

--- a/docs/skills/cspec.md
+++ b/docs/skills/cspec.md
@@ -18,7 +18,7 @@
 1. **Socratic brainstorm** — challenges your assumptions with targeted questions: "What problem does this solve? Not the feature — the problem." Scales depth to your confidence level.
 2. **Reads project context** — ARCHITECTURE.md, antipatterns, drift debt, QA history, and recent git log to ground the spec in your codebase's reality
 3. **Researches current best practices** (when needed) — spawns a research subagent for topics where training data may be stale (new library versions, security protocols, rapidly-evolving APIs). Saves findings to an artifact.
-4. **Drafts the spec** — Lite mode produces Rules (R-001, R-002...) with test levels. Full mode produces Invariants, Prohibitions, Boundary Conditions, and optionally STRIDE analysis.
+4. **Drafts the spec** — at standard intensity, produces Rules (R-001, R-002...) with test levels. At high/critical intensity, produces Invariants, Prohibitions, Boundary Conditions, and optionally STRIDE analysis.
 5. **Walks you through the spec** — presents rules in small groups for approval, resolves open questions, checks against known antipatterns, and advances the workflow state when approved
 
 ## Example
@@ -67,15 +67,15 @@ Agent: Based on our discussion, here's what I understand: rate limiting on
 | `AGENT_CONTEXT.md` | `.correctless/specs/{task-slug}.md` |
 | `ARCHITECTURE.md` | `.correctless/artifacts/research/{slug}-research.md` (if research triggered) |
 | `.correctless/antipatterns.md` | `.correctless/artifacts/token-log-{slug}.json` |
-| `.correctless/meta/drift-debt.json` (Full) | Workflow state (advances to review phase) |
+| `.correctless/meta/drift-debt.json` (high+ intensity) | Workflow state (advances to review phase) |
 | `.correctless/artifacts/qa-findings-*.json` | |
 | Git log (recent 20 commits) | |
 
-## Lite vs Full
+## Intensity Levels
 
-**Lite** produces 5 sections: What, Rules (R-xxx with test levels), Won't Do, Risks, Open Questions. Simple and fast.
+**Standard intensity** produces 5 sections: What, Rules (R-xxx with test levels), Won't Do, Risks, Open Questions. Simple and fast.
 
-**Full** scales artifact weight by intensity level. Standard adds Boundary Conditions and Complexity Budget. High/critical adds STRIDE analysis, Environment Assumptions, and Design Decisions. Full mode also checks drift debt and recommends an intensity level based on trust boundaries touched.
+**High/critical intensity** scales artifact weight by intensity level. High adds Boundary Conditions and Complexity Budget. Critical adds STRIDE analysis, Environment Assumptions, and Design Decisions. At high/critical intensity, the skill also checks drift debt and recommends an intensity level based on trust boundaries touched.
 
 ## Common Issues
 

--- a/docs/skills/cstatus.md
+++ b/docs/skills/cstatus.md
@@ -17,7 +17,7 @@ This skill can be invoked at any point. It reads the current workflow state and 
 
 - Verifies Correctless is configured in the project (checks for `workflow-config.json`, hooks, and `ARCHITECTURE.md`).
 - Reads the current workflow phase and shows phase-specific guidance (e.g., "RED phase — writing tests. Source files are blocked.").
-- Lists all available commands for the current mode (Lite or Full).
+- Lists all available commands for the current intensity level.
 - **Detects problems proactively**:
   - **Stale workflows**: If a phase has been active for more than 24 hours, warns and suggests re-running the phase skill or using an override.
   - **Empty docs**: If `ARCHITECTURE.md` or `AGENT_CONTEXT.md` still contains placeholder markers (`{PROJECT_NAME}`), recommends running `/csetup`.
@@ -29,7 +29,7 @@ This skill can be invoked at any point. It reads the current workflow state and 
 ```
 User: /cstatus
 
-Correctless Lite — active workflow on `feature/rate-limiting`
+Correctless — active workflow on `feature/rate-limiting`
 
 Phase: tdd-impl (GREEN)
 Entered: 3 hours ago
@@ -55,10 +55,10 @@ No problems detected.
 | `AGENT_CONTEXT.md` | |
 | Workflow state file | |
 
-## Lite vs Full
+## Intensity Levels
 
-- **Lite mode**: Shows the Lite pipeline and Lite commands.
-- **Full mode**: Also shows Full-only commands (`/cmodel`, `/creview-spec`, `/caudit`, `/cupdate-arch`, `/cpostmortem`, `/cdevadv`, `/credteam`) and Full-specific phases.
+- **Standard intensity**: Shows the standard pipeline and standard commands.
+- **High/critical intensity**: Also shows high+ intensity commands (`/cmodel`, `/creview-spec`, `/caudit`, `/cupdate-arch`, `/cpostmortem`, `/cdevadv`, `/credteam`) and extended phases.
 
 ## Common Issues
 

--- a/docs/skills/csummary.md
+++ b/docs/skills/csummary.md
@@ -68,9 +68,9 @@ Spec: .correctless/specs/rate-limiting.md
 | Workflow state file | |
 | Git log (branch duration, commit count) | |
 
-## Lite vs Full
+## Intensity Levels
 
-Same in both modes. The summary reports whatever phases actually ran. Full mode features that ran (model, audit) will appear in the summary if their artifacts exist.
+Same at all intensity levels. The summary reports whatever phases actually ran. High+ intensity features that ran (model, audit) will appear in the summary if their artifacts exist.
 
 ## Common Issues
 

--- a/docs/skills/ctdd.md
+++ b/docs/skills/ctdd.md
@@ -66,9 +66,9 @@ Agent: Spawning test-writing agent — reading spec (5 rules),
 | | `.correctless/artifacts/checkpoint-ctdd-{slug}.json` |
 | | `.correctless/artifacts/token-log-{slug}.json` |
 
-## Lite vs Full
+## Intensity Levels
 
-Both modes run the full RED → test audit → GREEN → QA pipeline with agent separation. Full mode adds git commit trailers (`Spec:`, `Rules-covered:`, `Phase:`) for traceability, and transitions to a verify phase before marking done.
+Same at all intensity levels for the RED → test audit → GREEN → QA pipeline with agent separation. At high/critical intensity, git commit trailers (`Spec:`, `Rules-covered:`, `Phase:`) are added for traceability, and the workflow transitions to a verify phase before marking done.
 
 ## Common Issues
 

--- a/docs/skills/cupdate-arch.md
+++ b/docs/skills/cupdate-arch.md
@@ -13,7 +13,7 @@
 
 Runs after features are merged and documented. Keeps the living architecture document accurate so that future `/cspec`, `/creview-spec`, and `/caudit` runs have correct context. Stale architecture docs cause every downstream skill to make wrong assumptions.
 
-**Full mode only.** This skill is not available in Lite mode.
+**Requires high intensity or above.**
 
 ## What It Does
 
@@ -57,9 +57,9 @@ Each entry follows a structured format with required fields:
 | Pattern | PAT-xxx | Rule, violated-when, test |
 | Environment Assumption | ENV-xxx | Runtime assumption, invariant, violated-when |
 
-## Lite vs Full
+## Intensity Levels
 
-This skill is **Full mode only**. In Lite mode, architecture documentation is maintained manually. The structured scanning and entry drafting require the full agent pipeline for context.
+This skill **requires high intensity or above**. At standard intensity, architecture documentation is maintained manually. The structured scanning and entry drafting require the extended agent pipeline for context.
 
 ## Common Issues
 

--- a/docs/skills/cverify.md
+++ b/docs/skills/cverify.md
@@ -64,9 +64,9 @@ Agent: Rule coverage complete — 5/5 rules covered, 1 weak.
 | `.correctless/meta/workflow-effectiveness.json` | |
 | Package manifests (diff against base branch) | |
 
-## Lite vs Full
+## Intensity Levels
 
-Both modes run rule coverage, dependency checks, architecture compliance, and drift detection. Full mode adds mutation testing, cross-spec impact analysis, and checks whether structural changes affect other features' invariants.
+Same at all intensity levels for rule coverage, dependency checks, architecture compliance, and drift detection. At high/critical intensity, mutation testing, cross-spec impact analysis, and checks whether structural changes affect other features' invariants are added.
 
 ## Common Issues
 

--- a/docs/skills/cwtf.md
+++ b/docs/skills/cwtf.md
@@ -79,10 +79,10 @@ or shortcuts detected.
 | `~/.claude/usage-data/session-meta/*.json` | |
 | Conversation JSONL (targeted queries only) | |
 
-## Lite vs Full
+## Intensity Levels
 
-- **Lite**: Checks the Lite phase sequence (spec, review, tdd-tests, tdd-impl, tdd-qa, done, verified, documented).
-- **Full**: Checks the Full phase sequence (adds model, review-spec, tdd-verify) and includes additional checks for those phases.
+- **Standard intensity**: Checks the standard phase sequence (spec, review, tdd-tests, tdd-impl, tdd-qa, done, verified, documented).
+- **High/critical intensity**: Checks the extended phase sequence (adds model, review-spec, tdd-verify) and includes additional checks for those phases.
 
 ## Common Issues
 


### PR DESCRIPTION
## Summary
- The Lite/Full two-distribution model was merged into a single plugin with intensity levels (standard/high/critical) in PR #13 (Stage 1). Documentation across 29 files still used the old terminology.
- **CLAUDE.md**: "Correctless Lite" → "Correctless"
- **Issue templates**: Lite/Full checkboxes → Standard/High/Critical intensity selectors
- **26 skill docs**: All "Lite vs Full" sections → "Intensity Levels", "Full mode only" badges → "Requires high intensity or above"

## Test plan
- [x] No code changes — documentation only
- [x] Final grep confirms zero remaining stale references across all updated files
- [x] All pre-commit hooks pass (typos, trailing whitespace, etc.)