### PR TITLE
QA Olympics audit: 80 fixes across security, correctness, UX

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "correctless",
       "source": "./correctless",
-      "description": "Correctness workflow for structured development. 26 skills with configurable intensity levels: spec-before-code, skeptical review, enforced TDD, formal modeling, adversarial review, verification, documentation, and metrics. Intensity gates let you choose standard, high, or critical rigor per project.",
+      "description": "Correctness workflow for structured development. 27 skills with configurable intensity levels: spec-before-code, skeptical review, enforced TDD, formal modeling, adversarial review, verification, documentation, and metrics. Intensity gates let you choose standard, high, or critical rigor per project.",
       "version": "3.0.0"
     }
   ]

--- a/.correctless/AGENT_CONTEXT.md
+++ b/.correctless/AGENT_CONTEXT.md
@@ -12,13 +12,13 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 |-----------|----------|---------|
 | Skills | `skills/*/SKILL.md` | 27 skill definitions. Each is a slash command with frontmatter contract. |
 | Agents | `agents/*.md` | Plugin sub-agents: fix-diff-reviewer, supervisor, decision-agent. System prompt + frontmatter. Synced to `correctless/agents/` via sync.sh. See ABS-010. |
-| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, token-tracking.sh (PostToolUse token logging with phase-to-skill mapping) |
+| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), sensitive-file-guard.sh (PreToolUse file protection), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, auto-format.sh (PostToolUse formatting), token-tracking.sh (PostToolUse token logging with phase-to-skill mapping) |
 | Scripts | `scripts/` | 15 shared scripts: lib.sh (shared utilities + sha256_hash_file), antipattern-scan.sh, auto-policy.sh (Tier 0 engine), auto-report.sh (Auto Run Report + Phase 3 review/override sections), budget-check.sh (token+time enforcement), cauto-lock.sh (pipeline lockfile), decision-record.sh (append-only DD-xxx), decision-routing.sh (tier hierarchy), intent-hash.sh (immutable intent), security-scan.sh (PRH-001 3-layer), workflow-state-ext.sh (state fields + spec approval), review-triage.sh (Phase 3 review finding triage + PRH-003 enforcement), supervisor-mandate.sh (Phase 3 mandate validation + hard limits + citation check), override-scrutiny.sh (Phase 3 override lifecycle + Jaccard retry prevention), override-crosscheck.sh (Phase 3 base-commit verification + file-touch drift + spec completeness) |
 | Templates | `templates/` | Scaffolding for new projects: ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, configs, auto-policy.json |
 | Helpers | `helpers/` | PBT guides per language (high+ intensity) |
 | Distribution | `correctless/` | Single 27-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `tests/test*.sh` | 48 test files (~3,530 shell tests) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation |
+| Tests | `tests/test*.sh` | 48 test files (~3,800 shell tests) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation |
 | Sync | `sync.sh` | Propagates source edits to the `correctless/` distribution |
 
 ## Design Patterns

--- a/.correctless/ARCHITECTURE.md
+++ b/.correctless/ARCHITECTURE.md
@@ -160,7 +160,7 @@
 - **Test**: test-auto-budget.sh — BND-006 suite
 
 ### ABS-016: Auto-policy config (.correctless/config/)
-- **What**: JSON config at `.correctless/config/auto-policy.json` defining Tier 0 policy rules. Sections: review_dispositions, qa_dispositions, spec_update, drift, security, budget, time, hard_stops. Controlled category vocabulary (8 values) and disposition vocabulary (8 values). First-match-wins evaluation. Scaffolded by `/csetup` with conservative defaults.
+- **What**: JSON config at `.correctless/config/auto-policy.json` defining Tier 0 policy rules. Sections: review_dispositions, qa_dispositions, spec_update, drift, security, budget, time, hard_stops. Controlled category vocabulary (14 values) and disposition vocabulary (8 values). First-match-wins evaluation. Scaffolded by `/csetup` with conservative defaults.
 - **Invariant**: Tier 0 evaluation is deterministic — same DR-xxx + same policy = same disposition (INV-001). Policy integrity verified via SHA-256 hash on each Tier 0 evaluation (INV-018). `security.never_relax_autonomously` hardcoded in orchestrator, not overridable. Malformed JSON → all decisions route to Tier 1+ (BND-001). Protected by sensitive-file-guard.
 - **Enforced at**: `scripts/auto-policy.sh` (policy_evaluate, policy_hash), `hooks/sensitive-file-guard.sh`
 - **Violated when**: Non-deterministic evaluation, hash mismatch not detected, security floor bypassed via config

--- a/.correctless/antipatterns.md
+++ b/.correctless/antipatterns.md
@@ -109,3 +109,18 @@ When a bug is found (pre-merge by QA, or post-merge by /cpostmortem):
 - **Frequency**: 0 findings in-project (external report, Andrew's clawker)
 - **Scanner rule**: Detect phantom execution by checking for execution evidence in test output. Look for timestamp progression, execution log entries, actual test output with durations, and docker/service startup logs for integration-tagged tests. Flag tests that contain `t.Skip`, `@pytest.mark.skip`, or `xit(`/`describe(` in integration/e2e suites. Implementation deferred to language-specific dogfooding.
 - **Source**: Andrew's clawker feedback, 2026-04-13
+
+### AP-019: Fail-open fallback on security enforcement failure
+- **What went wrong**: `enforce_prh003` in review-triage.sh had `|| result="$raw_decisions"` — if the security enforcement function failed, the fallback passed through unenforced supervisor decisions. A supervisor `reject` on a red-team security finding would not be elevated to `hard_stop`.
+- **How to catch it**: Security enforcement functions must never have a fail-open fallback. When enforcement cannot be verified, return a safe default (empty array + error code) rather than the unenforced input. Spec rule: "Functions implementing PRH-xxx constraints must return hard_stop or error on failure, never the unenforced input."
+- **Frequency**: 1 finding in 1 feature (qa-audit-2026-04-12 R1)
+
+### AP-020: Paired-array processing without cardinality assertion
+- **What went wrong**: `enforce_prh003` iterated over `[range($resp | length)]` instead of `[range($findings | length)]`. When the supervisor returned fewer decisions than findings, trailing security findings were silently dropped from output — no enforcement, no error.
+- **How to catch it**: Any function that zips two arrays by index must validate they have the same length first. Iterate over the longer array and handle missing elements explicitly (hard_stop for security, accept for non-security). Spec rule: "Paired-array processing must assert equal lengths. Mismatched lengths are fail-closed for security elements."
+- **Frequency**: 1 finding in 1 feature (qa-audit-2026-04-12 R1)
+
+### AP-021: Lock mechanism creates coupled artifacts without consistent cleanup
+- **What went wrong**: cauto-lock.sh's R1 fix introduced a `.d` directory alongside the legacy lockfile for atomic locking, but `lock_check_stale` only cleaned the flat file, not the directory. Stale lock recovery was permanently broken — users had to manually delete the `.d` directory.
+- **How to catch it**: When a lock mechanism creates multiple artifacts (file + directory), all cleanup paths (stale detection, release, error recovery) must remove all artifacts. Test stale recovery end-to-end: create lock with dead PID, verify new acquisition succeeds.
+- **Frequency**: 1 finding in 1 feature (qa-audit-2026-04-12 R2, R1 regression)

--- a/.correctless/artifacts/findings/audit-qa-history.md
+++ b/.correctless/artifacts/findings/audit-qa-history.md
@@ -190,3 +190,61 @@ Zero new findings from Regression Hunter. **Converged.**
 - **.claude/hooks/ stale copies**: sync.sh syncs to correctless/hooks/ but not .claude/hooks/. The installed hooks drift from source. (2026-04-03, 2026-04-05, 2026-04-09). Root cause fixed in 2026-04-09: install_hooks() now always overwrites.
 - **HOOK_MATCHER expansion without body update**: Adding tools to HOOK_MATCHER without updating the hook body's tool-specific logic (field extraction, warning exclusions). (2026-04-09)
 - **locked_update_state string interpolation**: User-supplied values embedded in jq filter strings via bash interpolation instead of jq --arg. Same class as QA-007 (2026-04-03). Fixed by extending locked_update_state to accept --arg passthrough. (2026-04-09)
+- **PRH-003 enforcement fail-open**: Security enforcement function had fail-open fallback. Paired-array cardinality mismatch silently dropped security findings. (2026-04-12)
+- **Phase name drift between policy_evaluate and tier2_build_context**: Phase 3 added review-spec and tdd-verify phases but only updated one of the two consumers. (2026-04-12)
+- **AP-001 \s/grep -P systemic**: 4th+ recurrence — 49+ occurrences in 5 test files. Needs scanner expansion. (2026-04-12)
+- **AP-005 stale counts**: README badge, test count, CONTRIBUTING file count all stale after 16 test files added. (2026-04-12)
+
+## Run: 2026-04-12
+### Round 1
+| ID | Severity | Tier | Title | Status | Fixed in |
+|----|----------|------|-------|--------|----------|
+| QA-001 | high | confirmed | PRH-003 enforcement fail-open fallback | fixed | adc5235 |
+| QA-002 | high | confirmed | policy_evaluate misses review-spec phase | fixed | adc5235 |
+| QA-003 | high | confirmed | check_hard_limits categories not in drx_validate | fixed | adc5235 |
+| QA-004 | high | confirmed | enforce_prh003 array length mismatch drops findings | fixed | adc5235 |
+| QA-005 | medium | confirmed | Git worktree leaked in base_commit_crosscheck | fixed | adc5235 |
+| QA-006 | medium | confirmed | rejected_overrides never written (PRH-006 dead) | fixed | adc5235 |
+| QA-007 | medium | confirmed | check_spec_completeness fail-open on malformed JSON | fixed | adc5235 |
+| QA-008 | medium | confirmed | build_mandate_context _current_category leak | fixed | adc5235 |
+| QA-009 | medium | confirmed | ws_set/increment_field missing EXIT trap | fixed | adc5235 |
+| QA-010 | medium | confirmed | build_mandate_context awk leaks S-prefixed sections | fixed | adc5235 |
+| QA-014 | medium | probable | base_commit_crosscheck timeout = disconfirmed | fixed | adc5235 |
+| QA-015 | medium | probable | cauto-lock TOCTOU (file-based) | fixed | adc5235 |
+| QA-017 | medium | probable | override_log unbounded growth | fixed | adc5235 |
+| QA-018 | medium | confirmed | tier2_build_context temp file no trap | fixed | adc5235 |
+| QA-019 | medium | confirmed | REGRESSION: grep -P in test-bugfixes.sh (AP-001) | fixed | adc5235 |
+| QA-020 | medium | confirmed | REGRESSION: \s in 4 test files (AP-001) | fixed | adc5235 |
+| QA-021 | medium | confirmed | REGRESSION: README badge 26→27 skills (AP-005) | fixed | adc5235 |
+| QA-022 | medium | confirmed | REGRESSION: README ~3,060→~3,900 tests (AP-005) | fixed | adc5235 |
+| QA-023 | medium | confirmed | REGRESSION: CONTRIBUTING 32→48 files (AP-005) | fixed | adc5235 |
+| QA-024 | low | confirmed | cmd_reset missing new artifact cleanup | fixed | adc5235 |
+| QA-025 | low | confirmed | budget_check awk interpolation | fixed | adc5235 |
+| QA-026 | low | confirmed | build_override_action_payload silent on bad JSON | fixed | adc5235 |
+
+### Round 2
+| ID | Severity | Tier | Title | Status | Fixed in |
+|----|----------|------|-------|--------|----------|
+| R2-001 | high | confirmed | R1 regression: lock_check_stale misses .d dir | fixed | 5aa376d |
+| R2-002 | high | confirmed | R1 regression: enforce_prh003 hard_stops all missing | fixed | 5aa376d |
+| R2-003 | high | confirmed | R1 incomplete: infrastructure failures still false | fixed | 5aa376d |
+| R2-004 | high | confirmed | budget_check division by zero on max_tokens=0 | fixed | 5aa376d |
+| R2-005 | medium | confirmed | triage fail-closed double-failure passes raw data | fixed | 5aa376d |
+| R2-006 | medium | confirmed | trap quoting uses single-quotes not printf %q | fixed | 5aa376d |
+| R2-007 | medium | confirmed | build_mandate_context silent empty output | fixed | 5aa376d |
+| R2-008 | low | confirmed | ws_increment_field type inconsistency (number/string) | fixed | 5aa376d |
+| R2-009 | low | probable | rejected_overrides unbounded growth | fixed | 5aa376d |
+| R2-010 | low | confirmed | dd_entries_since validates JSON not array type | fixed | 5aa376d |
+
+### Round 3
+| ID | Severity | Tier | Title | Status | Fixed in |
+|----|----------|------|-------|--------|----------|
+| R3-001 | medium | confirmed | Supervisor prompt missing null claim_verified doc | fixed | 3430408 |
+| R3-002 | medium | probable | Auto-accept missing decisions lacks reasoning | fixed | 3430408 |
+| R3-004 | low | confirmed | build_mandate_context fallback masks root cause | fixed | 3430408 |
+
+Zero HIGH findings in Round 3. **Converged.**
+
+### Deferred
+- QA-011: setup detect_config heredoc JSON injection (previously deferred 2026-04-03)
+- QA-016: Adherence state unlocked read-modify-write (previously deferred)

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -11,12 +11,12 @@ Claude Code plugin framework that enforces a correctness-oriented development wo
 | Component | Location | Purpose |
 |-----------|----------|---------|
 | Skills | `skills/*/SKILL.md` | 27 skill definitions. Each is a slash command with frontmatter contract. |
-| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, token-tracking.sh (PostToolUse token logging) |
+| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), sensitive-file-guard.sh (PreToolUse file protection), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, auto-format.sh (PostToolUse formatting), token-tracking.sh (PostToolUse token logging) |
 | Templates | `templates/` | Scaffolding for new projects: ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, configs |
 | Helpers | `helpers/` | PBT guides per language (high+ intensity) |
-| Distribution | `correctless/` | Single 26-skill distribution target — never edit directly |
+| Distribution | `correctless/` | Single 27-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `tests/test*.sh` | 21 test files (~2,140 shell tests) covering setup, state machine, gate hook, full mode, MCP integration, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets, dynamic rigor, intensity detection, wire-intensity-creview, wire-intensity-pipeline, auto-format, sensitive-file-guard, antipattern-scan, shift-left-review, lib, lib-locking, gate-path-exceptions, token-tracking, token-tracking-setup |
+| Tests | `tests/test*.sh` | 48 test files (~3,800 shell tests) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation |
 | Sync | `sync.sh` | Propagates source edits to the `correctless/` distribution |
 
 ## Design Patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,10 @@ bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 
 ```
 skills/               # Source skills (27 SKILL.md files)
-hooks/                # Bash hooks (gate, state machine, statusline, audit trail)
+hooks/                # Bash hooks (gate, sensitive-file-guard, state machine, statusline, audit trail, auto-format, token-tracking)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT guides per language (high+ intensity)
-tests/                # 48 test files (~3,900 assertions)
+tests/                # 48 test files (~3,800 assertions)
 setup                 # Install script
 sync.sh               # Copies source → correctless/ distribution
 correctless/          # Single distribution (27 skills, intensity-gated)
@@ -72,7 +72,7 @@ The hooks (`hooks/workflow-gate.sh`, `hooks/workflow-advance.sh`, `hooks/audit-t
 - **Gate must be <5s.** It runs before every file edit.
 - **Audit trail must be <100ms.** It runs after every tool call.
 - **Statusline must be <50ms.** It renders continuously.
-- **All hooks must be macOS + Linux portable.** Test with: `md5sum || md5`, `stat -c || stat -f`, no bashisms beyond what bash 3.2 supports.
+- **All hooks must be macOS + Linux portable.** Requires Bash 4+ (see ENV-001). Test with: `md5sum || md5`, `stat -c || stat -f`. macOS users need Homebrew bash (`brew install bash`).
 - **Gate must never fail open.** If something goes wrong, block (exit 2), don't allow (exit 0). Exception: the no-state-file path.
 
 Run ShellCheck before submitting: `shellcheck hooks/*.sh`
@@ -80,7 +80,7 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Code Style
 
 - **Skills:** Markdown with YAML frontmatter. Keep descriptions as trigger conditions ("Use when X"), not capability summaries.
-- **Hooks:** Bash with `set -euo pipefail`. Portable to macOS bash 3.2 + BSD tools.
+- **PreToolUse hooks:** Bash with `set -euo pipefail` (fail-closed, see PAT-001). **PostToolUse hooks:** NO `set -euo pipefail` (fail-open, see PAT-005). Requires Bash 4+.
 - **Tests:** Bash assertions in `tests/test*.sh`. Each test is a function that prints PASS/FAIL.
 - **No emojis in skill files** unless the user explicitly requests them.
 - **No model overrides** in skill frontmatter (`model:` field). Removed early to avoid rate limits.
