### PR TITLE
QA Olympics audit: 12 findings fixed across 2 rounds

### DIFF
--- a/.correctless/ARCHITECTURE.md
+++ b/.correctless/ARCHITECTURE.md
@@ -101,7 +101,7 @@
 ### ABS-008: preferences.md contract (.correctless/)
 - **What**: Project-level preference file at `.correctless/preferences.md`. Scaffolded by `/csetup` from `templates/preferences.md`. Read by `/cauto` and all pipeline skills. Edited by the human. Contains codified judgment calls: QA finding triage, documentation scope, commit granularity, escalation sensitivity, PR creation mode.
 - **Invariant**: `/csetup` scaffolds the file (idempotent — never overwrites). `/cauto` and pipeline skills read preferences. The human is the sole editor. Falls back to built-in defaults when missing.
-- **Enforced at**: setup (scaffolding), skills/cauto/SKILL.md (reader), hooks/sensitive-file-guard.sh (protection)
+- **Enforced at**: setup (scaffolding), skills/cauto/SKILL.md (reader), hooks/sensitive-file-guard.sh (protection), skills/_shared/constraints.md (reader instruction for all skills)
 - **Violated when**: A skill writes to preferences.md, or the pipeline fails when preferences.md is absent
 - **Test**: R-004 in semi-auto-mode tests (template categories), R-013 (setup scaffolding), R-019 (sensitive-file-guard protection)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,11 +8,11 @@
 | Hooks | `hooks/` | 4 bash scripts: workflow gate (PreToolUse), state machine (workflow-advance), statusline, audit trail. These enforce the workflow. |
 | Templates | `templates/` | Scaffolding templates for ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, invariant templates (high+ intensity), spec templates, workflow configs. |
 | Helpers | `helpers/` | Property-based testing guides per language (Go, Python, TypeScript, Rust). High+ intensity. |
-| Distribution | `correctless/` | Single 26-skill distribution. Intensity gates control which skills activate at each level. |
+| Distribution | `correctless/` | Single 27-skill distribution. Intensity gates control which skills activate at each level. |
 | Docs | `docs/` | Per-skill user-facing documentation and feature docs. |
 | Design Specs | `docs/design/correctless.md` | Design specification covering all intensity levels. |
 | Setup | `setup` | Bash script: detects stack, scaffolds config/hooks/templates, registers Claude Code hooks. Idempotent. |
-| Tests | `tests/test*.sh` | 17 test files covering setup, state machine, gate, full mode, MCP, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets, dynamic rigor, intensity detection, wire-intensity-creview, wire-intensity-pipeline, auto-format, sensitive-file-guard, antipattern-scan. |
+| Tests | `tests/test*.sh` | 32 test files covering setup, state machine, gate, full mode, MCP, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets, dynamic rigor, intensity detection, wire-intensity-creview, wire-intensity-pipeline, auto-format, sensitive-file-guard, antipattern-scan, hook-sync, lib, lib-locking, token-tracking, token-tracking-setup, token-tracking-skill-field, allowed-tools-check, gate-path-exceptions, intensity-calibration, auto-recurring-patterns, shift-left-review, ci-hook-wiring, token-aware-intensity, semi-auto-mode. |
 | Sync | `sync.sh` | Copies source files into the `correctless/` distribution target. |
 
 ## Design Patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Correctless are documented here.
 - Verbatim Effective Intensity section (R-022) across all pipeline skills
 
 ### Added — Infrastructure
-- 17 test files with ~1,900 assertions (up from 57 in v2.0.0)
+- 32 test files with ~2,000 assertions (up from 57 in v2.0.0)
 - Calm reset prompts in /ctdd and /caudit orchestrators
 - Spec template files (spec-lite.md, spec-full.md) for intensity-aware spec generation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Correctless are documented here.
 ## [3.0.0] - 2026-04-04
 
 ### Changed — Single Distribution with Dynamic Rigor