@@ -88,8 +88,8 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Testing
 
 ```bash
-# Run all 48 test suites (canonical command from workflow-config.json):
-bash tests/test.sh && bash tests/test-mcp.sh && bash tests/test-bugfixes.sh && bash tests/test-qol.sh && bash tests/test-decisions.sh && bash tests/test-statusline.sh && bash tests/test-consolidation.sh && bash tests/test-crelease.sh && bash tests/test-calm-resets.sh && bash tests/test-dynamic-rigor.sh && bash tests/test-intensity-detection.sh && bash tests/test-wire-intensity-creview.sh && bash tests/test-wire-intensity-pipeline.sh && bash tests/test-cexplain.sh && bash tests/test-auto-format.sh && bash tests/test-sensitive-file-guard.sh && bash tests/test-antipattern-scan.sh
+# Run all 48 test suites — use the canonical command from workflow-config.json:
+jq -r '.commands.test' .correctless/config/workflow-config.json | bash
 
 # Quick smoke test (2 suites):
 bash tests/test.sh && bash tests/test-mcp.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ skills/               # Source skills (27 SKILL.md files)
 hooks/                # Bash hooks (gate, state machine, statusline, audit trail)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT guides per language (high+ intensity)
-tests/                # 32 test files (~2,000 assertions)
+tests/                # 48 test files (~3,900 assertions)
 setup                 # Install script
 sync.sh               # Copies source → correctless/ distribution
 correctless/          # Single distribution (27 skills, intensity-gated)
@@ -88,7 +88,7 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Testing
 
 ```bash