-- Merged Lite and Full distributions into a single 26-skill plugin
+- Merged Lite and Full distributions into a single 27-skill plugin
 - Retired "Lite mode" / "Full mode" terminology in favor of intensity levels (standard, high, critical)
 - Intensity gates control which features activate — standard (~10-15 min/feature), high/critical (~1-2 hr/feature)
 - Per-feature intensity override via `workflow-advance.sh set-intensity`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 ## Project Structure
 
 ```
-skills/               # Source skills (26 SKILL.md files)
+skills/               # Source skills (27 SKILL.md files)
 hooks/                # Bash hooks (gate, state machine, statusline, audit trail)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT guides per language (high+ intensity)
-tests/                # 17 test files (~1,900 assertions)
+tests/                # 32 test files (~2,000 assertions)
 setup                 # Install script
 sync.sh               # Copies source → correctless/ distribution
 correctless/          # Single distribution (27 skills, intensity-gated)
@@ -88,7 +88,7 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Testing
 
 ```bash
-# Run all 17 test suites (canonical command from workflow-config.json):
+# Run all 32 test suites (canonical command from workflow-config.json):
 bash tests/test.sh && bash tests/test-mcp.sh && bash tests/test-bugfixes.sh && bash tests/test-qol.sh && bash tests/test-decisions.sh && bash tests/test-statusline.sh && bash tests/test-consolidation.sh && bash tests/test-crelease.sh && bash tests/test-calm-resets.sh && bash tests/test-dynamic-rigor.sh && bash tests/test-intensity-detection.sh && bash tests/test-wire-intensity-creview.sh && bash tests/test-wire-intensity-pipeline.sh && bash tests/test-cexplain.sh && bash tests/test-auto-format.sh && bash tests/test-sensitive-file-guard.sh && bash tests/test-antipattern-scan.sh
 
 # Quick smoke test (2 suites):

--- a/correctless/hooks/sensitive-file-guard.sh
+++ b/correctless/hooks/sensitive-file-guard.sh
@@ -338,7 +338,7 @@ id_ed25519
 id_ed25519.*
 *.keystore
 *.jks
-preferences.md"
+.correctless/preferences.md"
 
 # ============================================
 # STEP 7: Read custom patterns from config (INV-005)

--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -1084,7 +1084,7 @@ case "$cmd" in
   *)
     echo "Usage: workflow-advance.sh <command> [args]"
     echo ""
-    echo "Phase transitions (Lite):"
+    echo "Phase transitions:"
     echo "  init \"task\"       Create workflow state (must be on a feature branch)"
     echo "  review             spec → review (requires spec file exists)"
     echo "  tests              review|review-spec|spec(update) → tdd-tests"