-# Run all 32 test suites (canonical command from workflow-config.json):
+# Run all 48 test suites (canonical command from workflow-config.json):
 bash tests/test.sh && bash tests/test-mcp.sh && bash tests/test-bugfixes.sh && bash tests/test-qol.sh && bash tests/test-decisions.sh && bash tests/test-statusline.sh && bash tests/test-consolidation.sh && bash tests/test-crelease.sh && bash tests/test-calm-resets.sh && bash tests/test-dynamic-rigor.sh && bash tests/test-intensity-detection.sh && bash tests/test-wire-intensity-creview.sh && bash tests/test-wire-intensity-pipeline.sh && bash tests/test-cexplain.sh && bash tests/test-auto-format.sh && bash tests/test-sensitive-file-guard.sh && bash tests/test-antipattern-scan.sh
 
 # Quick smoke test (2 suites):

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ graph LR
     style F fill:#51cf66,color:#fff
 ```
 
-Each box is a separate agent. The test writer doesn't know the implementation plan. The QA agent didn't write the tests. A PreToolUse hook blocks source code edits until tests exist — this isn't a suggestion, it's enforced by bash. See the [Standard Workflow Guide](https://joshft.github.io/correctless/standard-workflow) for state machine diagrams, hook architecture, and phase gating details.
+Each box is a separate agent. The test writer doesn't know the implementation plan. The QA agent didn't write the tests. A PreToolUse hook blocks source code edits until tests exist — this isn't a suggestion, it's enforced by bash. See the [Standard Workflow Guide](docs/standard-workflow.md) for state machine diagrams, hook architecture, and phase gating details.
 
 ### The Critical Workflow
 
@@ -381,11 +381,37 @@ Mutation testing and PBT helpers are available at high+ intensity. Standard inte
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI
 - A **Claude Max subscription** ($100/mo or $200/mo plan). Correctless spawns multiple agents per feature — $200/mo is recommended at high+ intensity.
 - A project with a test runner
+- **jq** (JSON processor) — required for all hooks. Install: `brew install jq` (macOS), `apt install jq` (Ubuntu)
+- **Bash 4+** — required for hooks. macOS ships Bash 3.2 by default; install modern bash: `brew install bash`
 
 Optional (high+/critical):
 - [Alloy Analyzer](https://alloytools.org/) for formal modeling
 - Mutation testing tool for your language
 - Isolated environment (Docker/VPS) for red team assessments
+
+## Good to Know
+
+**Opt-in per feature.** Correctless is passive when no workflow is active. Start a workflow with `/cspec` on a feature branch — skip it on branches where you don't need it. All normal Claude Code behavior is unchanged outside active workflows.
+
+**CI unchanged.** Correctless runs entirely inside Claude Code sessions via local hooks. It does not modify your CI pipeline, add CI steps, or require any CI changes.
+
+**After merge.** Delete the feature branch and start fresh with a new branch + `/cspec`. Workflow state files in `.correctless/artifacts/` are branch-scoped and harmless — they provide history for `/cmetrics` and `/csummary`.
+
+### Uninstall
+
+To fully remove Correctless from a project:
+
+```bash
+# Remove the plugin
+/plugin uninstall correctless
+
+# Clean up project files
+rm -rf .correctless/
+rm -f scripts/lib.sh scripts/antipattern-scan.sh
+
+# Remove hook entries from .claude/settings.json (edit manually or delete the file)
+# Remove the "## Correctless" section from CLAUDE.md if present
+```
 
 ## Glossary
 
@@ -406,7 +432,7 @@ Optional (high+/critical):
 
 ## Status
 
-**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,800 automated tests, 5 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
+**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,800 automated tests, 7 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Optional (high+/critical):
 
 ## Status
 
-**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,900 automated tests, 4 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
+**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,800 automated tests, 5 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/joshft/correctless/badge)](https://scorecard.dev/viewer/?uri=github.com/joshft/correctless)
 [![CI](https://github.com/joshft/correctless/actions/workflows/ci.yml/badge.svg)](https://github.com/joshft/correctless/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Skills: 26](https://img.shields.io/badge/skills-26-blue.svg)](docs/skills/)
+[![Skills: 27](https://img.shields.io/badge/skills-27-blue.svg)](docs/skills/)
 [![Version: 3.0.0](https://img.shields.io/badge/version-3.0.0-green.svg)](CHANGELOG.md)
 
 Composable [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills that enforce a correctness-oriented development workflow. Spec before you code. Test before you implement. Never let an agent grade its own work.
@@ -406,7 +406,7 @@ Optional (high+/critical):
 
 ## Status
 
-**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,060 automated tests, 4 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
+**Correctless 3.0.0 — Early release.** 27 skills, 3 intensity levels, ~3,900 automated tests, 4 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
 
 ## License
 

--- a/agents/supervisor.md
+++ b/agents/supervisor.md
@@ -84,7 +84,9 @@ standard supervisor input:
 > independently verify:
 >
 > 1. **Pre-existing claims**: Did the cross-check evidence confirm the claim?
->    If claim_verified is false, reject immediately.
+>    If claim_verified is false, reject immediately. If claim_verified is
+>    null (infrastructure failure — timeout, no test command), escalate to
+>    human — do not approve with inconclusive evidence.
 > 2. **Scope drift**: Does the file-touch evidence show files outside the
 >    override reason, spec scope, or intent summary? If so, escalate.
 > 3. **Pretext**: At window closure, did the accumulated work actually ADDRESS

--- a/correctless/agents/supervisor.md
+++ b/correctless/agents/supervisor.md
@@ -84,7 +84,9 @@ standard supervisor input:
 > independently verify:
 >
 > 1. **Pre-existing claims**: Did the cross-check evidence confirm the claim?
->    If claim_verified is false, reject immediately.
+>    If claim_verified is false, reject immediately. If claim_verified is
+>    null (infrastructure failure — timeout, no test command), escalate to
+>    human — do not approve with inconclusive evidence.
 > 2. **Scope drift**: Does the file-touch evidence show files outside the
 >    override reason, spec scope, or intent summary? If so, escalate.
 > 3. **Pretext**: At window closure, did the accumulated work actually ADDRESS

--- a/correctless/hooks/sensitive-file-guard.sh
+++ b/correctless/hooks/sensitive-file-guard.sh
@@ -478,7 +478,8 @@ while IFS= read -r target; do
   matched_pattern="$(_check_file_against_patterns "$target")" || true
 
   if [ -n "$matched_pattern" ]; then
-    echo "BLOCKED [sensitive-file]: $target matches protected pattern '$matched_pattern'. Edit sensitive files manually." >&2
+    echo "BLOCKED [sensitive-file]: $target matches protected pattern '$matched_pattern'.
+  Edit this file outside Claude Code, or add an exclusion to protected_files.custom_patterns in .correctless/config/workflow-config.json if this file is not actually sensitive." >&2
     exit 2
   fi
 done <<< "$FILE_TARGETS"

--- a/correctless/hooks/sensitive-file-guard.sh
+++ b/correctless/hooks/sensitive-file-guard.sh
@@ -340,7 +340,10 @@ id_ed25519.*
 *.jks
 .correctless/preferences.md
 .correctless/config/auto-policy.json
-.correctless/artifacts/intent-*.md"
+.correctless/config/workflow-config.json
+.correctless/artifacts/intent-*.md
+.correctless/artifacts/workflow-state-*.json
+.correctless/artifacts/decision-record-*.md"
 
 # ============================================
 # STEP 7: Read custom patterns from config (INV-005)

--- a/correctless/hooks/sensitive-file-guard.sh
+++ b/correctless/hooks/sensitive-file-guard.sh
@@ -280,6 +280,68 @@ _extract_bash_targets() {
           continue
         fi
         ;;
+      # touch/chmod/chown/chgrp/mkdir: emit all non-flag arguments (R6 fix)
+      touch|chmod|chown|chgrp|mkdir)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # tar: emit all non-flag arguments (archive and extracted files)
+      tar)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # unzip/7z/cpio/ar: emit all non-flag arguments (R6 fix)
+      unzip|7z|cpio|ar)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # scp/sftp: emit all non-flag arguments (R6 fix)
+      scp|sftp)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # git write subcommands: emit all non-flag arguments after the subcommand
+      git)
+        if [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean|apply|am|merge|rebase|cherry-pick) ]]; then
+          i=$((i + 2))  # skip 'git' and the subcommand
+          while [ $i -lt ${#tokens[@]} ]; do
+            case "${tokens[$i]}" in
+              -*) ;;
+              *) _strip_quotes "${tokens[$i]}" ;;
+            esac
+            i=$((i + 1))
+          done
+          continue
+        fi
+        ;;
       # python/node/ruby: generic interpreters that could write to any file
       # Over-extract all non-flag tokens as potential targets (downstream matching filters)
       python|python3|node|ruby)

--- a/correctless/hooks/sensitive-file-guard.sh
+++ b/correctless/hooks/sensitive-file-guard.sh
@@ -340,7 +340,6 @@ id_ed25519.*
 *.jks
 .correctless/preferences.md
 .correctless/config/auto-policy.json
-.correctless/config/workflow-config.json
 .correctless/artifacts/intent-*.md
 .correctless/artifacts/workflow-state-*.json
 .correctless/artifacts/decision-record-*.md"

--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -115,7 +115,8 @@ require_phase() {
   local expected="$1"
   local current
   current="$(read_phase)"
-  [ "$current" = "$expected" ] || die "Expected phase '$expected', but current phase is '$current'"
+  [ "$current" = "$expected" ] || die "Expected phase '$expected', but current phase is '$current'.
+  Run /cstatus to see available transitions, or use 'workflow-advance.sh status' for details."
 }
 
 require_phase_oneof() {
@@ -124,7 +125,8 @@ require_phase_oneof() {
   for p in "$@"; do
     [ "$current" = "$p" ] && return 0
   done
-  die "Current phase '$current' is not one of: $*"
+  die "Current phase '$current' is not one of: $*.
+  Run /cstatus to see available transitions, or use 'workflow-advance.sh status' for details."
 }
 
 read_config_field() {
@@ -372,7 +374,8 @@ cmd_init() {
   [ -z "$default_branch" ] && default_branch="main"
 
   if [ "$branch" = "$default_branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
-    die "Cannot init workflow on '$branch'. Create a feature branch first: git checkout -b feature/my-feature"
+    die "Cannot init workflow on '$branch'. Create a feature branch first: git checkout -b feature/my-feature
+  For small fixes (< 50 LOC), try /cquick instead."
   fi
 
   local sf
@@ -864,7 +867,7 @@ cmd_override() {
     [ -f "$_os_dir/override-scrutiny.sh" ] && source "$_os_dir/override-scrutiny.sh" 2>/dev/null
   }; then
     if ! check_override_retry "$reason" "$sf" 2>/dev/null; then
-      die "Override rejected: too similar to a previously rejected override (Jaccard >= 0.4). Rephrase with a materially different justification."
+      die "Override rejected: your reason is too similar to a previous override request. Provide a genuinely different justification — explain why this specific edit is needed, not just a rephrasing of the previous reason."
     fi
   fi
 

--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -857,6 +857,17 @@ cmd_override() {
     die "Override limit reached (3 per workflow). If the gate is consistently blocking legitimate edits, the workflow config or patterns may need adjustment. Use 'reset' as a last resort."
   fi
 
+  # R4-S1: Check for Jaccard retry prevention (PRH-006)
+  if command -v jaccard_similarity >/dev/null 2>&1 || {
+    local _os_dir
+    _os_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/../scripts"
+    [ -f "$_os_dir/override-scrutiny.sh" ] && source "$_os_dir/override-scrutiny.sh" 2>/dev/null
+  }; then
+    if ! check_override_retry "$reason" "$sf" 2>/dev/null; then
+      die "Override rejected: too similar to a previously rejected override (Jaccard >= 0.4). Rephrase with a materially different justification."
+    fi
+  fi
+
   # Block renewal while an override is still active
   local override_active
   override_active="$(echo "$state" | jq -r '.override.active // false')"

--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -823,6 +823,9 @@ cmd_reset() {
           "$ARTIFACTS_DIR/checkpoint-creview-spec-"*.json "$ARTIFACTS_DIR/checkpoint-caudit-"*.json 2>/dev/null
     rm -f "$ARTIFACTS_DIR/.pkg-cache-"*.json 2>/dev/null
     rm -f "$ARTIFACTS_DIR/tdd-test-edits.log" "$ARTIFACTS_DIR/coverage-baseline-${slug_hash}.out" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/token-log-${slug_hash}.jsonl" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/review-decisions-${slug_hash}.json" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/antipattern-findings-${slug_hash}.json" 2>/dev/null
     # Clean lock dirs and temp files from locking operations
     rm -rf "${sf}.lock" "${sf}.lock.breaking."* 2>/dev/null
     rm -f "${sf}."*.tmp "${sf}."[0-9]* 2>/dev/null

--- a/correctless/hooks/workflow-gate.sh
+++ b/correctless/hooks/workflow-gate.sh
@@ -130,9 +130,10 @@ if [ ! -f "$STATE_FILE" ]; then
           IFS="$_FC_OLDIFS"
           case "$BASENAME_CHECK" in
             $p)
-              echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+              echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
               exit 2
               ;;
@@ -152,9 +153,10 @@ if [ ! -f "$STATE_FILE" ]; then
             IFS="$_FC_OLDIFS2"
             case "$_fc_bn" in
               $p)
-                echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+                echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
                 exit 2
                 ;;
@@ -177,9 +179,10 @@ if [ ! -f "$STATE_FILE" ]; then
             IFS="$_FC_OLDIFS"
             case "$BASENAME_CHECK" in
               $p)
-                echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+                echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
                 exit 2
                 ;;
@@ -202,12 +205,18 @@ eval "$(jq -r '
   @sh "OVERRIDE_ACTIVE=\(.override.active // false)",
   @sh "OVERRIDE_REMAINING=\(.override.remaining_calls // 0)"
 ' "$STATE_FILE" 2>/dev/null)" || {
-  echo "BLOCKED: State file is corrupt or unreadable. Run workflow-advance.sh status to check." >&2
+  echo "BLOCKED: State file is corrupt or unreadable.
+  Try: .correctless/hooks/workflow-advance.sh status
+  If that also fails: .correctless/hooks/workflow-advance.sh reset
+  (Reset removes state for this branch — restart with init.)" >&2
   exit 2
 }
 # Post-eval validation: if PHASE is still empty, jq produced no output (corrupt file)
 if [ -z "$PHASE" ]; then
-  echo "BLOCKED: State file is corrupt or unreadable. Run workflow-advance.sh status to check." >&2
+  echo "BLOCKED: State file is corrupt or unreadable.
+  Try: .correctless/hooks/workflow-advance.sh status
+  If that also fails: .correctless/hooks/workflow-advance.sh reset
+  (Reset removes state for this branch — restart with init.)" >&2
   exit 2
 fi
 

--- a/correctless/scripts/auto-policy.sh
+++ b/correctless/scripts/auto-policy.sh
@@ -83,7 +83,7 @@ policy_evaluate() {
   local disposition=""
 
   case "$phase" in
-    review)
+    review|review-spec)
       disposition="$(echo "$parsed" | jq -r --arg cat "$category" \
         '.review_dispositions[$cat] // .review_dispositions.default // empty' 2>/dev/null)" || true
       ;;
@@ -95,7 +95,7 @@ policy_evaluate() {
         disposition="tier2_decide"
       fi
       ;;
-    verify|done|verified)
+    verify|done|verified|tdd-verify)
       disposition="$(echo "$parsed" | jq -r --arg cat "$category" \
         '.drift[$cat] // empty' 2>/dev/null)" || true
       ;;

--- a/correctless/scripts/budget-check.sh
+++ b/correctless/scripts/budget-check.sh
@@ -123,6 +123,11 @@ budget_check() {
     return 0
   fi
 
+  # R2-F4: guard against division by zero if policy sets max_tokens to 0
+  if [ "$max_tokens" -le 0 ] 2>/dev/null; then
+    max_tokens=2000000
+  fi
+
   # Calculate token percentage
   local token_pct=$(( (token_usage * 100) / max_tokens ))
 

--- a/correctless/scripts/budget-check.sh
+++ b/correctless/scripts/budget-check.sh
@@ -98,10 +98,10 @@ budget_check() {
 
   local time_exceeded="no" time_warn="no"
   if [ -n "$elapsed" ] && [ "$elapsed" != "0" ]; then
-    eval "$(awk "BEGIN {
-      if ($elapsed >= $max_hours) print \"time_exceeded=yes\"
-      else if ($elapsed >= $warn_hours) print \"time_warn=yes\"
-    }")"
+    eval "$(awk -v elapsed="$elapsed" -v max_hours="$max_hours" -v warn_hours="$warn_hours" 'BEGIN {
+      if (elapsed >= max_hours) print "time_exceeded=yes"
+      else if (elapsed >= warn_hours) print "time_warn=yes"
+    }')"
   fi
 
   if [ "$time_exceeded" = "yes" ]; then

--- a/correctless/scripts/cauto-lock.sh
+++ b/correctless/scripts/cauto-lock.sh
@@ -78,7 +78,8 @@ lock_check_stale() {
     # PID is alive — lock is active
     return 1
   else
-    # PID is dead — stale lock, auto-clean
+    # PID is dead — stale lock, auto-clean (including .d directory from atomic locking)
+    rm -rf "${lock_file}.d" 2>/dev/null
     rm -f "$lock_file"
     return 0
   fi

--- a/correctless/scripts/cauto-lock.sh
+++ b/correctless/scripts/cauto-lock.sh
@@ -12,20 +12,33 @@
 # Writes current PID to lockfile. Checks for stale locks (BND-006).
 lock_acquire() {
   local lock_file="$1"
+  local lock_dir="${lock_file}.d"
 
-  if [ -f "$lock_file" ]; then
-    # Check if existing lock is stale (0=stale/cleaned, 1=active, 2=corrupted)
-    lock_check_stale "$lock_file"
-    case $? in
-      0) ;; # Stale lock was auto-cleaned — proceed to acquire
-      1) echo "ERROR: Another /cauto run is active on this branch." >&2; return 1 ;;
-      2) echo "ERROR: Lockfile corrupted; delete '$lock_file' manually if no /cauto run is active." >&2; return 1 ;;
-    esac
+  # QA-015: use mkdir for atomic lock creation (matches lib.sh pattern)
+  if mkdir "$lock_dir" 2>/dev/null; then
+    # Acquired — write PID inside the lock directory
+    echo "$$" > "$lock_dir/pid" 2>/dev/null || true
+    # Also write to the legacy lock_file location for lock_check_stale compat
+    echo "$$" > "$lock_file" 2>/dev/null || true
+    return 0
   fi
 
-  # Create lockfile with current PID
-  echo "$$" > "$lock_file" || return 1
-  return 0
+  # Lock dir exists — check if stale
+  lock_check_stale "$lock_file"
+  case $? in
+    0)
+      # Stale lock was cleaned — retry acquire
+      if mkdir "$lock_dir" 2>/dev/null; then
+        echo "$$" > "$lock_dir/pid" 2>/dev/null || true
+        echo "$$" > "$lock_file" 2>/dev/null || true
+        return 0
+      fi
+      echo "ERROR: Another /cauto run is active on this branch." >&2
+      return 1
+      ;;
+    1) echo "ERROR: Another /cauto run is active on this branch." >&2; return 1 ;;
+    2) echo "ERROR: Lockfile corrupted; delete '$lock_file' and '$lock_dir' manually if no /cauto run is active." >&2; return 1 ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -34,6 +47,7 @@ lock_acquire() {
 # Usage: lock_release LOCK_FILE
 lock_release() {
   local lock_file="$1"
+  rm -rf "${lock_file}.d" 2>/dev/null
   rm -f "$lock_file"
   return 0
 }

--- a/correctless/scripts/decision-record.sh
+++ b/correctless/scripts/decision-record.sh
@@ -54,7 +54,7 @@ drx_validate() {
   category="$(echo "$dr_json" | jq -r '.category' 2>/dev/null)"
 
   case "$category" in
-    security|availability|testability|scope_expansion|performance|architecture|observability|technical_debt|intent|hard_stop_multiplex)
+    security|availability|testability|scope_expansion|performance|architecture|observability|technical_debt|intent|hard_stop_multiplex|dependency|budget|policy|configuration)
       # Valid category
       ;;
     *)

--- a/correctless/scripts/decision-routing.sh
+++ b/correctless/scripts/decision-routing.sh
@@ -132,6 +132,8 @@ tier2_build_context() {
   # Use a temp file approach for complex JSON to avoid shell quoting issues
   local _ctx_tmp
   _ctx_tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$_ctx_tmp'" EXIT
   echo "$dr_json" > "$_ctx_tmp"
 
   local result
@@ -148,6 +150,7 @@ tier2_build_context() {
     }' 2>/dev/null)"
   local rc=$?
   rm -f "$_ctx_tmp"
+  trap - EXIT
   echo "$result"
   return "$rc"
 }

--- a/correctless/scripts/decision-routing.sh
+++ b/correctless/scripts/decision-routing.sh
@@ -133,7 +133,7 @@ tier2_build_context() {
   local _ctx_tmp
   _ctx_tmp="$(mktemp)"
   # shellcheck disable=SC2064
-  trap "rm -f '$_ctx_tmp'" EXIT
+  trap "$(printf 'rm -f %q' "$_ctx_tmp")" EXIT
   echo "$dr_json" > "$_ctx_tmp"
 
   local result

--- a/correctless/scripts/lib.sh
+++ b/correctless/scripts/lib.sh
@@ -238,6 +238,7 @@ _has_write_pattern() {
   for tok in $cmd; do
     case "$tok" in
       cp|mv|tee|install|rm|rmdir|unlink|dd|curl|wget|rsync|patch|truncate|shred|ln|python|python3|node|ruby) return 0 ;;
+      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean) ]] && return 0 ;;
       sed) [[ "$cmd" =~ sed[[:space:]]+-i ]] && return 0 ;;
       perl) [[ "$cmd" =~ perl[[:space:]]+-i ]] && return 0 ;;
     esac

--- a/correctless/scripts/lib.sh
+++ b/correctless/scripts/lib.sh
@@ -238,7 +238,8 @@ _has_write_pattern() {
   for tok in $cmd; do
     case "$tok" in
       cp|mv|tee|install|rm|rmdir|unlink|dd|curl|wget|rsync|patch|truncate|shred|ln|python|python3|node|ruby) return 0 ;;
-      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean) ]] && return 0 ;;
+      tar|unzip|7z|cpio|ar|touch|chmod|chown|chgrp|scp|sftp|mkdir) return 0 ;;
+      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean|apply|am|merge|rebase|cherry-pick) ]] && return 0 ;;
       sed) [[ "$cmd" =~ sed[[:space:]]+-i ]] && return 0 ;;
       perl) [[ "$cmd" =~ perl[[:space:]]+-i ]] && return 0 ;;
     esac

--- a/correctless/scripts/override-crosscheck.sh
+++ b/correctless/scripts/override-crosscheck.sh
@@ -121,7 +121,12 @@ base_commit_crosscheck() {
   # Clean up worktree on exit
   local worktree_path="${worktree_dir}/crosscheck"
 
+  # QA-005: trap for worktree cleanup on signal/abnormal exit
+  # shellcheck disable=SC2064
+  trap "(cd '$config_dir' && git worktree remove --force '$worktree_path' 2>/dev/null) || true; rm -rf '$worktree_dir' 2>/dev/null" EXIT SIGTERM SIGINT
+
   if ! (cd "$config_dir" && git worktree add -q "$worktree_path" "$base_commit" 2>/dev/null); then
+    trap - EXIT SIGTERM SIGINT
     rm -rf "$worktree_dir"
     jq -n --arg bc "$base_commit" '{
       pre_existing_claimed: false,
@@ -150,22 +155,27 @@ base_commit_crosscheck() {
   local build_success="false"
   [ "$build_exit_code" -eq 0 ] && build_success="true"
 
-  # Clean up worktree
+  # Clean up worktree (trap handles abnormal exit; explicit cleanup for normal path)
   (cd "$config_dir" && git worktree remove --force "$worktree_path" 2>/dev/null) || true
   rm -rf "$worktree_dir" 2>/dev/null || true
+  trap - EXIT SIGTERM SIGINT
 
   # Determine claim_verified: if build fails on base, the claim might be true
   # If build succeeds on base, the pre-existing claim is false
+  # QA-014: timeout is inconclusive (null), not disconfirmed (false)
   local claim_verified="false"
   if [ "$build_success" = "false" ] && [ "$failure_mode_val" = "null" ]; then
     claim_verified="true"
+  elif [ "$failure_mode_val" != "null" ]; then
+    # Timeout or other non-clean failure — inconclusive
+    claim_verified="null"
   fi
 
   jq -n --arg bc "$base_commit" \
     --argjson success "$build_success" \
     --argjson exit_code "$build_exit_code" \
     --arg stderr "$build_stderr" \
-    --argjson verified "$claim_verified" \
+    --arg verified "$claim_verified" \
     --arg fm "$failure_mode_val" \
     '{
       pre_existing_claimed: false,
@@ -173,7 +183,7 @@ base_commit_crosscheck() {
       base_build_success: $success,
       base_build_exit_code: $exit_code,
       base_build_stderr: $stderr,
-      claim_verified: $verified,
+      claim_verified: (if $verified == "null" then null elif $verified == "true" then true else false end),
       failure_mode: (if $fm == "null" then null else $fm end)
     }'
 
@@ -375,6 +385,19 @@ check_spec_completeness() {
       missing_deliverables: [],
       check_applicable: false,
       complete: true
+    }'
+    return 0
+  fi
+
+  # QA-007: Validate completed_files_json before --argjson (fail-closed on malformed input)
+  if ! echo "$_completed_files_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    # Malformed completed_files — fail-closed: report all deliverables as missing
+    jq -n --argjson declared "$deliverables" '{
+      declared_deliverables: $declared,
+      completed_deliverables: [],
+      missing_deliverables: $declared,
+      check_applicable: true,
+      complete: false
     }'
     return 0
   fi

--- a/correctless/scripts/override-crosscheck.sh
+++ b/correctless/scripts/override-crosscheck.sh
@@ -49,7 +49,7 @@ detect_pre_existing_claim() {
 # Usage: base_commit_crosscheck CONFIG_FILE
 # Outputs cross-check evidence JSON:
 #   {"pre_existing_claimed":bool,"base_commit":"...","base_build_success":bool,
-#    "base_build_exit_code":N,"base_build_stderr":"...","claim_verified":bool,
+#    "base_build_exit_code":N,"base_build_stderr":"...","claim_verified":bool|null,
 #    "failure_mode":null|"..."}
 base_commit_crosscheck() {
   local _config_file="$1"
@@ -70,7 +70,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "no_test_command"
     }'
     return 0
@@ -97,7 +97,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "merge_base_failed"
     }'
     return 0
@@ -112,7 +112,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "worktree_creation_failed"
     }'
     return 0
@@ -123,7 +123,7 @@ base_commit_crosscheck() {
 
   # QA-005: trap for worktree cleanup on signal/abnormal exit
   # shellcheck disable=SC2064
-  trap "(cd '$config_dir' && git worktree remove --force '$worktree_path' 2>/dev/null) || true; rm -rf '$worktree_dir' 2>/dev/null" EXIT SIGTERM SIGINT
+  trap "$(printf '(cd %q && git worktree remove --force %q 2>/dev/null) || true; rm -rf %q 2>/dev/null' "$config_dir" "$worktree_path" "$worktree_dir")" EXIT SIGTERM SIGINT
 
   if ! (cd "$config_dir" && git worktree add -q "$worktree_path" "$base_commit" 2>/dev/null); then
     trap - EXIT SIGTERM SIGINT
@@ -134,7 +134,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "worktree_add_failed"
     }'
     return 0

--- a/correctless/scripts/override-scrutiny.sh
+++ b/correctless/scripts/override-scrutiny.sh
@@ -87,9 +87,17 @@ review_override_issuance() {
 
   if [ "$claim_verified" = "false" ]; then
     # Pre-existing claim was false — reject the override
-    # In production, the supervisor agent would make this decision via
-    # Task(subagent_type="correctless:supervisor") with activation_type override_issued
+    # QA-006: persist rejection so Jaccard retry prevention (PRH-006) can detect retries
+    if [ -f "$_state_file" ]; then
+      locked_update_state "$_state_file" \
+        '.rejected_overrides = ((.rejected_overrides // []) + [$reason])' \
+        --arg reason "$_override_reason" 2>/dev/null || true
+    fi
     echo "reject_override"
+    return 0
+  elif [ "$claim_verified" = "null" ]; then
+    # QA-014: timeout or inconclusive — escalate instead of rejecting
+    echo "escalate_to_human"
     return 0
   fi
 
@@ -109,6 +117,11 @@ build_override_action_payload() {
   local _override_reason="$2"
   local _intent_summary="$3"
   local _dd_entries_since="$4"
+
+  # QA-026: validate _dd_entries_since is valid JSON before --argjson
+  if ! echo "$_dd_entries_since" | jq -e '.' >/dev/null 2>&1; then
+    _dd_entries_since="[]"
+  fi
 
   # Build JSON payload using jq --arg (AP-010)
   jq -n \
@@ -293,13 +306,13 @@ update_override_log() {
 
   # Use locked_update_state from lib.sh for atomic read-modify-write (AP-010)
   locked_update_state "$_state_file" \
-    '.override_log = ((.override_log // []) + [{
+    '.override_log = (((.override_log // []) + [{
        override_id: $oid,
        review_type: $rt,
        disposition: $disp,
        reasoning: $rsn,
        timestamp: $ts
-     }])' \
+     }]) | .[-100:])' \
     --arg oid "$_override_id" --arg rt "$_review_type" \
     --arg disp "$_disposition" --arg rsn "$_reasoning" --arg ts "$timestamp"
 }

--- a/correctless/scripts/override-scrutiny.sh
+++ b/correctless/scripts/override-scrutiny.sh
@@ -84,6 +84,10 @@ review_override_issuance() {
           echo "hard_stop"
           return 0
         fi
+      else
+        # R5-F2: Intent file missing or path unknown — fail-closed
+        echo "hard_stop"
+        return 0
       fi
     fi
   fi

--- a/correctless/scripts/override-scrutiny.sh
+++ b/correctless/scripts/override-scrutiny.sh
@@ -90,7 +90,7 @@ review_override_issuance() {
     # QA-006: persist rejection so Jaccard retry prevention (PRH-006) can detect retries
     if [ -f "$_state_file" ]; then
       locked_update_state "$_state_file" \
-        '.rejected_overrides = ((.rejected_overrides // []) + [$reason])' \
+        '.rejected_overrides = (((.rejected_overrides // []) + [$reason]) | .[-50:])' \
         --arg reason "$_override_reason" 2>/dev/null || true
     fi
     echo "reject_override"
@@ -118,8 +118,8 @@ build_override_action_payload() {
   local _intent_summary="$3"
   local _dd_entries_since="$4"
 
-  # QA-026: validate _dd_entries_since is valid JSON before --argjson
-  if ! echo "$_dd_entries_since" | jq -e '.' >/dev/null 2>&1; then
+  # QA-026 + R2-F10: validate _dd_entries_since is a JSON array before --argjson
+  if ! echo "$_dd_entries_since" | jq -e 'type == "array"' >/dev/null 2>&1; then
     _dd_entries_since="[]"
   fi
 

--- a/correctless/scripts/override-scrutiny.sh
+++ b/correctless/scripts/override-scrutiny.sh
@@ -70,8 +70,23 @@ review_override_issuance() {
   local _decision_record_file="$5"
   local _crosscheck_evidence="$6"
 
-  # BND-008: Intent hash presence check.
-  # In production, intent_verify would be called for full verification.
+  # R4-S4 / BND-008: Intent hash verification (mirrors review_override_action pattern)
+  if [ -f "$_state_file" ]; then
+    local stored_intent_hash
+    stored_intent_hash="$(jq -r '.intent_hash // ""' "$_state_file" 2>/dev/null)" || true
+    if [ -n "$stored_intent_hash" ] && [ "$stored_intent_hash" != "null" ]; then
+      local intent_file
+      intent_file="$(jq -r '.intent_file // ""' "$_state_file" 2>/dev/null)" || intent_file=""
+      if [ -n "$intent_file" ] && [ -f "$intent_file" ]; then
+        local current_intent_hash
+        current_intent_hash="$(sha256_hash_file "$intent_file" 2>/dev/null)" || current_intent_hash=""
+        if [ -n "$current_intent_hash" ] && [ "$current_intent_hash" != "$stored_intent_hash" ]; then
+          echo "hard_stop"
+          return 0
+        fi
+      fi
+    fi
+  fi
 
   # BND-006: Validate cross-check evidence is valid JSON
   if ! echo "$_crosscheck_evidence" | jq '.' >/dev/null 2>&1; then

--- a/correctless/scripts/review-triage.sh
+++ b/correctless/scripts/review-triage.sh
@@ -154,7 +154,7 @@ enforce_prh003() {
       if $decision == null then
         # R2-F2: missing decision — hard_stop for security, accept for non-security
         if $is_security then {"decision": "hard_stop", "prh003_missing_decision": true}
-        else {"decision": "accept", "prh003_missing_decision": true}
+        else {"decision": "accept", "prh003_missing_decision": true, "reasoning": "Auto-accepted: supervisor returned fewer decisions than findings"}
         end
       elif $is_security and ($decision.decision == "reject") then
         $decision | .decision = "hard_stop" | .prh003_override = true

--- a/correctless/scripts/review-triage.sh
+++ b/correctless/scripts/review-triage.sh
@@ -131,14 +131,20 @@ enforce_prh003() {
   # Security keywords from PRH-001 (security-scan.sh keyword list)
   local security_keywords="auth credential encrypt token secret permission access control trust boundary identity authorization login verification level privilege"
 
-  # Process each finding: if source_agent is red-team OR category/summary
-  # contains security keywords, and supervisor returned "reject", override to "hard_stop"
+  # QA-004: Cardinality assertion — fail-closed on array length mismatch.
+  # If supervisor returned fewer decisions than findings, security findings
+  # beyond the response are silently dropped. Iterate over findings length
+  # and treat missing decisions as hard_stop for security-tagged findings.
   local result
   result="$(jq -n --argjson resp "$_supervisor_response" --argjson findings "$_findings_json" \
     --arg keywords "$security_keywords" '
-    [range($resp | length)] | map(. as $i |
-      $resp[$i] as $decision |
+    [range($findings | length)] | map(. as $i |
+      ($resp[$i] // null) as $decision |
       $findings[$i] as $finding |
+      # QA-004: if decision is null (supervisor returned fewer), use hard_stop for security
+      if $decision == null then
+        {"decision": "hard_stop", "prh003_missing_decision": true}
+      else
       (
         # Check if this finding requires PRH-003 enforcement
         ($finding.source_agent == "red-team") or
@@ -155,6 +161,7 @@ enforce_prh003() {
         $decision | .decision = "hard_stop" | .prh003_override = true
       else
         $decision
+      end
       end
     )
   ' 2>/dev/null)" || { echo "[]"; return 1; }
@@ -210,8 +217,22 @@ triage_findings_batch() {
   raw_decisions="$($supervisor_fn "$_findings_json" 2>/dev/null)" || { echo "[]"; return 1; }
 
   # Step 4: Apply enforce_prh003 post-processing on supervisor result
+  # QA-001: fail-closed — if enforcement fails and security findings exist,
+  # force hard_stop on all security-tagged findings instead of passing through raw decisions
   local result
-  result="$(enforce_prh003 "$raw_decisions" "$_findings_json" 2>/dev/null)" || result="$raw_decisions"
+  if ! result="$(enforce_prh003 "$raw_decisions" "$_findings_json" 2>/dev/null)"; then
+    # Check if any finding is security-tagged — if so, fail-closed
+    local has_security
+    has_security="$(echo "$_findings_json" | jq '[.[] | select(
+      .source_agent == "red-team" or .category == "security"
+    )] | length' 2>/dev/null)" || has_security="0"
+    if [ "$has_security" -gt 0 ] 2>/dev/null; then
+      # Fail-closed: force hard_stop on all decisions
+      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || result="$raw_decisions"
+    else
+      result="$raw_decisions"
+    fi
+  fi
 
   echo "$result"
   return 0

--- a/correctless/scripts/review-triage.sh
+++ b/correctless/scripts/review-triage.sh
@@ -141,27 +141,25 @@ enforce_prh003() {
     [range($findings | length)] | map(. as $i |
       ($resp[$i] // null) as $decision |
       $findings[$i] as $finding |
-      # QA-004: if decision is null (supervisor returned fewer), use hard_stop for security
-      if $decision == null then
-        {"decision": "hard_stop", "prh003_missing_decision": true}
-      else
       (
-        # Check if this finding requires PRH-003 enforcement
         ($finding.source_agent == "red-team") or
         ($finding.category == "security") or
         (
-          # Check security keywords in summary and category
           ($keywords | split(" ")) as $kws |
           (($finding.summary // "") | ascii_downcase) as $summary_lower |
           (($finding.category // "") | ascii_downcase) as $cat_lower |
           any($kws[]; . as $kw | ($summary_lower | contains($kw)) or ($cat_lower | contains($kw)))
         )
       ) as $is_security |
-      if $is_security and ($decision.decision == "reject") then
+      if $decision == null then
+        # R2-F2: missing decision — hard_stop for security, accept for non-security
+        if $is_security then {"decision": "hard_stop", "prh003_missing_decision": true}
+        else {"decision": "accept", "prh003_missing_decision": true}
+        end
+      elif $is_security and ($decision.decision == "reject") then
         $decision | .decision = "hard_stop" | .prh003_override = true
       else
         $decision
-      end
       end
     )
   ' 2>/dev/null)" || { echo "[]"; return 1; }
@@ -228,7 +226,8 @@ triage_findings_batch() {
     )] | length' 2>/dev/null)" || has_security="0"
     if [ "$has_security" -gt 0 ] 2>/dev/null; then
       # Fail-closed: force hard_stop on all decisions
-      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || result="$raw_decisions"
+      # R2-F5: if jq also fails (malformed raw_decisions), return empty array, not raw data
+      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || { echo "[]"; return 1; }
     else
       result="$raw_decisions"
     fi

--- a/correctless/scripts/supervisor-mandate.sh
+++ b/correctless/scripts/supervisor-mandate.sh
@@ -113,7 +113,10 @@ build_mandate_context() {
       preferences: $prefs,
       decision_patterns: $dp,
       spec_scope: $scope
-    }' 2>/dev/null || echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
+    }' 2>/dev/null || {
+    echo "WARNING: build_mandate_context jq assembly failed, using empty context" >&2
+    echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
+  }
 
   return 0
 }

--- a/correctless/scripts/supervisor-mandate.sh
+++ b/correctless/scripts/supervisor-mandate.sh
@@ -79,6 +79,9 @@ build_mandate_context() {
       esac
     done < "$_decision_record_file"
 
+    # R2-F7: validate categories_json is valid JSON before --argjson
+    echo "$categories_json" | jq -e '.' >/dev/null 2>&1 || categories_json="{}"
+
     decision_patterns="$(jq -n \
       --argjson cats "$categories_json" \
       --argjson total "$total" \
@@ -101,7 +104,7 @@ build_mandate_context() {
     spec_scope="$(awk '/^## Scope$/{found=1; next} /^## /{if(found) exit} found' "$_spec_file" 2>/dev/null | head -20)" || true
   fi
 
-  # Assemble the full context
+  # Assemble the full context (R2-F7: fallback if jq fails)
   jq -n \
     --argjson prefs "$preferences" \
     --argjson dp "$decision_patterns" \
@@ -110,7 +113,7 @@ build_mandate_context() {
       preferences: $prefs,
       decision_patterns: $dp,
       spec_scope: $scope
-    }'
+    }' 2>/dev/null || echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
 
   return 0
 }

--- a/correctless/scripts/supervisor-mandate.sh
+++ b/correctless/scripts/supervisor-mandate.sh
@@ -43,11 +43,13 @@ build_mandate_context() {
     # Extract tier and category and disposition from structured entries
     local total=0 tier0=0 tier1=0 tier2=0 tier3=0
     local categories_json="{}"
+    local _current_category=""
 
     while IFS= read -r line; do
       case "$line" in
         "### DD-"*)
           total=$((total + 1))
+          _current_category=""
           ;;
         *"**Tier**:"*)
           local tier_val
@@ -62,7 +64,6 @@ build_mandate_context() {
         *"**Category**:"*)
           local cat_val
           cat_val="$(echo "$line" | sed 's/.*Category[^:]*:[[:space:]]*//' | tr -d '[:space:]')"
-          # Will pair with disposition on next relevant line
           _current_category="$cat_val"
           ;;
         *"**Disposition**:"*)
@@ -96,7 +97,8 @@ build_mandate_context() {
   local spec_scope=""
   if [ -f "$_spec_file" ]; then
     # Extract content under ## Scope heading until the next ## heading
-    spec_scope="$(awk '/^## Scope/,/^## [^S]/' "$_spec_file" 2>/dev/null | head -20)" || true
+    # QA-010: stop at ANY next ## heading, not just non-S headings
+    spec_scope="$(awk '/^## Scope$/{found=1; next} /^## /{if(found) exit} found' "$_spec_file" 2>/dev/null | head -20)" || true
   fi
 
   # Assemble the full context

--- a/correctless/scripts/workflow-state-ext.sh
+++ b/correctless/scripts/workflow-state-ext.sh
@@ -59,7 +59,7 @@ ws_increment_field() {
 
   # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
   locked_update_state "$state_file" \
-    '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
+    '((.[$f] // 0) | tonumber) as $cur | .[$f] = (($cur + 1) | tostring)' \
     --arg f "$field"
 }
 

--- a/correctless/scripts/workflow-state-ext.sh
+++ b/correctless/scripts/workflow-state-ext.sh
@@ -40,23 +40,9 @@ ws_set_field() {
 
   [ -f "$state_file" ] || return 1
 
-  # QA-002 / ABS-003: acquire advisory lock before state file write
-  _acquire_state_lock "$state_file" || return 1
-
-  local tmp_file="${state_file}.$$.tmp"
-  local rc=0
-  # Use if/else to handle numeric vs string values (jq 1.7 compat — no try/catch)
-  if jq --arg f "$field" --arg v "$value" \
-      'if ($v | test("^-?[0-9]+$")) then .[$f] = ($v | tonumber) else .[$f] = $v end' \
-      "$state_file" > "$tmp_file" 2>/dev/null; then
-    mv "$tmp_file" "$state_file" || { rm -f "$tmp_file"; rc=1; }
-  else
-    rm -f "$tmp_file"
-    rc=1
-  fi
-
-  _release_state_lock "$state_file"
-  return "$rc"
+  # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
+  # QA-012: always store as string — callers needing integers use ws_increment_field
+  locked_update_state "$state_file" '.[$f] = $v' --arg f "$field" --arg v "$value"
 }
 
 # ---------------------------------------------------------------------------
@@ -71,22 +57,10 @@ ws_increment_field() {
 
   [ -f "$state_file" ] || return 1
 
-  # QA-002 / ABS-003: acquire advisory lock before state file write
-  _acquire_state_lock "$state_file" || return 1
-
-  local tmp_file="${state_file}.$$.tmp"
-  local rc=0
-  if jq --arg f "$field" \
-      '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
-      "$state_file" > "$tmp_file" 2>/dev/null; then
-    mv "$tmp_file" "$state_file" || { rm -f "$tmp_file"; rc=1; }
-  else
-    rm -f "$tmp_file"
-    rc=1
-  fi
-
-  _release_state_lock "$state_file"
-  return "$rc"
+  # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
+  locked_update_state "$state_file" \
+    '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
+    --arg f "$field"
 }
 
 # ---------------------------------------------------------------------------

--- a/correctless/setup
+++ b/correctless/setup
@@ -7,6 +7,19 @@
 
 set -euo pipefail
 
+# Fail-fast prerequisites
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "ERROR: Correctless requires Bash 4+. You have Bash ${BASH_VERSION}." >&2
+  echo "  macOS: brew install bash" >&2
+  echo "  Ubuntu: sudo apt install bash" >&2
+  exit 1
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: Not in a git repository. Run setup from within a git project." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -906,11 +919,11 @@ echo "Correctless — Setup"
 echo "==================="
 echo ""
 
-# Check for jq — hooks require it
+# Check for jq — hooks require it (fail-fast, not warn)
 if ! command -v jq >/dev/null 2>&1; then
-  warn "jq is not installed. The workflow hooks require jq to function."
-  warn "Install: brew install jq (macOS) / apt install jq (Debian) / pacman -S jq (Arch)"
-  echo ""
+  echo "ERROR: jq is required but not installed. All hooks depend on jq for JSON processing." >&2
+  echo "  Install: brew install jq (macOS) / apt install jq (Debian) / pacman -S jq (Arch)" >&2
+  exit 1
 fi
 
 # Detect language
@@ -1073,5 +1086,5 @@ echo "     Note: On existing projects, this takes a few minutes — the agent is
 if [ "$HAS_INTENSITY" != "true" ]; then
   echo "     To increase intensity: add \"intensity\": \"high\" or \"critical\" to workflow section"
 fi
-echo "  2. Try it: git checkout -b feature/my-feature && then run /cspec"
+echo "  2. Try it: git checkout -b feature/my-feature, then run /cspec"
 echo ""

--- a/correctless/skills/csetup/SKILL.md
+++ b/correctless/skills/csetup/SKILL.md
@@ -143,7 +143,7 @@ If something looks wrong, let the human correct it before proceeding.
 
 ## Step 2: Run the Setup Script
 
-Tell the user what this step does before running: "I'll run the setup script now — it creates the `.correctless/artifacts/` directory, registers workflow hooks, and generates a config template. It doesn't modify your source code."
+Tell the user what this step does before running: "I'll run the setup script now — it creates the `.correctless/artifacts/` directory, registers workflow hooks, and generates a config template. It does not modify your application source code, but it creates/updates `.claude/settings.json` (hook registration) and `scripts/lib.sh` (shared utilities)."
 
 Then run the setup script to do the mechanical work:
 

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -341,7 +341,6 @@ id_ed25519.*
 *.jks
 .correctless/preferences.md
 .correctless/config/auto-policy.json
-.correctless/config/workflow-config.json
 .correctless/artifacts/intent-*.md
 .correctless/artifacts/workflow-state-*.json
 .correctless/artifacts/decision-record-*.md"

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -479,7 +479,8 @@ while IFS= read -r target; do
   matched_pattern="$(_check_file_against_patterns "$target")" || true
 
   if [ -n "$matched_pattern" ]; then
-    echo "BLOCKED [sensitive-file]: $target matches protected pattern '$matched_pattern'. Edit sensitive files manually." >&2
+    echo "BLOCKED [sensitive-file]: $target matches protected pattern '$matched_pattern'.
+  Edit this file outside Claude Code, or add an exclusion to protected_files.custom_patterns in .correctless/config/workflow-config.json if this file is not actually sensitive." >&2
     exit 2
   fi
 done <<< "$FILE_TARGETS"

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -281,6 +281,68 @@ _extract_bash_targets() {
           continue
         fi
         ;;
+      # touch/chmod/chown/chgrp/mkdir: emit all non-flag arguments (R6 fix)
+      touch|chmod|chown|chgrp|mkdir)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # tar: emit all non-flag arguments (archive and extracted files)
+      tar)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # unzip/7z/cpio/ar: emit all non-flag arguments (R6 fix)
+      unzip|7z|cpio|ar)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # scp/sftp: emit all non-flag arguments (R6 fix)
+      scp|sftp)
+        i=$((i + 1))
+        while [ $i -lt ${#tokens[@]} ]; do
+          case "${tokens[$i]}" in
+            -*) ;;
+            *) _strip_quotes "${tokens[$i]}" ;;
+          esac
+          i=$((i + 1))
+        done
+        continue
+        ;;
+      # git write subcommands: emit all non-flag arguments after the subcommand
+      git)
+        if [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean|apply|am|merge|rebase|cherry-pick) ]]; then
+          i=$((i + 2))  # skip 'git' and the subcommand
+          while [ $i -lt ${#tokens[@]} ]; do
+            case "${tokens[$i]}" in
+              -*) ;;
+              *) _strip_quotes "${tokens[$i]}" ;;
+            esac
+            i=$((i + 1))
+          done
+          continue
+        fi
+        ;;
       # python/node/ruby: generic interpreters that could write to any file
       # Over-extract all non-flag tokens as potential targets (downstream matching filters)
       python|python3|node|ruby)

--- a/hooks/sensitive-file-guard.sh
+++ b/hooks/sensitive-file-guard.sh
@@ -341,7 +341,10 @@ id_ed25519.*
 *.jks
 .correctless/preferences.md
 .correctless/config/auto-policy.json
-.correctless/artifacts/intent-*.md"
+.correctless/config/workflow-config.json
+.correctless/artifacts/intent-*.md
+.correctless/artifacts/workflow-state-*.json
+.correctless/artifacts/decision-record-*.md"
 
 # ============================================
 # STEP 7: Read custom patterns from config (INV-005)

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -115,7 +115,8 @@ require_phase() {
   local expected="$1"
   local current
   current="$(read_phase)"
-  [ "$current" = "$expected" ] || die "Expected phase '$expected', but current phase is '$current'"
+  [ "$current" = "$expected" ] || die "Expected phase '$expected', but current phase is '$current'.
+  Run /cstatus to see available transitions, or use 'workflow-advance.sh status' for details."
 }
 
 require_phase_oneof() {
@@ -124,7 +125,8 @@ require_phase_oneof() {
   for p in "$@"; do
     [ "$current" = "$p" ] && return 0
   done
-  die "Current phase '$current' is not one of: $*"
+  die "Current phase '$current' is not one of: $*.
+  Run /cstatus to see available transitions, or use 'workflow-advance.sh status' for details."
 }
 
 read_config_field() {
@@ -372,7 +374,8 @@ cmd_init() {
   [ -z "$default_branch" ] && default_branch="main"
 
   if [ "$branch" = "$default_branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
-    die "Cannot init workflow on '$branch'. Create a feature branch first: git checkout -b feature/my-feature"
+    die "Cannot init workflow on '$branch'. Create a feature branch first: git checkout -b feature/my-feature
+  For small fixes (< 50 LOC), try /cquick instead."
   fi
 
   local sf
@@ -864,7 +867,7 @@ cmd_override() {
     [ -f "$_os_dir/override-scrutiny.sh" ] && source "$_os_dir/override-scrutiny.sh" 2>/dev/null
   }; then
     if ! check_override_retry "$reason" "$sf" 2>/dev/null; then
-      die "Override rejected: too similar to a previously rejected override (Jaccard >= 0.4). Rephrase with a materially different justification."
+      die "Override rejected: your reason is too similar to a previous override request. Provide a genuinely different justification — explain why this specific edit is needed, not just a rephrasing of the previous reason."
     fi
   fi
 

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -857,6 +857,17 @@ cmd_override() {
     die "Override limit reached (3 per workflow). If the gate is consistently blocking legitimate edits, the workflow config or patterns may need adjustment. Use 'reset' as a last resort."
   fi
 
+  # R4-S1: Check for Jaccard retry prevention (PRH-006)
+  if command -v jaccard_similarity >/dev/null 2>&1 || {
+    local _os_dir
+    _os_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/../scripts"
+    [ -f "$_os_dir/override-scrutiny.sh" ] && source "$_os_dir/override-scrutiny.sh" 2>/dev/null
+  }; then
+    if ! check_override_retry "$reason" "$sf" 2>/dev/null; then
+      die "Override rejected: too similar to a previously rejected override (Jaccard >= 0.4). Rephrase with a materially different justification."
+    fi
+  fi
+
   # Block renewal while an override is still active
   local override_active
   override_active="$(echo "$state" | jq -r '.override.active // false')"

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -823,6 +823,9 @@ cmd_reset() {
           "$ARTIFACTS_DIR/checkpoint-creview-spec-"*.json "$ARTIFACTS_DIR/checkpoint-caudit-"*.json 2>/dev/null
     rm -f "$ARTIFACTS_DIR/.pkg-cache-"*.json 2>/dev/null
     rm -f "$ARTIFACTS_DIR/tdd-test-edits.log" "$ARTIFACTS_DIR/coverage-baseline-${slug_hash}.out" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/token-log-${slug_hash}.jsonl" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/review-decisions-${slug_hash}.json" 2>/dev/null
+    rm -f "$ARTIFACTS_DIR/antipattern-findings-${slug_hash}.json" 2>/dev/null
     # Clean lock dirs and temp files from locking operations
     rm -rf "${sf}.lock" "${sf}.lock.breaking."* 2>/dev/null
     rm -f "${sf}."*.tmp "${sf}."[0-9]* 2>/dev/null

--- a/hooks/workflow-gate.sh
+++ b/hooks/workflow-gate.sh
@@ -131,9 +131,10 @@ if [ ! -f "$STATE_FILE" ]; then
           IFS="$_FC_OLDIFS"
           case "$BASENAME_CHECK" in
             $p)
-              echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+              echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
               exit 2
               ;;
@@ -153,9 +154,10 @@ if [ ! -f "$STATE_FILE" ]; then
             IFS="$_FC_OLDIFS2"
             case "$_fc_bn" in
               $p)
-                echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+                echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
                 exit 2
                 ;;
@@ -178,9 +180,10 @@ if [ ! -f "$STATE_FILE" ]; then
             IFS="$_FC_OLDIFS"
             case "$BASENAME_CHECK" in
               $p)
-                echo "BLOCKED [fail-closed]: This project requires an active workflow before editing source files.
+                echo "BLOCKED [fail-closed]: Cannot edit source file — no active workflow.
   Start a workflow: .correctless/hooks/workflow-advance.sh init \"task description\"
   (You must be on a feature branch, not main.)
+  Diagnose: .correctless/hooks/workflow-advance.sh diagnose \"filepath\"
   Or run /cstatus to see what's going on." >&2
                 exit 2
                 ;;
@@ -203,12 +206,18 @@ eval "$(jq -r '
   @sh "OVERRIDE_ACTIVE=\(.override.active // false)",
   @sh "OVERRIDE_REMAINING=\(.override.remaining_calls // 0)"
 ' "$STATE_FILE" 2>/dev/null)" || {
-  echo "BLOCKED: State file is corrupt or unreadable. Run workflow-advance.sh status to check." >&2
+  echo "BLOCKED: State file is corrupt or unreadable.
+  Try: .correctless/hooks/workflow-advance.sh status
+  If that also fails: .correctless/hooks/workflow-advance.sh reset
+  (Reset removes state for this branch — restart with init.)" >&2
   exit 2
 }
 # Post-eval validation: if PHASE is still empty, jq produced no output (corrupt file)
 if [ -z "$PHASE" ]; then
-  echo "BLOCKED: State file is corrupt or unreadable. Run workflow-advance.sh status to check." >&2
+  echo "BLOCKED: State file is corrupt or unreadable.
+  Try: .correctless/hooks/workflow-advance.sh status
+  If that also fails: .correctless/hooks/workflow-advance.sh reset
+  (Reset removes state for this branch — restart with init.)" >&2
   exit 2
 fi
 

--- a/scripts/auto-policy.sh
+++ b/scripts/auto-policy.sh
@@ -83,7 +83,7 @@ policy_evaluate() {
   local disposition=""
 
   case "$phase" in
-    review)
+    review|review-spec)
       disposition="$(echo "$parsed" | jq -r --arg cat "$category" \
         '.review_dispositions[$cat] // .review_dispositions.default // empty' 2>/dev/null)" || true
       ;;
@@ -95,7 +95,7 @@ policy_evaluate() {
         disposition="tier2_decide"
       fi
       ;;
-    verify|done|verified)
+    verify|done|verified|tdd-verify)
       disposition="$(echo "$parsed" | jq -r --arg cat "$category" \
         '.drift[$cat] // empty' 2>/dev/null)" || true
       ;;

--- a/scripts/budget-check.sh
+++ b/scripts/budget-check.sh
@@ -123,6 +123,11 @@ budget_check() {
     return 0
   fi
 
+  # R2-F4: guard against division by zero if policy sets max_tokens to 0
+  if [ "$max_tokens" -le 0 ] 2>/dev/null; then
+    max_tokens=2000000
+  fi
+
   # Calculate token percentage
   local token_pct=$(( (token_usage * 100) / max_tokens ))
 

--- a/scripts/budget-check.sh
+++ b/scripts/budget-check.sh
@@ -98,10 +98,10 @@ budget_check() {
 
   local time_exceeded="no" time_warn="no"
   if [ -n "$elapsed" ] && [ "$elapsed" != "0" ]; then
-    eval "$(awk "BEGIN {
-      if ($elapsed >= $max_hours) print \"time_exceeded=yes\"
-      else if ($elapsed >= $warn_hours) print \"time_warn=yes\"
-    }")"
+    eval "$(awk -v elapsed="$elapsed" -v max_hours="$max_hours" -v warn_hours="$warn_hours" 'BEGIN {
+      if (elapsed >= max_hours) print "time_exceeded=yes"
+      else if (elapsed >= warn_hours) print "time_warn=yes"
+    }')"
   fi
 
   if [ "$time_exceeded" = "yes" ]; then

--- a/scripts/cauto-lock.sh
+++ b/scripts/cauto-lock.sh
@@ -78,7 +78,8 @@ lock_check_stale() {
     # PID is alive — lock is active
     return 1
   else
-    # PID is dead — stale lock, auto-clean
+    # PID is dead — stale lock, auto-clean (including .d directory from atomic locking)
+    rm -rf "${lock_file}.d" 2>/dev/null
     rm -f "$lock_file"
     return 0
   fi

--- a/scripts/cauto-lock.sh
+++ b/scripts/cauto-lock.sh
@@ -12,20 +12,33 @@
 # Writes current PID to lockfile. Checks for stale locks (BND-006).
 lock_acquire() {
   local lock_file="$1"
+  local lock_dir="${lock_file}.d"
 
-  if [ -f "$lock_file" ]; then
-    # Check if existing lock is stale (0=stale/cleaned, 1=active, 2=corrupted)
-    lock_check_stale "$lock_file"
-    case $? in
-      0) ;; # Stale lock was auto-cleaned — proceed to acquire
-      1) echo "ERROR: Another /cauto run is active on this branch." >&2; return 1 ;;
-      2) echo "ERROR: Lockfile corrupted; delete '$lock_file' manually if no /cauto run is active." >&2; return 1 ;;
-    esac
+  # QA-015: use mkdir for atomic lock creation (matches lib.sh pattern)
+  if mkdir "$lock_dir" 2>/dev/null; then
+    # Acquired — write PID inside the lock directory
+    echo "$$" > "$lock_dir/pid" 2>/dev/null || true
+    # Also write to the legacy lock_file location for lock_check_stale compat
+    echo "$$" > "$lock_file" 2>/dev/null || true
+    return 0
   fi
 
-  # Create lockfile with current PID
-  echo "$$" > "$lock_file" || return 1
-  return 0
+  # Lock dir exists — check if stale
+  lock_check_stale "$lock_file"
+  case $? in
+    0)
+      # Stale lock was cleaned — retry acquire
+      if mkdir "$lock_dir" 2>/dev/null; then
+        echo "$$" > "$lock_dir/pid" 2>/dev/null || true
+        echo "$$" > "$lock_file" 2>/dev/null || true
+        return 0
+      fi
+      echo "ERROR: Another /cauto run is active on this branch." >&2
+      return 1
+      ;;
+    1) echo "ERROR: Another /cauto run is active on this branch." >&2; return 1 ;;
+    2) echo "ERROR: Lockfile corrupted; delete '$lock_file' and '$lock_dir' manually if no /cauto run is active." >&2; return 1 ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -34,6 +47,7 @@ lock_acquire() {
 # Usage: lock_release LOCK_FILE
 lock_release() {
   local lock_file="$1"
+  rm -rf "${lock_file}.d" 2>/dev/null
   rm -f "$lock_file"
   return 0
 }

--- a/scripts/decision-record.sh
+++ b/scripts/decision-record.sh
@@ -54,7 +54,7 @@ drx_validate() {
   category="$(echo "$dr_json" | jq -r '.category' 2>/dev/null)"
 
   case "$category" in
-    security|availability|testability|scope_expansion|performance|architecture|observability|technical_debt|intent|hard_stop_multiplex)
+    security|availability|testability|scope_expansion|performance|architecture|observability|technical_debt|intent|hard_stop_multiplex|dependency|budget|policy|configuration)
       # Valid category
       ;;
     *)

--- a/scripts/decision-routing.sh
+++ b/scripts/decision-routing.sh
@@ -132,6 +132,8 @@ tier2_build_context() {
   # Use a temp file approach for complex JSON to avoid shell quoting issues
   local _ctx_tmp
   _ctx_tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$_ctx_tmp'" EXIT
   echo "$dr_json" > "$_ctx_tmp"
 
   local result
@@ -148,6 +150,7 @@ tier2_build_context() {
     }' 2>/dev/null)"
   local rc=$?
   rm -f "$_ctx_tmp"
+  trap - EXIT
   echo "$result"
   return "$rc"
 }

--- a/scripts/decision-routing.sh
+++ b/scripts/decision-routing.sh
@@ -133,7 +133,7 @@ tier2_build_context() {
   local _ctx_tmp
   _ctx_tmp="$(mktemp)"
   # shellcheck disable=SC2064
-  trap "rm -f '$_ctx_tmp'" EXIT
+  trap "$(printf 'rm -f %q' "$_ctx_tmp")" EXIT
   echo "$dr_json" > "$_ctx_tmp"
 
   local result

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -238,6 +238,7 @@ _has_write_pattern() {
   for tok in $cmd; do
     case "$tok" in
       cp|mv|tee|install|rm|rmdir|unlink|dd|curl|wget|rsync|patch|truncate|shred|ln|python|python3|node|ruby) return 0 ;;
+      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean) ]] && return 0 ;;
       sed) [[ "$cmd" =~ sed[[:space:]]+-i ]] && return 0 ;;
       perl) [[ "$cmd" =~ perl[[:space:]]+-i ]] && return 0 ;;
     esac

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -238,7 +238,8 @@ _has_write_pattern() {
   for tok in $cmd; do
     case "$tok" in
       cp|mv|tee|install|rm|rmdir|unlink|dd|curl|wget|rsync|patch|truncate|shred|ln|python|python3|node|ruby) return 0 ;;
-      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean) ]] && return 0 ;;
+      tar|unzip|7z|cpio|ar|touch|chmod|chown|chgrp|scp|sftp|mkdir) return 0 ;;
+      git) [[ "$cmd" =~ git[[:space:]]+(checkout|restore|reset|stash|clean|apply|am|merge|rebase|cherry-pick) ]] && return 0 ;;
       sed) [[ "$cmd" =~ sed[[:space:]]+-i ]] && return 0 ;;
       perl) [[ "$cmd" =~ perl[[:space:]]+-i ]] && return 0 ;;
     esac

--- a/scripts/override-crosscheck.sh
+++ b/scripts/override-crosscheck.sh
@@ -121,7 +121,12 @@ base_commit_crosscheck() {
   # Clean up worktree on exit
   local worktree_path="${worktree_dir}/crosscheck"
 
+  # QA-005: trap for worktree cleanup on signal/abnormal exit
+  # shellcheck disable=SC2064
+  trap "(cd '$config_dir' && git worktree remove --force '$worktree_path' 2>/dev/null) || true; rm -rf '$worktree_dir' 2>/dev/null" EXIT SIGTERM SIGINT
+
   if ! (cd "$config_dir" && git worktree add -q "$worktree_path" "$base_commit" 2>/dev/null); then
+    trap - EXIT SIGTERM SIGINT
     rm -rf "$worktree_dir"
     jq -n --arg bc "$base_commit" '{
       pre_existing_claimed: false,
@@ -150,22 +155,27 @@ base_commit_crosscheck() {
   local build_success="false"
   [ "$build_exit_code" -eq 0 ] && build_success="true"
 
-  # Clean up worktree
+  # Clean up worktree (trap handles abnormal exit; explicit cleanup for normal path)
   (cd "$config_dir" && git worktree remove --force "$worktree_path" 2>/dev/null) || true
   rm -rf "$worktree_dir" 2>/dev/null || true
+  trap - EXIT SIGTERM SIGINT
 
   # Determine claim_verified: if build fails on base, the claim might be true
   # If build succeeds on base, the pre-existing claim is false
+  # QA-014: timeout is inconclusive (null), not disconfirmed (false)
   local claim_verified="false"
   if [ "$build_success" = "false" ] && [ "$failure_mode_val" = "null" ]; then
     claim_verified="true"
+  elif [ "$failure_mode_val" != "null" ]; then
+    # Timeout or other non-clean failure — inconclusive
+    claim_verified="null"
   fi
 
   jq -n --arg bc "$base_commit" \
     --argjson success "$build_success" \
     --argjson exit_code "$build_exit_code" \
     --arg stderr "$build_stderr" \
-    --argjson verified "$claim_verified" \
+    --arg verified "$claim_verified" \
     --arg fm "$failure_mode_val" \
     '{
       pre_existing_claimed: false,
@@ -173,7 +183,7 @@ base_commit_crosscheck() {
       base_build_success: $success,
       base_build_exit_code: $exit_code,
       base_build_stderr: $stderr,
-      claim_verified: $verified,
+      claim_verified: (if $verified == "null" then null elif $verified == "true" then true else false end),
       failure_mode: (if $fm == "null" then null else $fm end)
     }'
 
@@ -375,6 +385,19 @@ check_spec_completeness() {
       missing_deliverables: [],
       check_applicable: false,
       complete: true
+    }'
+    return 0
+  fi
+
+  # QA-007: Validate completed_files_json before --argjson (fail-closed on malformed input)
+  if ! echo "$_completed_files_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    # Malformed completed_files — fail-closed: report all deliverables as missing
+    jq -n --argjson declared "$deliverables" '{
+      declared_deliverables: $declared,
+      completed_deliverables: [],
+      missing_deliverables: $declared,
+      check_applicable: true,
+      complete: false
     }'
     return 0
   fi

--- a/scripts/override-crosscheck.sh
+++ b/scripts/override-crosscheck.sh
@@ -49,7 +49,7 @@ detect_pre_existing_claim() {
 # Usage: base_commit_crosscheck CONFIG_FILE
 # Outputs cross-check evidence JSON:
 #   {"pre_existing_claimed":bool,"base_commit":"...","base_build_success":bool,
-#    "base_build_exit_code":N,"base_build_stderr":"...","claim_verified":bool,
+#    "base_build_exit_code":N,"base_build_stderr":"...","claim_verified":bool|null,
 #    "failure_mode":null|"..."}
 base_commit_crosscheck() {
   local _config_file="$1"
@@ -70,7 +70,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "no_test_command"
     }'
     return 0
@@ -97,7 +97,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "merge_base_failed"
     }'
     return 0
@@ -112,7 +112,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "worktree_creation_failed"
     }'
     return 0
@@ -123,7 +123,7 @@ base_commit_crosscheck() {
 
   # QA-005: trap for worktree cleanup on signal/abnormal exit
   # shellcheck disable=SC2064
-  trap "(cd '$config_dir' && git worktree remove --force '$worktree_path' 2>/dev/null) || true; rm -rf '$worktree_dir' 2>/dev/null" EXIT SIGTERM SIGINT
+  trap "$(printf '(cd %q && git worktree remove --force %q 2>/dev/null) || true; rm -rf %q 2>/dev/null' "$config_dir" "$worktree_path" "$worktree_dir")" EXIT SIGTERM SIGINT
 
   if ! (cd "$config_dir" && git worktree add -q "$worktree_path" "$base_commit" 2>/dev/null); then
     trap - EXIT SIGTERM SIGINT
@@ -134,7 +134,7 @@ base_commit_crosscheck() {
       base_build_success: false,
       base_build_exit_code: null,
       base_build_stderr: "",
-      claim_verified: false,
+      claim_verified: null,
       failure_mode: "worktree_add_failed"
     }'
     return 0

--- a/scripts/override-scrutiny.sh
+++ b/scripts/override-scrutiny.sh
@@ -87,9 +87,17 @@ review_override_issuance() {
 
   if [ "$claim_verified" = "false" ]; then
     # Pre-existing claim was false — reject the override
-    # In production, the supervisor agent would make this decision via
-    # Task(subagent_type="correctless:supervisor") with activation_type override_issued
+    # QA-006: persist rejection so Jaccard retry prevention (PRH-006) can detect retries
+    if [ -f "$_state_file" ]; then
+      locked_update_state "$_state_file" \
+        '.rejected_overrides = ((.rejected_overrides // []) + [$reason])' \
+        --arg reason "$_override_reason" 2>/dev/null || true
+    fi
     echo "reject_override"
+    return 0
+  elif [ "$claim_verified" = "null" ]; then
+    # QA-014: timeout or inconclusive — escalate instead of rejecting
+    echo "escalate_to_human"
     return 0
   fi
 
@@ -109,6 +117,11 @@ build_override_action_payload() {
   local _override_reason="$2"
   local _intent_summary="$3"
   local _dd_entries_since="$4"
+
+  # QA-026: validate _dd_entries_since is valid JSON before --argjson
+  if ! echo "$_dd_entries_since" | jq -e '.' >/dev/null 2>&1; then
+    _dd_entries_since="[]"
+  fi
 
   # Build JSON payload using jq --arg (AP-010)
   jq -n \
@@ -293,13 +306,13 @@ update_override_log() {
 
   # Use locked_update_state from lib.sh for atomic read-modify-write (AP-010)
   locked_update_state "$_state_file" \
-    '.override_log = ((.override_log // []) + [{
+    '.override_log = (((.override_log // []) + [{
        override_id: $oid,
        review_type: $rt,
        disposition: $disp,
        reasoning: $rsn,
        timestamp: $ts
-     }])' \
+     }]) | .[-100:])' \
     --arg oid "$_override_id" --arg rt "$_review_type" \
     --arg disp "$_disposition" --arg rsn "$_reasoning" --arg ts "$timestamp"
 }

--- a/scripts/override-scrutiny.sh
+++ b/scripts/override-scrutiny.sh
@@ -84,6 +84,10 @@ review_override_issuance() {
           echo "hard_stop"
           return 0
         fi
+      else
+        # R5-F2: Intent file missing or path unknown — fail-closed
+        echo "hard_stop"
+        return 0
       fi
     fi
   fi

--- a/scripts/override-scrutiny.sh
+++ b/scripts/override-scrutiny.sh
@@ -90,7 +90,7 @@ review_override_issuance() {
     # QA-006: persist rejection so Jaccard retry prevention (PRH-006) can detect retries
     if [ -f "$_state_file" ]; then
       locked_update_state "$_state_file" \
-        '.rejected_overrides = ((.rejected_overrides // []) + [$reason])' \
+        '.rejected_overrides = (((.rejected_overrides // []) + [$reason]) | .[-50:])' \
         --arg reason "$_override_reason" 2>/dev/null || true
     fi
     echo "reject_override"
@@ -118,8 +118,8 @@ build_override_action_payload() {
   local _intent_summary="$3"
   local _dd_entries_since="$4"
 
-  # QA-026: validate _dd_entries_since is valid JSON before --argjson
-  if ! echo "$_dd_entries_since" | jq -e '.' >/dev/null 2>&1; then
+  # QA-026 + R2-F10: validate _dd_entries_since is a JSON array before --argjson
+  if ! echo "$_dd_entries_since" | jq -e 'type == "array"' >/dev/null 2>&1; then
     _dd_entries_since="[]"
   fi
 

--- a/scripts/override-scrutiny.sh
+++ b/scripts/override-scrutiny.sh
@@ -70,8 +70,23 @@ review_override_issuance() {
   local _decision_record_file="$5"
   local _crosscheck_evidence="$6"
 
-  # BND-008: Intent hash presence check.
-  # In production, intent_verify would be called for full verification.
+  # R4-S4 / BND-008: Intent hash verification (mirrors review_override_action pattern)
+  if [ -f "$_state_file" ]; then
+    local stored_intent_hash
+    stored_intent_hash="$(jq -r '.intent_hash // ""' "$_state_file" 2>/dev/null)" || true
+    if [ -n "$stored_intent_hash" ] && [ "$stored_intent_hash" != "null" ]; then
+      local intent_file
+      intent_file="$(jq -r '.intent_file // ""' "$_state_file" 2>/dev/null)" || intent_file=""
+      if [ -n "$intent_file" ] && [ -f "$intent_file" ]; then
+        local current_intent_hash
+        current_intent_hash="$(sha256_hash_file "$intent_file" 2>/dev/null)" || current_intent_hash=""
+        if [ -n "$current_intent_hash" ] && [ "$current_intent_hash" != "$stored_intent_hash" ]; then
+          echo "hard_stop"
+          return 0
+        fi
+      fi
+    fi
+  fi
 
   # BND-006: Validate cross-check evidence is valid JSON
   if ! echo "$_crosscheck_evidence" | jq '.' >/dev/null 2>&1; then

--- a/scripts/review-triage.sh
+++ b/scripts/review-triage.sh
@@ -154,7 +154,7 @@ enforce_prh003() {
       if $decision == null then
         # R2-F2: missing decision — hard_stop for security, accept for non-security
         if $is_security then {"decision": "hard_stop", "prh003_missing_decision": true}
-        else {"decision": "accept", "prh003_missing_decision": true}
+        else {"decision": "accept", "prh003_missing_decision": true, "reasoning": "Auto-accepted: supervisor returned fewer decisions than findings"}
         end
       elif $is_security and ($decision.decision == "reject") then
         $decision | .decision = "hard_stop" | .prh003_override = true

--- a/scripts/review-triage.sh
+++ b/scripts/review-triage.sh
@@ -131,14 +131,20 @@ enforce_prh003() {
   # Security keywords from PRH-001 (security-scan.sh keyword list)
   local security_keywords="auth credential encrypt token secret permission access control trust boundary identity authorization login verification level privilege"
 
-  # Process each finding: if source_agent is red-team OR category/summary
-  # contains security keywords, and supervisor returned "reject", override to "hard_stop"
+  # QA-004: Cardinality assertion — fail-closed on array length mismatch.
+  # If supervisor returned fewer decisions than findings, security findings
+  # beyond the response are silently dropped. Iterate over findings length
+  # and treat missing decisions as hard_stop for security-tagged findings.
   local result
   result="$(jq -n --argjson resp "$_supervisor_response" --argjson findings "$_findings_json" \
     --arg keywords "$security_keywords" '
-    [range($resp | length)] | map(. as $i |
-      $resp[$i] as $decision |
+    [range($findings | length)] | map(. as $i |
+      ($resp[$i] // null) as $decision |
       $findings[$i] as $finding |
+      # QA-004: if decision is null (supervisor returned fewer), use hard_stop for security
+      if $decision == null then
+        {"decision": "hard_stop", "prh003_missing_decision": true}
+      else
       (
         # Check if this finding requires PRH-003 enforcement
         ($finding.source_agent == "red-team") or
@@ -155,6 +161,7 @@ enforce_prh003() {
         $decision | .decision = "hard_stop" | .prh003_override = true
       else
         $decision
+      end
       end
     )
   ' 2>/dev/null)" || { echo "[]"; return 1; }
@@ -210,8 +217,22 @@ triage_findings_batch() {
   raw_decisions="$($supervisor_fn "$_findings_json" 2>/dev/null)" || { echo "[]"; return 1; }
 
   # Step 4: Apply enforce_prh003 post-processing on supervisor result
+  # QA-001: fail-closed — if enforcement fails and security findings exist,
+  # force hard_stop on all security-tagged findings instead of passing through raw decisions
   local result
-  result="$(enforce_prh003 "$raw_decisions" "$_findings_json" 2>/dev/null)" || result="$raw_decisions"
+  if ! result="$(enforce_prh003 "$raw_decisions" "$_findings_json" 2>/dev/null)"; then
+    # Check if any finding is security-tagged — if so, fail-closed
+    local has_security
+    has_security="$(echo "$_findings_json" | jq '[.[] | select(
+      .source_agent == "red-team" or .category == "security"
+    )] | length' 2>/dev/null)" || has_security="0"
+    if [ "$has_security" -gt 0 ] 2>/dev/null; then
+      # Fail-closed: force hard_stop on all decisions
+      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || result="$raw_decisions"
+    else
+      result="$raw_decisions"
+    fi
+  fi
 
   echo "$result"
   return 0

--- a/scripts/review-triage.sh
+++ b/scripts/review-triage.sh
@@ -141,27 +141,25 @@ enforce_prh003() {
     [range($findings | length)] | map(. as $i |
       ($resp[$i] // null) as $decision |
       $findings[$i] as $finding |
-      # QA-004: if decision is null (supervisor returned fewer), use hard_stop for security
-      if $decision == null then
-        {"decision": "hard_stop", "prh003_missing_decision": true}
-      else
       (
-        # Check if this finding requires PRH-003 enforcement
         ($finding.source_agent == "red-team") or
         ($finding.category == "security") or
         (
-          # Check security keywords in summary and category
           ($keywords | split(" ")) as $kws |
           (($finding.summary // "") | ascii_downcase) as $summary_lower |
           (($finding.category // "") | ascii_downcase) as $cat_lower |
           any($kws[]; . as $kw | ($summary_lower | contains($kw)) or ($cat_lower | contains($kw)))
         )
       ) as $is_security |
-      if $is_security and ($decision.decision == "reject") then
+      if $decision == null then
+        # R2-F2: missing decision — hard_stop for security, accept for non-security
+        if $is_security then {"decision": "hard_stop", "prh003_missing_decision": true}
+        else {"decision": "accept", "prh003_missing_decision": true}
+        end
+      elif $is_security and ($decision.decision == "reject") then
         $decision | .decision = "hard_stop" | .prh003_override = true
       else
         $decision
-      end
       end
     )
   ' 2>/dev/null)" || { echo "[]"; return 1; }
@@ -228,7 +226,8 @@ triage_findings_batch() {
     )] | length' 2>/dev/null)" || has_security="0"
     if [ "$has_security" -gt 0 ] 2>/dev/null; then
       # Fail-closed: force hard_stop on all decisions
-      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || result="$raw_decisions"
+      # R2-F5: if jq also fails (malformed raw_decisions), return empty array, not raw data
+      result="$(echo "$raw_decisions" | jq '[.[] | .decision = "hard_stop" | .prh003_failclosed = true]' 2>/dev/null)" || { echo "[]"; return 1; }
     else
       result="$raw_decisions"
     fi

--- a/scripts/supervisor-mandate.sh
+++ b/scripts/supervisor-mandate.sh
@@ -113,7 +113,10 @@ build_mandate_context() {
       preferences: $prefs,
       decision_patterns: $dp,
       spec_scope: $scope
-    }' 2>/dev/null || echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
+    }' 2>/dev/null || {
+    echo "WARNING: build_mandate_context jq assembly failed, using empty context" >&2
+    echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
+  }
 
   return 0
 }

--- a/scripts/supervisor-mandate.sh
+++ b/scripts/supervisor-mandate.sh
@@ -79,6 +79,9 @@ build_mandate_context() {
       esac
     done < "$_decision_record_file"
 
+    # R2-F7: validate categories_json is valid JSON before --argjson
+    echo "$categories_json" | jq -e '.' >/dev/null 2>&1 || categories_json="{}"
+
     decision_patterns="$(jq -n \
       --argjson cats "$categories_json" \
       --argjson total "$total" \
@@ -101,7 +104,7 @@ build_mandate_context() {
     spec_scope="$(awk '/^## Scope$/{found=1; next} /^## /{if(found) exit} found' "$_spec_file" 2>/dev/null | head -20)" || true
   fi
 
-  # Assemble the full context
+  # Assemble the full context (R2-F7: fallback if jq fails)
   jq -n \
     --argjson prefs "$preferences" \
     --argjson dp "$decision_patterns" \
@@ -110,7 +113,7 @@ build_mandate_context() {
       preferences: $prefs,
       decision_patterns: $dp,
       spec_scope: $scope
-    }'
+    }' 2>/dev/null || echo '{"preferences":{},"decision_patterns":{},"spec_scope":""}'
 
   return 0
 }

--- a/scripts/supervisor-mandate.sh
+++ b/scripts/supervisor-mandate.sh
@@ -43,11 +43,13 @@ build_mandate_context() {
     # Extract tier and category and disposition from structured entries
     local total=0 tier0=0 tier1=0 tier2=0 tier3=0
     local categories_json="{}"
+    local _current_category=""
 
     while IFS= read -r line; do
       case "$line" in
         "### DD-"*)
           total=$((total + 1))
+          _current_category=""
           ;;
         *"**Tier**:"*)
           local tier_val
@@ -62,7 +64,6 @@ build_mandate_context() {
         *"**Category**:"*)
           local cat_val
           cat_val="$(echo "$line" | sed 's/.*Category[^:]*:[[:space:]]*//' | tr -d '[:space:]')"
-          # Will pair with disposition on next relevant line
           _current_category="$cat_val"
           ;;
         *"**Disposition**:"*)
@@ -96,7 +97,8 @@ build_mandate_context() {
   local spec_scope=""
   if [ -f "$_spec_file" ]; then
     # Extract content under ## Scope heading until the next ## heading
-    spec_scope="$(awk '/^## Scope/,/^## [^S]/' "$_spec_file" 2>/dev/null | head -20)" || true
+    # QA-010: stop at ANY next ## heading, not just non-S headings
+    spec_scope="$(awk '/^## Scope$/{found=1; next} /^## /{if(found) exit} found' "$_spec_file" 2>/dev/null | head -20)" || true
   fi
 
   # Assemble the full context

--- a/scripts/workflow-state-ext.sh
+++ b/scripts/workflow-state-ext.sh
@@ -59,7 +59,7 @@ ws_increment_field() {
 
   # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
   locked_update_state "$state_file" \
-    '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
+    '((.[$f] // 0) | tonumber) as $cur | .[$f] = (($cur + 1) | tostring)' \
     --arg f "$field"
 }
 

--- a/scripts/workflow-state-ext.sh
+++ b/scripts/workflow-state-ext.sh
@@ -40,23 +40,9 @@ ws_set_field() {
 
   [ -f "$state_file" ] || return 1
 
-  # QA-002 / ABS-003: acquire advisory lock before state file write
-  _acquire_state_lock "$state_file" || return 1
-
-  local tmp_file="${state_file}.$$.tmp"
-  local rc=0
-  # Use if/else to handle numeric vs string values (jq 1.7 compat — no try/catch)
-  if jq --arg f "$field" --arg v "$value" \
-      'if ($v | test("^-?[0-9]+$")) then .[$f] = ($v | tonumber) else .[$f] = $v end' \
-      "$state_file" > "$tmp_file" 2>/dev/null; then
-    mv "$tmp_file" "$state_file" || { rm -f "$tmp_file"; rc=1; }
-  else
-    rm -f "$tmp_file"
-    rc=1
-  fi
-
-  _release_state_lock "$state_file"
-  return "$rc"
+  # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
+  # QA-012: always store as string — callers needing integers use ws_increment_field
+  locked_update_state "$state_file" '.[$f] = $v' --arg f "$field" --arg v "$value"
 }
 
 # ---------------------------------------------------------------------------
@@ -71,22 +57,10 @@ ws_increment_field() {
 
   [ -f "$state_file" ] || return 1
 
-  # QA-002 / ABS-003: acquire advisory lock before state file write
-  _acquire_state_lock "$state_file" || return 1
-
-  local tmp_file="${state_file}.$$.tmp"
-  local rc=0
-  if jq --arg f "$field" \
-      '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
-      "$state_file" > "$tmp_file" 2>/dev/null; then
-    mv "$tmp_file" "$state_file" || { rm -f "$tmp_file"; rc=1; }
-  else
-    rm -f "$tmp_file"
-    rc=1
-  fi
-
-  _release_state_lock "$state_file"
-  return "$rc"
+  # QA-009: use locked_update_state for correct EXIT trap handling (AP-015 class fix)
+  locked_update_state "$state_file" \
+    '((.[$f] // 0) | tonumber) as $cur | .[$f] = ($cur + 1)' \
+    --arg f "$field"
 }
 
 # ---------------------------------------------------------------------------

--- a/setup
+++ b/setup
@@ -7,6 +7,19 @@
 
 set -euo pipefail
 
+# Fail-fast prerequisites
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "ERROR: Correctless requires Bash 4+. You have Bash ${BASH_VERSION}." >&2
+  echo "  macOS: brew install bash" >&2
+  echo "  Ubuntu: sudo apt install bash" >&2
+  exit 1
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "ERROR: Not in a git repository. Run setup from within a git project." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -906,11 +919,11 @@ echo "Correctless — Setup"
 echo "==================="
 echo ""
 
-# Check for jq — hooks require it
+# Check for jq — hooks require it (fail-fast, not warn)
 if ! command -v jq >/dev/null 2>&1; then
-  warn "jq is not installed. The workflow hooks require jq to function."
-  warn "Install: brew install jq (macOS) / apt install jq (Debian) / pacman -S jq (Arch)"
-  echo ""
+  echo "ERROR: jq is required but not installed. All hooks depend on jq for JSON processing." >&2
+  echo "  Install: brew install jq (macOS) / apt install jq (Debian) / pacman -S jq (Arch)" >&2
+  exit 1
 fi
 
 # Detect language
@@ -1073,5 +1086,5 @@ echo "     Note: On existing projects, this takes a few minutes — the agent is
 if [ "$HAS_INTENSITY" != "true" ]; then
   echo "     To increase intensity: add \"intensity\": \"high\" or \"critical\" to workflow section"
 fi
-echo "  2. Try it: git checkout -b feature/my-feature && then run /cspec"
+echo "  2. Try it: git checkout -b feature/my-feature, then run /cspec"
 echo ""

--- a/skills/csetup/SKILL.md
+++ b/skills/csetup/SKILL.md
@@ -143,7 +143,7 @@ If something looks wrong, let the human correct it before proceeding.
 
 ## Step 2: Run the Setup Script
 
-Tell the user what this step does before running: "I'll run the setup script now — it creates the `.correctless/artifacts/` directory, registers workflow hooks, and generates a config template. It doesn't modify your source code."
+Tell the user what this step does before running: "I'll run the setup script now — it creates the `.correctless/artifacts/` directory, registers workflow hooks, and generates a config template. It does not modify your application source code, but it creates/updates `.claude/settings.json` (hook registration) and `scripts/lib.sh` (shared utilities)."
 
 Then run the setup script to do the mechanical work:
 

--- a/tests/test-auto-crosscheck.sh
+++ b/tests/test-auto-crosscheck.sh
@@ -600,10 +600,10 @@ EOF
   echo "$result" | jq -e '.failure_mode != null' >/dev/null 2>&1 && has_failure="yes"
   assert_eq "BND-007: merge-base failure sets failure_mode" "yes" "$has_failure"
 
-  # claim_verified should be false (fail-closed)
-  local verified="true"
-  echo "$result" | jq -e '.claim_verified == false' >/dev/null 2>&1 && verified="false"
-  assert_eq "BND-007: merge-base failure → claim not verified (fail-closed)" "false" "$verified"
+  # R2-F3: infrastructure failures return null (inconclusive), not false (disconfirmed)
+  local verified
+  verified="$(echo "$result" | jq -r 'if .claim_verified == null then "null" elif .claim_verified == true then "true" else "false" end' 2>/dev/null)"
+  assert_eq "BND-007: merge-base failure → claim inconclusive (null)" "null" "$verified"
 }
 
 test_bnd007_no_test_command() {

--- a/tests/test-bugfixes.sh
+++ b/tests/test-bugfixes.sh
@@ -288,8 +288,8 @@ test_qa_findings_status() {
   # This must appear as a spawned agent instruction (in a blockquote or dedicated section),
   # not just the orchestrator's own procedure notes.
   # We look for "fix agent" near "qa-findings" and "status" in a targeted way.
-  if grep -qiP 'fix\s+agent.*qa-findings.*status.*fixed' "$ctdd_skill" || \
-     grep -qiP '> .*update.*qa-findings.*status.*fixed' "$ctdd_skill"; then
+  if grep -qiE 'fix[[:space:]]+agent.*qa-findings.*status.*fixed' "$ctdd_skill" || \
+     grep -qiE '> .*update.*qa-findings.*status.*fixed' "$ctdd_skill"; then
     has_fix_agent_instruction="true"
   fi
   assert_eq "R-006: /ctdd SKILL.md instructs fix agent to update findings status to fixed" "true" "$has_fix_agent_instruction"
@@ -299,9 +299,9 @@ test_qa_findings_status() {
   # each fix round and update any finding that was fixed but still shows status: open"
 
   local has_verify_instruction="false"
-  if grep -qiP 'orchestrator.*verify.*findings.*status' "$ctdd_skill" || \
-     grep -qiP 'verify.*finding.*status.*(open|fixed)' "$ctdd_skill" || \
-     grep -qiP 'after.*fix.*round.*verif' "$ctdd_skill"; then
+  if grep -qiE 'orchestrator.*verify.*findings.*status' "$ctdd_skill" || \
+     grep -qiE 'verify.*finding.*status.*(open|fixed)' "$ctdd_skill" || \
+     grep -qiE 'after.*fix.*round.*verif' "$ctdd_skill"; then
     has_verify_instruction="true"
   fi
   assert_eq "R-007: /ctdd SKILL.md instructs orchestrator to verify findings statuses" "true" "$has_verify_instruction"

--- a/tests/test-ci-hook-wiring.sh
+++ b/tests/test-ci-hook-wiring.sh
@@ -198,7 +198,7 @@ test_inv002_hook_metadata_headers() {
     first10="$(head -10 "$hook_path")"
 
     local has_type="false"
-    if echo "$first10" | grep -qE '^# HOOK_TYPE:\s*(PreToolUse|PostToolUse)\s*$'; then
+    if echo "$first10" | grep -qE '^# HOOK_TYPE:[[:space:]]*(PreToolUse|PostToolUse)[[:space:]]*$'; then
       has_type="true"
     fi
     assert_eq "INV-002: $hook has valid HOOK_TYPE header" "true" "$has_type"
@@ -216,7 +216,7 @@ test_inv002_hook_metadata_headers() {
 
     # Check HOOK_MATCHER header in first 10 lines
     local has_matcher="false"
-    if echo "$first10" | grep -qE '^# HOOK_MATCHER:\s*.+$'; then
+    if echo "$first10" | grep -qE '^# HOOK_MATCHER:[[:space:]]*.+$'; then
       has_matcher="true"
     fi
     assert_eq "INV-002: $hook has HOOK_MATCHER header" "true" "$has_matcher"
@@ -393,13 +393,13 @@ test_inv005_auto_format_in_hooks() {
     first10="$(head -10 "$REPO_DIR/hooks/auto-format.sh")"
 
     local has_type="false"
-    if echo "$first10" | grep -qE '^# HOOK_TYPE:\s*(PreToolUse|PostToolUse)\s*$'; then
+    if echo "$first10" | grep -qE '^# HOOK_TYPE:[[:space:]]*(PreToolUse|PostToolUse)[[:space:]]*$'; then
       has_type="true"
     fi
     assert_eq "INV-005: auto-format.sh has valid HOOK_TYPE" "true" "$has_type"
 
     local has_matcher="false"
-    if echo "$first10" | grep -qE '^# HOOK_MATCHER:\s*.+$'; then
+    if echo "$first10" | grep -qE '^# HOOK_MATCHER:[[:space:]]*.+$'; then
       has_matcher="true"
     fi
     assert_eq "INV-005: auto-format.sh has HOOK_MATCHER" "true" "$has_matcher"
@@ -533,7 +533,7 @@ test_inv008_shellcheck_scans_scripts() {
   fi
 
   # Option C: scandir is . (scans everything)
-  if echo "$ci_content" | grep -qE 'scandir:\s*\.\s*$'; then
+  if echo "$ci_content" | grep -qE 'scandir:[[:space:]]*\.[[:space:]]*$'; then
     covers_scripts="true"
   fi
 
@@ -542,14 +542,14 @@ test_inv008_shellcheck_scans_scripts() {
   # Specifically verify scripts/lib.sh would be scanned
   # This is a secondary check — if scandir covers scripts/, this passes implicitly
   local lib_covered="false"
-  if echo "$ci_content" | grep -qE '(scripts/lib\.sh|scandir:\s*\./?\s*$|scandir:.*scripts)'; then
+  if echo "$ci_content" | grep -qE '(scripts/lib\.sh|scandir:[[:space:]]*\./?[[:space:]]*$|scandir:.*scripts)'; then
     lib_covered="true"
   fi
   assert_eq "INV-008: scripts/lib.sh covered by shellcheck" "true" "$lib_covered"
 
   # Verify scripts/antipattern-scan.sh would be scanned
   local scan_covered="false"
-  if echo "$ci_content" | grep -qE '(scripts/antipattern-scan\.sh|scandir:\s*\./?\s*$|scandir:.*scripts)'; then
+  if echo "$ci_content" | grep -qE '(scripts/antipattern-scan\.sh|scandir:[[:space:]]*\./?[[:space:]]*$|scandir:.*scripts)'; then
     scan_covered="true"
   fi
   assert_eq "INV-008: scripts/antipattern-scan.sh covered by shellcheck" "true" "$scan_covered"

--- a/tests/test-lib-locking.sh
+++ b/tests/test-lib-locking.sh
@@ -377,33 +377,33 @@ test_no_flock_dependency() {
   # Static analysis: grep lib.sh for flock or lockfile as command invocations
   # (exclude comments — lines starting with #)
   local flock_found="no"
-  if grep -vE '^\s*#' "$LIB_SH" 2>/dev/null | grep -qE '\bflock\b'; then
+  if grep -vE '^[[:space:]]*#' "$LIB_SH" 2>/dev/null | grep -qE '\bflock\b'; then
     flock_found="yes"
   fi
   assert_eq "R-021a: lib.sh does not invoke flock" "no" "$flock_found"
 
   local lockfile_found="no"
-  if grep -vE '^\s*#' "$LIB_SH" 2>/dev/null | grep -qE '\blockfile\b'; then
+  if grep -vE '^[[:space:]]*#' "$LIB_SH" 2>/dev/null | grep -qE '\blockfile\b'; then
     lockfile_found="yes"
   fi
   assert_eq "R-021b: lib.sh does not invoke lockfile command" "no" "$lockfile_found"
 
   # Verify mkdir IS used in non-comment code (positive check)
   local mkdir_found="no"
-  if grep -vE '^\s*#' "$LIB_SH" 2>/dev/null | grep -qE 'mkdir.*lock'; then
+  if grep -vE '^[[:space:]]*#' "$LIB_SH" 2>/dev/null | grep -qE 'mkdir.*lock'; then
     mkdir_found="yes"
   fi
   assert_eq "R-021c: lib.sh uses mkdir for locking" "yes" "$mkdir_found"
 
   # Also check workflow-advance.sh and workflow-gate.sh for flock invocations
   local adv_flock="no"
-  if grep -vE '^\s*#' "$ADV_HOOK" 2>/dev/null | grep -qE '\bflock\b'; then
+  if grep -vE '^[[:space:]]*#' "$ADV_HOOK" 2>/dev/null | grep -qE '\bflock\b'; then
     adv_flock="yes"
   fi
   assert_eq "R-021d: workflow-advance.sh does not invoke flock" "no" "$adv_flock"
 
   local gate_flock="no"
-  if grep -vE '^\s*#' "$GATE_HOOK" 2>/dev/null | grep -qE '\bflock\b'; then
+  if grep -vE '^[[:space:]]*#' "$GATE_HOOK" 2>/dev/null | grep -qE '\bflock\b'; then
     gate_flock="yes"
   fi
   assert_eq "R-021e: workflow-gate.sh does not invoke flock" "no" "$gate_flock"
@@ -430,7 +430,7 @@ test_all_state_writers_use_locking() {
     # Exclude scripts that only READ state or write to OTHER files
     if grep -qE 'mv.*state_file|mv.*STATE_FILE|mv.*workflow-state' "$script" 2>/dev/null; then
       scripts_with_state_writes+=("$bname")
-    elif grep -qE '>\s*"\$.*state_file|>\s*"\$.*STATE_FILE' "$script" 2>/dev/null; then
+    elif grep -qE '>[[:space:]]*"\$.*state_file|>[[:space:]]*"\$.*STATE_FILE' "$script" 2>/dev/null; then
       scripts_with_state_writes+=("$bname")
     fi
   done

--- a/tests/test-statusline.sh
+++ b/tests/test-statusline.sh
@@ -143,7 +143,7 @@ state_filename() {
   local branch="$1"
   local slug hash
   slug="$(printf '%s' "$branch" | sed 's/[^a-zA-Z0-9]/-/g' | cut -c1-80)"
-  hash="$(printf '%s' "$branch" | md5sum | cut -c1-6)"
+  hash="$(printf '%s' "$branch" | (md5sum 2>/dev/null || md5) | cut -c1-6)"
   echo ".correctless/artifacts/workflow-state-${slug}-${hash}.json"
 }
 

--- a/tests/test-token-tracking-skill-field.sh
+++ b/tests/test-token-tracking-skill-field.sh
@@ -251,14 +251,14 @@ test_r001_skill_mapping() {
 
   # Must contain a case statement (non-comment lines)
   local has_case="no"
-  if grep -vE '^\s*#' <<<"$hook_src" | grep -qE '^\s*case\b'; then
+  if grep -vE '^[[:space:]]*#' <<<"$hook_src" | grep -qE '^[[:space:]]*case\b'; then
     has_case="yes"
   fi
   assert_eq "R-001m: mapping uses bash case statement" "yes" "$has_case"
 
   # The case statement body must reference at least spec, review, tdd
   local case_body
-  case_body="$(grep -vE '^\s*#' <<<"$hook_src" || true)"
+  case_body="$(grep -vE '^[[:space:]]*#' <<<"$hook_src" || true)"
   local has_spec_in_case="no"
   if grep -qF 'spec)' <<<"$case_body" || grep -qF 'spec|' <<<"$case_body" || grep -qF '"spec"' <<<"$case_body"; then
     has_spec_in_case="yes"
@@ -277,7 +277,7 @@ test_r002_skill_via_arg() {
   local hook_src
   hook_src="$(cat "$HOOK")"
   local non_comment
-  non_comment="$(grep -vE '^\s*#' <<<"$hook_src")"
+  non_comment="$(grep -vE '^[[:space:]]*#' <<<"$hook_src")"
 
   # -----------------------------------------------
   # R-002a: --arg for skill must appear in the jq command
@@ -341,11 +341,11 @@ test_r003_mapping_in_hook() {
   local hook_src
   hook_src="$(cat "$HOOK")"
   local non_comment
-  non_comment="$(grep -vE '^\s*#' <<<"$hook_src")"
+  non_comment="$(grep -vE '^[[:space:]]*#' <<<"$hook_src")"
 
   local hook_has_mapping="no"
   # The hook must have a case statement and reference skill-related terms
-  if grep -qE '^\s*case\b' <<<"$non_comment"; then
+  if grep -qE '^[[:space:]]*case\b' <<<"$non_comment"; then
     # And within that code, we should see skill assignments (cspec, ctdd, creview, etc.)
     if grep -qF 'cspec' <<<"$non_comment" || grep -qF 'ctdd' <<<"$non_comment" || grep -qF 'creview' <<<"$non_comment"; then
       hook_has_mapping="yes"
@@ -359,7 +359,7 @@ test_r003_mapping_in_hook() {
   # -----------------------------------------------
   local extra_sources
   # Match 'source FILE' or '. FILE' (dot-space for POSIX sourcing), exclude lib.sh
-  extra_sources="$(grep -vE '^\s*#' <<<"$hook_src" | grep -E '(^|[[:space:]])(source[[:space:]]|\.[[:space:]])' | grep -vE 'lib\.sh' || true)"
+  extra_sources="$(grep -vE '^[[:space:]]*#' <<<"$hook_src" | grep -E '(^|[[:space:]])(source[[:space:]]|\.[[:space:]])' | grep -vE 'lib\.sh' || true)"
   local has_extra_source="no"
   if [ -n "$extra_sources" ]; then
     has_extra_source="yes"
@@ -592,7 +592,7 @@ test_r007_pat005_conventions() {
   # R-007a: no set -e (or set -euo pipefail)
   # -----------------------------------------------
   local has_set_e="no"
-  if grep -vE '^\s*#' <<<"$hook_src" | grep -qE 'set[[:space:]]+-[a-z]*e'; then
+  if grep -vE '^[[:space:]]*#' <<<"$hook_src" | grep -qE 'set[[:space:]]+-[a-z]*e'; then
     has_set_e="yes"
   fi
   assert_eq "R-007a: no set -e in hook" "no" "$has_set_e"
@@ -601,7 +601,7 @@ test_r007_pat005_conventions() {
   # R-007b: has || exit 0 guards (fail-open)
   # -----------------------------------------------
   local has_exit_0_guard="no"
-  if grep -vE '^\s*#' <<<"$hook_src" | grep -qE '\|\|[[:space:]]*exit[[:space:]]+0'; then
+  if grep -vE '^[[:space:]]*#' <<<"$hook_src" | grep -qE '\|\|[[:space:]]*exit[[:space:]]+0'; then
     has_exit_0_guard="yes"
   fi
   assert_eq "R-007b: hook has || exit 0 guards" "yes" "$has_exit_0_guard"
@@ -610,7 +610,7 @@ test_r007_pat005_conventions() {
   # R-007c: always exits 0 (last meaningful line)
   # -----------------------------------------------
   local last_line
-  last_line="$(grep -vE '^\s*$|^\s*#' <<<"$hook_src" | tail -1)"
+  last_line="$(grep -vE '^[[:space:]]*$|^[[:space:]]*#' <<<"$hook_src" | tail -1)"
   local ends_exit_0="no"
   if grep -qF 'exit 0' <<<"$last_line"; then
     ends_exit_0="yes"
@@ -621,7 +621,7 @@ test_r007_pat005_conventions() {
   # R-007d: no exit [1-9] anywhere (non-comment lines)
   # -----------------------------------------------
   local has_nonzero_exit="no"
-  if grep -vE '^\s*#' <<<"$hook_src" | grep -qE 'exit[[:space:]]+[1-9]'; then
+  if grep -vE '^[[:space:]]*#' <<<"$hook_src" | grep -qE 'exit[[:space:]]+[1-9]'; then
     has_nonzero_exit="yes"
   fi
   assert_eq "R-007d: no non-zero exit codes" "no" "$has_nonzero_exit"
@@ -711,7 +711,7 @@ test_r008_phase_sync() {
   local hook_src
   hook_src="$(cat "$HOOK")"
   local non_comment
-  non_comment="$(grep -vE '^\s*#' <<<"$hook_src")"
+  non_comment="$(grep -vE '^[[:space:]]*#' <<<"$hook_src")"
 
   local missing_count=0
   local missing_phases=""

--- a/tests/test-token-tracking.sh
+++ b/tests/test-token-tracking.sh
@@ -595,7 +595,7 @@ test_r007_structural_constraints() {
 
   # Count jq invocations in the hook source (exclude comments)
   local jq_count
-  jq_count="$(grep -vE '^\s*#' "$HOOK" | grep -cE '\bjq\b' || true)"
+  jq_count="$(grep -vE '^[[:space:]]*#' "$HOOK" | grep -cE '\bjq\b' || true)"
   jq_count="${jq_count:-0}"
   jq_count="$(echo "$jq_count" | tr -d '[:space:]')"
   if [ "$jq_count" -le 2 ]; then
@@ -610,8 +610,8 @@ test_r007_structural_constraints() {
   # Look for while/for blocks containing $()
   local subshell_in_loop
   subshell_in_loop="$(awk '
-    /^\s*(while|for)\b/ { in_loop=1 }
-    /^\s*done\b/ { in_loop=0 }
+    /^[[:space:]]*(while|for)\b/ { in_loop=1 }
+    /^[[:space:]]*done\b/ { in_loop=0 }
     in_loop && /\$\(/ { found=1 }
     END { print (found ? "yes" : "no") }
   ' "$HOOK")"
@@ -620,18 +620,18 @@ test_r007_structural_constraints() {
   # Check only allowed external commands: jq, date, cat, and file redirects
   # Extract non-comment lines that invoke external commands (exclude builtins)
   local disallowed_cmds
-  disallowed_cmds="$(grep -vE '^\s*#' "$HOOK" \
-    | grep -vE '^\s*$' \
-    | grep -vE '^\s*@sh\b' \
-    | grep -vE '^\s*(if|then|else|elif|fi|local|echo|exit|eval|source|return|set|\.|export|read|shift|case|esac|while|for|do|done|function|true|declare|unset|\[\[|test|printf|\{|\})' \
+  disallowed_cmds="$(grep -vE '^[[:space:]]*#' "$HOOK" \
+    | grep -vE '^[[:space:]]*$' \
+    | grep -vE '^[[:space:]]*@sh\b' \
+    | grep -vE '^[[:space:]]*(if|then|else|elif|fi|local|echo|exit|eval|source|return|set|\.|export|read|shift|case|esac|while|for|do|done|function|true|declare|unset|\[\[|test|printf|\{|\})' \
     | grep -vE '\b(jq|date|cat|command|mkdir|cd|pwd)\b' \
     | grep -vE '(>>|>|<|/dev/null|\|\|)' \
     | grep -vE '^[A-Z_]+=' \
-    | grep -vE '^\s*--arg(json)?\b' \
-    | grep -vE "^\s*['\"\{]" \
-    | grep -vE '^\s*\w+:' \
-    | grep -vE '^\s*[a-z|*-]+\)' \
-    | grep -vE '^\s*[A-Z_]+="[^"]*"\s*;;' \
+    | grep -vE '^[[:space:]]*--arg(json)?\b' \
+    | grep -vE "^[[:space:]]*['\"\{]" \
+    | grep -vE '^[[:space:]]*\w+:' \
+    | grep -vE '^[[:space:]]*[a-z|*-]+\)' \
+    | grep -vE '^[[:space:]]*[A-Z_]+="[^"]*"[[:space:]]*;;' \
     || echo "")"
   # This is advisory — we just log what we find for manual review
   if [ -z "$disallowed_cmds" ]; then
@@ -653,28 +653,28 @@ test_r009_pat005_conventions() {
 
   # Must NOT contain "set -euo pipefail" (that is PAT-001 for PreToolUse)
   local has_set_euo="no"
-  if grep -qE 'set\s+-[a-z]*e[a-z]*' "$HOOK"; then
+  if grep -qE 'set[[:space:]]+-[a-z]*e[a-z]*' "$HOOK"; then
     has_set_euo="yes"
   fi
   assert_eq "R-009a: hook does NOT use set -e (or set -euo pipefail)" "no" "$has_set_euo"
 
   # Must have || exit 0 guards (fail-open pattern)
   local has_exit_0_guard="no"
-  if grep -qE '\|\|\s*exit\s+0' "$HOOK"; then
+  if grep -qE '\|\|[[:space:]]*exit[[:space:]]+0' "$HOOK"; then
     has_exit_0_guard="yes"
   fi
   assert_eq "R-009b: hook has || exit 0 guards" "yes" "$has_exit_0_guard"
 
   # Must have command -v jq check with exit 0 (not exit 2 like PreToolUse)
   local has_jq_check="no"
-  if grep -qE 'command\s+-v\s+jq' "$HOOK"; then
+  if grep -qE 'command[[:space:]]+-v[[:space:]]+jq' "$HOOK"; then
     has_jq_check="yes"
   fi
   assert_eq "R-009c: hook checks command -v jq" "yes" "$has_jq_check"
 
   # The jq check must NOT exit 2 (that would be fail-closed like PreToolUse)
   local jq_exits_2="no"
-  if grep -A2 'command.*-v.*jq' "$HOOK" | grep -qE 'exit\s+2'; then
+  if grep -A2 'command.*-v.*jq' "$HOOK" | grep -qE 'exit[[:space:]]+2'; then
     jq_exits_2="yes"
   fi
   assert_eq "R-009d: jq check does NOT exit 2 (fail-open)" "no" "$jq_exits_2"
@@ -682,9 +682,9 @@ test_r009_pat005_conventions() {
   # Must have eval + jq -r @sh for stdin parsing (may span multiple lines)
   local has_eval_jq="no"
   local _has_eval _has_jq_r _has_at_sh
-  _has_eval="$(grep -vE '^\s*#' "$HOOK" | grep -cE '\beval\b' || echo 0)"
-  _has_jq_r="$(grep -vE '^\s*#' "$HOOK" | grep -cE 'jq\s+-r' || echo 0)"
-  _has_at_sh="$(grep -vE '^\s*#' "$HOOK" | grep -cE '@sh' || echo 0)"
+  _has_eval="$(grep -vE '^[[:space:]]*#' "$HOOK" | grep -cE '\beval\b' || echo 0)"
+  _has_jq_r="$(grep -vE '^[[:space:]]*#' "$HOOK" | grep -cE 'jq[[:space:]]+-r' || echo 0)"
+  _has_at_sh="$(grep -vE '^[[:space:]]*#' "$HOOK" | grep -cE '@sh' || echo 0)"
   if [ "$_has_eval" -gt 0 ] && [ "$_has_jq_r" -gt 0 ] && [ "$_has_at_sh" -gt 0 ]; then
     has_eval_jq="yes"
   fi
@@ -692,7 +692,7 @@ test_r009_pat005_conventions() {
 
   # Hook must always exit 0 — check the last line (excluding empty/comments)
   local last_meaningful_line
-  last_meaningful_line="$(grep -vE '^\s*$|^\s*#' "$HOOK" | tail -1)"
+  last_meaningful_line="$(grep -vE '^[[:space:]]*$|^[[:space:]]*#' "$HOOK" | tail -1)"
   assert_contains "R-009f: hook ends with exit 0" "exit 0" "$last_meaningful_line"
 }
 
@@ -736,7 +736,7 @@ EOF
   # Test 5: Hook must never exit non-zero (PRH-001)
   # Search the hook source for any exit statement with non-zero value
   local has_nonzero_exit="no"
-  if grep -vE '^\s*#' "$HOOK" | grep -qE 'exit\s+[1-9]'; then
+  if grep -vE '^[[:space:]]*#' "$HOOK" | grep -qE 'exit[[:space:]]+[1-9]'; then
     has_nonzero_exit="yes"
   fi
   assert_eq "R-010e: hook source has no exit [1-9] statements" "no" "$has_nonzero_exit"
@@ -759,14 +759,14 @@ test_r011_sources_lib() {
 
   # Check that the hook does NOT define branch_slug locally (ABS-001 violation)
   local defines_branch_slug="no"
-  if grep -qE '^branch_slug\s*\(\)|^function\s+branch_slug' "$HOOK"; then
+  if grep -qE '^branch_slug[[:space:]]*\(\)|^function[[:space:]]+branch_slug' "$HOOK"; then
     defines_branch_slug="yes"
   fi
   assert_eq "R-011b: hook does NOT define branch_slug locally" "no" "$defines_branch_slug"
 
   # Check that branch_slug is CALLED in executable code (not just sourced)
   local calls_branch_slug="no"
-  if grep -vE '^\s*#' "$HOOK" | grep -qE 'branch_slug'; then
+  if grep -vE '^[[:space:]]*#' "$HOOK" | grep -qE 'branch_slug'; then
     calls_branch_slug="yes"
   fi
   assert_eq "R-011b2: hook calls branch_slug in executable code" "yes" "$calls_branch_slug"
@@ -792,14 +792,14 @@ test_prh003_no_result_processing() {
 
   # Hook must not reference .result in jq expressions (non-comment lines)
   local refs_result_jq="no"
-  if grep -vE '^\s*#' "$HOOK" | grep -qE '\.result'; then
+  if grep -vE '^[[:space:]]*#' "$HOOK" | grep -qE '\.result'; then
     refs_result_jq="yes"
   fi
   assert_eq "PRH-003a: no .result in jq expressions" "no" "$refs_result_jq"
 
   # Hook must not declare a variable named result or RESULT
   local has_result_var="no"
-  if grep -vE '^\s*#' "$HOOK" | grep -qE '\b(result|RESULT)\s*='; then
+  if grep -vE '^[[:space:]]*#' "$HOOK" | grep -qE '\b(result|RESULT)[[:space:]]*='; then
     has_result_var="yes"
   fi
   assert_eq "PRH-003b: no shell variable named result/RESULT" "no" "$has_result_var"


### PR DESCRIPTION
## Summary

Full-scope QA Olympics audit of the entire Correctless codebase. 7 convergence rounds + 1 UX-focused round with 17 specialist agents.

**Security fixes (highest impact):**
- PRH-003 enforcement had fail-open fallback — security findings silently dropped on enforcement failure
- `check_override_retry` (Jaccard retry prevention) was defined and tested but never called — PRH-006 was dead code
- `git checkout/restore/reset` bypassed both hooks entirely — not in `_has_write_pattern`
- Override window allowed direct writes to workflow-state and workflow-config files
- `enforce_prh003` paired-array cardinality mismatch silently dropped trailing security findings
- Intent hash verification missing from `review_override_issuance`
- 12 write commands (tar, unzip, touch, chmod, scp, etc.) had no target extractors in sensitive-file-guard

**Correctness fixes:**
- `policy_evaluate` missed `review-spec` and `tdd-verify` phases — Tier 0 bypass for Phase 3
- `check_hard_limits` categories not in `drx_validate` vocabulary — hard limits unreachable
- `rejected_overrides` never written — Jaccard retry prevention structurally inert
- `base_commit_crosscheck` treated timeout as claim-disconfirmed instead of inconclusive
- `ws_set_field`/`ws_increment_field` missing EXIT trap for lock cleanup
- `cauto-lock` TOCTOU fixed with mkdir-based atomic locking
- `budget_check` division by zero on `max_tokens=0`

**Regressions caught (AP-001, AP-005):**
- `grep -P` in test-bugfixes.sh (4th recurrence of AP-001)
- `\s` GNU extension in 4 test files (49+ occurrences)
- README/CONTRIBUTING stale counts (skills, tests, hooks)

**UX improvements:**
- Setup fails fast on missing jq, bash < 4, non-git directory
- Phase transition errors suggest `/cstatus` for next steps
- BLOCKED messages include `diagnose` command and recovery guidance
- README: prerequisites, uninstall instructions, "opt-in per feature", "CI unchanged"
- Override rejection uses plain language instead of "Jaccard >= 0.4"

**New antipatterns:** AP-019 (fail-open security fallback), AP-020 (paired-array cardinality), AP-021 (coupled lock artifacts)

## Stats

| Round | Findings | Fixed | Key Theme |
|-------|----------|-------|-----------|
| R1 | 25 | 23 | PRH-003, phase drift, AP-001/005 regressions |
| R2 | 11 | 10 | R1 regressions: lock cleanup, enforce_prh003 |
| R3 | 4 | 3 | Supervisor prompt, auto-accept reasoning |
| R4 | 33 | 15 | PRH-006 wired, git bypass, state protection, docs |
| R5 | 4 | 3 | R4 regressions: csetup unblocked, intent fail-closed |
| R6 | 1 | 1 | Target extractors for 12 write commands |
| R7 | 0 | 0 | Converged |
| UX | 38 | 21 | Docs, error messages, setup prerequisites |

49 files changed, 740 insertions, 265 deletions.

## Test plan

- [x] All 48 test suites pass (~3,800 assertions)
- [x] Shellcheck passes on all hooks and scripts
- [x] `sync.sh --check` clean
- [x] Manual verification: `touch .env`, `chmod 777 .env`, `git checkout -- .env` all blocked
- [x] Manual verification: `touch README.md`, `git status`, `mkdir src/` all allowed