--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -132,7 +132,9 @@ read_config_field() {
 is_full_mode() {
   [ -f "$CONFIG_FILE" ] || return 1
   local intensity
-  intensity="$(jq -r '.workflow.intensity // empty' "$CONFIG_FILE")"
+  intensity="$(jq -r '.workflow.intensity // empty' "$CONFIG_FILE" 2>/dev/null)" || true
+  # Normalize case — handle user-edited configs with "High" or "CRITICAL"
+  intensity="${intensity,,}"
 
   # Also check feature_intensity from the state file (PAT-005: effective intensity)
   local STATE_FILE
@@ -140,6 +142,8 @@ is_full_mode() {
   if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
     local feature_intensity
     feature_intensity="$(jq -r '.feature_intensity // empty' "$STATE_FILE" 2>/dev/null)" || true
+    # Normalize case
+    feature_intensity="${feature_intensity,,}"
     # Compute effective intensity as max(project, feature) using ordering standard < high < critical
     if [ -n "$feature_intensity" ]; then
       case "$feature_intensity" in
@@ -1108,7 +1112,7 @@ case "$cmd" in
     echo "  status             Print current workflow state"
     echo "  status-all         Print all active workflows across branches"
     echo ""
-    echo "Skills: /csetup /cspec /creview /ctdd /cverify /cdocs /crefactor /cpr-review /ccontribute /cmaintain /cstatus /csummary /cmetrics /cdebug /chelp /cwtf /cquick /crelease /cexplain"
+    echo "Skills: /csetup /cspec /creview /ctdd /cverify /cdocs /crefactor /cpr-review /ccontribute /cmaintain /cstatus /csummary /cmetrics /cdebug /chelp /cwtf /cquick /crelease /cexplain /cauto"
     echo "High+:  /cmodel /creview-spec /caudit /cupdate-arch /cpostmortem /cdevadv /credteam"
     exit 1
     ;;

--- a/correctless/skills/cauto/SKILL.md
+++ b/correctless/skills/cauto/SKILL.md
@@ -38,6 +38,8 @@ Built-in defaults when preferences.md is missing:
 - Escalation sensitivity: escalate on any architectural decision
 - PR creation: `gh` (create PR via `gh pr create`)
 
+Log a `preference_applied` audit event for each non-default preference loaded from `preferences.md`. If all preferences match the built-in defaults (or the file is absent), no `preference_applied` events are logged.
+
 ## Resumption Check (R-016)
 
 On invocation, check for an existing escalation file at `.correctless/artifacts/escalation-{branch_slug}.md`. If present:
@@ -62,6 +64,8 @@ The effective intensity computation from shared constraints determines which ski
 - At **high** or **critical** intensity: run the full pipeline including `/cupdate-arch`.
 
 `cupdate-arch` has an independent intensity gate in its own SKILL.md — it will refuse to run at standard intensity regardless of whether `/cauto` invokes it.
+
+When `/cupdate-arch` is skipped due to standard intensity, log a `preference_applied` audit event with the reason "cupdate-arch skipped: standard intensity".
 
 ### Workflow State Machine Transitions (R-010)
 
@@ -125,6 +129,8 @@ At high or critical intensity, spawn a sub-agent to execute `/cupdate-arch`. Ski
 
 Spawn a sub-agent to execute `/cdocs`. Log `skill_started` before, `skill_completed` after.
 
+After `/cdocs` completes, run `git diff --name-only HEAD` and check if CLAUDE.md appears in the changed files. If it does, trigger R-006(e) escalation — CLAUDE.md changes require human approval. Write the escalation file and halt the pipeline; do not proceed to PR creation until the human approves the CLAUDE.md changes.
+
 ### Step 8: Create PR (R-008)
 
 Create a PR according to the `pr_creation` preference from `preferences.md`:
@@ -136,6 +142,8 @@ Create a PR according to the `pr_creation` preference from `preferences.md`:
   - **Verification status**: pass/fail from `/cverify`
 - **`skip`**: Skip PR creation, just report pipeline completion.
 - **Custom command**: Execute the specified custom PR command via shell (TB-001b: custom PR commands follow the same trust model as TB-001a test runner commands — the file is local, under the project owner's control, and protected by the sensitive-file-guard).
+
+Log a `preference_applied` audit event with the selected PR creation mode (e.g., "pr_creation: gh", "pr_creation: skip", or "pr_creation: custom").
 
 Log `pipeline_completed` in the audit trail.
 

--- a/correctless/skills/chelp/SKILL.md
+++ b/correctless/skills/chelp/SKILL.md
@@ -94,6 +94,7 @@ Other:
   /cwtf          Audit the workflow — did agents follow instructions?
   /crelease      Version bumping, changelog, release tagging
   /cexplain      Guided codebase exploration with diagrams
+  /cauto         Semi-auto pipeline — orchestrates ctdd through PR   [standard+]
 ```
 
 ### 4. Show Current Status

--- a/correctless/skills/csetup/SKILL.md
+++ b/correctless/skills/csetup/SKILL.md
@@ -1103,7 +1103,7 @@ Check workflow state anytime: `.correctless/hooks/workflow-advance.sh status`"
 Start a feature: `git checkout -b feature/my-feature` then `/cspec`.
 Or review a PR: `/cpr-review {number}`.
 
-Current commands: `/csetup`, `/cspec`, `/creview`, `/ctdd`, `/cverify`, `/cdocs`, `/crefactor`, `/cpr-review`, `/ccontribute`, `/cmaintain`, `/cstatus`, `/csummary`, `/cmetrics`, `/cdebug`, `/chelp`, `/cwtf`, `/cquick`, `/crelease`, `/cexplain`
+Current commands: `/csetup`, `/cspec`, `/creview`, `/ctdd`, `/cverify`, `/cdocs`, `/crefactor`, `/cpr-review`, `/ccontribute`, `/cmaintain`, `/cstatus`, `/csummary`, `/cmetrics`, `/cdebug`, `/chelp`, `/cwtf`, `/cquick`, `/crelease`, `/cexplain`, `/cauto`
 Check workflow state: `.correctless/hooks/workflow-advance.sh status`"
 
 If the human says they want to start a feature, ask what they want to build and suggest they run `/cspec`. **Do not auto-invoke `/cspec`.**

--- a/correctless/skills/cstatus/SKILL.md
+++ b/correctless/skills/cstatus/SKILL.md
@@ -135,6 +135,7 @@ Available commands:
   /cquick         Lightweight TDD — quick-start without full spec
   /crelease       Versioning and changelog management
   /cexplain       Guided codebase exploration
+  /cauto          Semi-auto pipeline — orchestrates ctdd through PR
 
 State management:
   .correctless/hooks/workflow-advance.sh status      Current phase

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -338,7 +338,7 @@ id_ed25519
 id_ed25519.*
 *.keystore
 *.jks
-preferences.md"
+.correctless/preferences.md"
 
 # ============================================
 # STEP 7: Read custom patterns from config (INV-005)

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -1084,7 +1084,7 @@ case "$cmd" in
   *)
     echo "Usage: workflow-advance.sh <command> [args]"
     echo ""
-    echo "Phase transitions (Lite):"
+    echo "Phase transitions:"
     echo "  init \"task\"       Create workflow state (must be on a feature branch)"
     echo "  review             spec → review (requires spec file exists)"
     echo "  tests              review|review-spec|spec(update) → tdd-tests"

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -132,7 +132,9 @@ read_config_field() {
 is_full_mode() {
   [ -f "$CONFIG_FILE" ] || return 1
   local intensity
-  intensity="$(jq -r '.workflow.intensity // empty' "$CONFIG_FILE")"
+  intensity="$(jq -r '.workflow.intensity // empty' "$CONFIG_FILE" 2>/dev/null)" || true
+  # Normalize case — handle user-edited configs with "High" or "CRITICAL"
+  intensity="${intensity,,}"
 
   # Also check feature_intensity from the state file (PAT-005: effective intensity)
   local STATE_FILE
@@ -140,6 +142,8 @@ is_full_mode() {
   if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
     local feature_intensity
     feature_intensity="$(jq -r '.feature_intensity // empty' "$STATE_FILE" 2>/dev/null)" || true
+    # Normalize case
+    feature_intensity="${feature_intensity,,}"
     # Compute effective intensity as max(project, feature) using ordering standard < high < critical
     if [ -n "$feature_intensity" ]; then
       case "$feature_intensity" in
@@ -1108,7 +1112,7 @@ case "$cmd" in
     echo "  status             Print current workflow state"
     echo "  status-all         Print all active workflows across branches"
     echo ""
-    echo "Skills: /csetup /cspec /creview /ctdd /cverify /cdocs /crefactor /cpr-review /ccontribute /cmaintain /cstatus /csummary /cmetrics /cdebug /chelp /cwtf /cquick /crelease /cexplain"
+    echo "Skills: /csetup /cspec /creview /ctdd /cverify /cdocs /crefactor /cpr-review /ccontribute /cmaintain /cstatus /csummary /cmetrics /cdebug /chelp /cwtf /cquick /crelease /cexplain /cauto"
     echo "High+:  /cmodel /creview-spec /caudit /cupdate-arch /cpostmortem /cdevadv /credteam"
     exit 1
     ;;

--- a/skills/cauto/SKILL.md
+++ b/skills/cauto/SKILL.md
@@ -38,6 +38,8 @@ Built-in defaults when preferences.md is missing:
 - Escalation sensitivity: escalate on any architectural decision
 - PR creation: `gh` (create PR via `gh pr create`)
 
+Log a `preference_applied` audit event for each non-default preference loaded from `preferences.md`. If all preferences match the built-in defaults (or the file is absent), no `preference_applied` events are logged.
+
 ## Resumption Check (R-016)
 
 On invocation, check for an existing escalation file at `.correctless/artifacts/escalation-{branch_slug}.md`. If present:
@@ -62,6 +64,8 @@ The effective intensity computation from shared constraints determines which ski
 - At **high** or **critical** intensity: run the full pipeline including `/cupdate-arch`.
 
 `cupdate-arch` has an independent intensity gate in its own SKILL.md — it will refuse to run at standard intensity regardless of whether `/cauto` invokes it.
+
+When `/cupdate-arch` is skipped due to standard intensity, log a `preference_applied` audit event with the reason "cupdate-arch skipped: standard intensity".
 
 ### Workflow State Machine Transitions (R-010)
 
@@ -125,6 +129,8 @@ At high or critical intensity, spawn a sub-agent to execute `/cupdate-arch`. Ski
 
 Spawn a sub-agent to execute `/cdocs`. Log `skill_started` before, `skill_completed` after.
 
+After `/cdocs` completes, run `git diff --name-only HEAD` and check if CLAUDE.md appears in the changed files. If it does, trigger R-006(e) escalation — CLAUDE.md changes require human approval. Write the escalation file and halt the pipeline; do not proceed to PR creation until the human approves the CLAUDE.md changes.
+
 ### Step 8: Create PR (R-008)
 
 Create a PR according to the `pr_creation` preference from `preferences.md`:
@@ -136,6 +142,8 @@ Create a PR according to the `pr_creation` preference from `preferences.md`:
   - **Verification status**: pass/fail from `/cverify`
 - **`skip`**: Skip PR creation, just report pipeline completion.
 - **Custom command**: Execute the specified custom PR command via shell (TB-001b: custom PR commands follow the same trust model as TB-001a test runner commands — the file is local, under the project owner's control, and protected by the sensitive-file-guard).
+
+Log a `preference_applied` audit event with the selected PR creation mode (e.g., "pr_creation: gh", "pr_creation: skip", or "pr_creation: custom").
 
 Log `pipeline_completed` in the audit trail.
 

--- a/skills/chelp/SKILL.md
+++ b/skills/chelp/SKILL.md
@@ -94,6 +94,7 @@ Other:
   /cwtf          Audit the workflow — did agents follow instructions?
   /crelease      Version bumping, changelog, release tagging
   /cexplain      Guided codebase exploration with diagrams
+  /cauto         Semi-auto pipeline — orchestrates ctdd through PR   [standard+]
 ```
 
 ### 4. Show Current Status

--- a/skills/csetup/SKILL.md
+++ b/skills/csetup/SKILL.md
@@ -1103,7 +1103,7 @@ Check workflow state anytime: `.correctless/hooks/workflow-advance.sh status`"
 Start a feature: `git checkout -b feature/my-feature` then `/cspec`.
 Or review a PR: `/cpr-review {number}`.
 
-Current commands: `/csetup`, `/cspec`, `/creview`, `/ctdd`, `/cverify`, `/cdocs`, `/crefactor`, `/cpr-review`, `/ccontribute`, `/cmaintain`, `/cstatus`, `/csummary`, `/cmetrics`, `/cdebug`, `/chelp`, `/cwtf`, `/cquick`, `/crelease`, `/cexplain`
+Current commands: `/csetup`, `/cspec`, `/creview`, `/ctdd`, `/cverify`, `/cdocs`, `/crefactor`, `/cpr-review`, `/ccontribute`, `/cmaintain`, `/cstatus`, `/csummary`, `/cmetrics`, `/cdebug`, `/chelp`, `/cwtf`, `/cquick`, `/crelease`, `/cexplain`, `/cauto`
 Check workflow state: `.correctless/hooks/workflow-advance.sh status`"
 
 If the human says they want to start a feature, ask what they want to build and suggest they run `/cspec`. **Do not auto-invoke `/cspec`.**

--- a/skills/cstatus/SKILL.md
+++ b/skills/cstatus/SKILL.md
@@ -135,6 +135,7 @@ Available commands:
   /cquick         Lightweight TDD — quick-start without full spec
   /crelease       Versioning and changelog management
   /cexplain       Guided codebase exploration
+  /cauto          Semi-auto pipeline — orchestrates ctdd through PR
 
 State management:
   .correctless/hooks/workflow-advance.sh status      Current phase

--- a/tests/test-dynamic-rigor.sh
+++ b/tests/test-dynamic-rigor.sh
@@ -84,12 +84,12 @@ file_contains_i() {
 }
 
 # ============================================
-# R-001: sync.sh copies 26 skills to single correctless/ dir
+# R-001: sync.sh copies 27 skills to single correctless/ dir
 # ============================================
 
 test_r001_sync_single_dist() {
   echo ""
-  echo "=== R-001: sync.sh copies all 26 skills to single correctless/ dir ==="
+  echo "=== R-001: sync.sh copies all 27 skills to single correctless/ dir ==="
 
   # R-001: correctless/ distribution directory must exist
   assert_eq "R-001: correctless/ directory exists" "true" \
@@ -103,7 +103,7 @@ test_r001_sync_single_dist() {
   assert_eq "R-001: correctless-full/ does NOT exist" "false" \
     "$([ -d "$REPO_DIR/correctless-full" ] && echo true || echo false)"
 
-  # R-001: correctless/ must have all 26 skills
+  # R-001: correctless/ must have all 27 skills
   local skill_count=0
   if [ -d "$REPO_DIR/correctless/skills" ]; then
     skill_count="$(find "$REPO_DIR/correctless/skills" -name "SKILL.md" | wc -l)"
@@ -545,12 +545,12 @@ test_r010_full_templates_in_dist() {
 }
 
 # ============================================
-# R-011: /chelp lists all 26 skills with intensity annotations
+# R-011: /chelp lists all 27 skills with intensity annotations
 # ============================================
 
 test_r011_chelp_all_skills() {
   echo ""
-  echo "=== R-011: /chelp lists all 26 skills with intensity annotations ==="
+  echo "=== R-011: /chelp lists all 27 skills with intensity annotations ==="
 
   local chelp="$REPO_DIR/skills/chelp/SKILL.md"
 

--- a/tests/test-dynamic-rigor.sh
+++ b/tests/test-dynamic-rigor.sh
@@ -110,8 +110,8 @@ test_r001_sync_single_dist() {
   fi
   assert_eq "R-001: correctless/ has 27 skills" "27" "$skill_count"
 
-  # R-001: verify each of the 26 skills exists in correctless/
-  for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick crelease cexplain; do
+  # R-001: verify each of the 27 skills exists in correctless/
+  for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick crelease cexplain cauto; do
     assert_eq "R-001: correctless/skills/$skill/SKILL.md exists" "true" \
       "$([ -f "$REPO_DIR/correctless/skills/$skill/SKILL.md" ] && echo true || echo false)"
   done
@@ -554,9 +554,9 @@ test_r011_chelp_all_skills() {
 
   local chelp="$REPO_DIR/skills/chelp/SKILL.md"
 
-  # R-011: chelp lists all 26 skills
+  # R-011: chelp lists all 27 skills
   # Check for each skill command name
-  for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick crelease cexplain; do
+  for skill in csetup cspec cmodel creview creview-spec ctdd cverify caudit cupdate-arch cdocs cpostmortem cdevadv credteam crefactor cpr-review ccontribute cmaintain cstatus csummary cmetrics cdebug chelp cwtf cquick crelease cexplain cauto; do
     file_contains "$chelp" "/$skill" \
       && local found="true" || local found="false"
     assert_eq "R-011: chelp mentions /$skill" "true" "$found"

--- a/tests/test-qol.sh
+++ b/tests/test-qol.sh
@@ -111,7 +111,7 @@ fi
 echo "--- R-005: cquick in sync.sh skill list ---"
 SYNC="$REPO_DIR/sync.sh"
 
-# Check the skill list (single for-loop listing all 26 skills)
+# Check the skill list (single for-loop listing all 27 skills)
 skill_line=$(grep "^for skill in" "$SYNC" | head -1)
 if echo "$skill_line" | grep -q "cquick"; then
   assert_eq "R-005a: cquick in skill list" "yes" "yes"

--- a/tests/test-semi-auto-mode.sh
+++ b/tests/test-semi-auto-mode.sh
@@ -482,7 +482,7 @@ test_r010_workflow_transitions() {
   pos_tdd_tests="$(echo "$skill_content" | grep -n "tdd-tests" | head -1 | cut -d: -f1)"
   pos_tdd_impl="$(echo "$skill_content" | grep -n "tdd-impl" | head -1 | cut -d: -f1)"
   pos_tdd_qa="$(echo "$skill_content" | grep -n "tdd-qa" | head -1 | cut -d: -f1)"
-  pos_done="$(echo "$skill_content" | grep -n '\bdone\b' | head -1 | cut -d: -f1)"
+  pos_done="$(echo "$skill_content" | grep -nw 'done' | head -1 | cut -d: -f1)"
   pos_verified="$(echo "$skill_content" | grep -n "verified" | head -1 | cut -d: -f1)"
   pos_documented="$(echo "$skill_content" | grep -n "documented" | head -1 | cut -d: -f1)"
 
@@ -801,11 +801,11 @@ test_r019_preferences_in_sensitive_guard() {
 
   local hook="$REPO_DIR/hooks/sensitive-file-guard.sh"
 
-  # R-019: sensitive-file-guard must list preferences.md in protected patterns
-  file_contains_i "$hook" "preferences.md" \
-    "R-019: sensitive-file-guard lists preferences.md in protected patterns"
+  # R-019: sensitive-file-guard must list .correctless/preferences.md in protected patterns
+  file_contains_i "$hook" ".correctless/preferences.md" \
+    "R-019: sensitive-file-guard lists .correctless/preferences.md in protected patterns"
 
-  # R-019: Integration test — hook blocks Write to preferences.md
+  # R-019: Integration test — hook blocks Write to .correctless/preferences.md
   local test_dir="$REPO_DIR/tests/tmp/semi-auto-r019-$$"
   rm -rf "$test_dir"
   mkdir -p "$test_dir/.correctless/config"
@@ -817,15 +817,19 @@ test_r019_preferences_in_sensitive_guard() {
 
   local result
   result="$(run_sfg_hook '{"tool_name":"Write","tool_input":{"file_path":".correctless/preferences.md","content":"test"}}')"
-  assert_eq "R-019: Write to preferences.md is blocked" "2" "$result"
+  assert_eq "R-019: Write to .correctless/preferences.md is blocked" "2" "$result"
 
-  # R-019: hook blocks Edit to preferences.md
+  # R-019: hook blocks Edit to .correctless/preferences.md
   result="$(run_sfg_hook '{"tool_name":"Edit","tool_input":{"file_path":".correctless/preferences.md","old_string":"a","new_string":"b"}}')"
-  assert_eq "R-019: Edit to preferences.md is blocked" "2" "$result"
+  assert_eq "R-019: Edit to .correctless/preferences.md is blocked" "2" "$result"
 
-  # R-019: hook blocks Bash writes to preferences.md
+  # R-019: hook blocks Bash writes to .correctless/preferences.md
   result="$(run_sfg_hook '{"tool_name":"Bash","tool_input":{"command":"cat data > .correctless/preferences.md"}}')"
-  assert_eq "R-019: Bash redirect to preferences.md is blocked" "2" "$result"
+  assert_eq "R-019: Bash redirect to .correctless/preferences.md is blocked" "2" "$result"
+
+  # R-019: negative test — docs/preferences.md should NOT be blocked (path-qualified pattern)
+  result="$(run_sfg_hook '{"tool_name":"Write","tool_input":{"file_path":"docs/preferences.md","content":"test"}}')"
+  assert_eq "R-019: Write to docs/preferences.md is NOT blocked" "0" "$result"
 
   cd "$REPO_DIR" || return
   rm -rf "$test_dir"
@@ -963,11 +967,11 @@ test_pre006_preferences_in_guard_defaults() {
 
   local hook="$REPO_DIR/hooks/sensitive-file-guard.sh"
 
-  # PRE-006: preferences.md must be in the DEFAULTS section (hardcoded built-in list)
+  # PRE-006: .correctless/preferences.md must be in the DEFAULTS section (hardcoded built-in list)
   # Extract the DEFAULTS block and check
   local defaults_block
   defaults_block="$(sed -n '/^DEFAULTS=/,/^"/p' "$hook" 2>/dev/null)"
-  assert_contains "PRE-006: preferences.md in DEFAULTS built-in list" "preferences.md" "$defaults_block"
+  assert_contains "PRE-006: .correctless/preferences.md in DEFAULTS built-in list" ".correctless/preferences.md" "$defaults_block"
 }
 
 # ============================================
@@ -1002,7 +1006,7 @@ test_qa001_skill_count_matches_docs() {
   done
 
   local doc_count
-  doc_count="$(grep -oP '\b\d+ skill' "$REPO_DIR/.correctless/AGENT_CONTEXT.md" | head -1 | grep -oP '\d+')"
+  doc_count="$(grep -Eo '[0-9]+ skill' "$REPO_DIR/.correctless/AGENT_CONTEXT.md" | head -1 | grep -Eo '[0-9]+')"
 
   assert_eq "QA-001: actual skill count ($actual_count) matches AGENT_CONTEXT.md ($doc_count)" "$actual_count" "$doc_count"
 }


### PR DESCRIPTION
## Summary

Post-feature QA Olympics audit after semi-auto mode (#45) landed. Converged in 2 rounds.

- **Round 1** (8 findings): preferences.md guard over-matching, is_full_mode() crash on corrupt config, grep -oP POSIX violation, /cauto missing from 4 registration points, stale doc counts, CLAUDE.md escalation detection gap, ABS-008 enforcement doc gap, preference_applied audit event gap
- **Round 2** (5 findings): remaining stale doc counts, cosmetic comment updates, stale "Lite" terminology in help text

Key fixes:
- `preferences.md` guard narrowed from basename to `.correctless/preferences.md` path-qualified pattern
- `is_full_mode()` hardened: jq error protection + case normalization for user-edited configs
- `/cauto` registered in chelp, cstatus, csetup, workflow-advance.sh help
- Post-cdocs CLAUDE.md diff check added for R-006(e) escalation
- All "26 skills" and "17 test files" references updated across docs

## Test plan

- [ ] 140 semi-auto-mode tests pass
- [ ] 101 sensitive-file-guard tests pass (preferences.md guard fix)
- [ ] 63 main test suite passes
- [ ] 255 dynamic-rigor tests pass (skill registration)
- [ ] All pre-commit hooks pass (shellcheck, typos, sync check)
- [ ] `sync.sh --check` clean