### PR TITLE
Add dev journal step to /cdocs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ skills/               # Source skills (28 SKILL.md files)
 hooks/                # Bash hooks (gate, sensitive-file-guard, state machine, statusline, audit trail, auto-format, token-tracking)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT guides per language (high+ intensity)
-tests/                # 54 test files (~4,556 assertions)
+tests/                # 55 test files (~4,563 assertions)
 setup                 # Install script
 sync.sh               # Copies source → correctless/ distribution
 correctless/          # Single distribution (28 skills, intensity-gated)

--- a/correctless/skills/cdocs/SKILL.md
+++ b/correctless/skills/cdocs/SKILL.md
@@ -161,6 +161,29 @@ Read the workflow state file (`.correctless/artifacts/workflow-state-{branch-slu
 
 Read the override count from the preserved file at `.correctless/meta/overrides/{task-slug}-*.json` (most recent by filename sort if multiple exist). If no preserved file exists, fall back to the ephemeral override log at `.correctless/artifacts/override-log.json` (filter entries by current branch and count). If neither file exists, the override count is 0.
 
+### Dev Journal
+
+Append a dev journal entry to `docs/dev-journal.md`. This file is append-only — never rewrite or delete existing entries. If the file doesn't exist, create it with a `# Dev Journal` header.
+
+Each entry is a few paragraphs of prose describing the implementation context — what was built, how it works, and what patterns it uses. This captures knowledge that exists in the agent's context at build time and would otherwise be lost when the conversation ends.
+
+Entry format:
+
+```markdown
+## {date} — {feature name}
+
+{2-4 paragraphs covering:}
+- What was built and why (plain language, not the spec's rule format)
+- What code was written — files touched, new functions or structures introduced
+- How it works — the actual mechanism, not just what it does
+- Which patterns and conventions it uses (reference PAT-xxx, ABS-xxx where applicable)
+- Design decisions that aren't obvious from the code (why this approach, what was considered and rejected)
+```
+
+Data sources for the entry: the spec (what was intended), `git diff main...HEAD` (what was actually written), `.correctless/ARCHITECTURE.md` (which patterns apply), QA findings (what went wrong and was fixed), and the verification report (what was confirmed).
+
+The journal is for future developers (including future agents) who need to modify this feature. Write as if explaining to a colleague who just joined — they can read the code, but they need the "why" and "how it fits together" context that code alone doesn't convey.
+
 ### Convention Learning
 
 If this is the 3rd or more feature where the same architectural pattern has appeared (check .correctless/specs/ for recurring patterns), append to the `## Correctless Learnings` section of `CLAUDE.md`:

--- a/skills/cdocs/SKILL.md
+++ b/skills/cdocs/SKILL.md
@@ -161,6 +161,29 @@ Read the workflow state file (`.correctless/artifacts/workflow-state-{branch-slu
 
 Read the override count from the preserved file at `.correctless/meta/overrides/{task-slug}-*.json` (most recent by filename sort if multiple exist). If no preserved file exists, fall back to the ephemeral override log at `.correctless/artifacts/override-log.json` (filter entries by current branch and count). If neither file exists, the override count is 0.
 
+### Dev Journal
+
+Append a dev journal entry to `docs/dev-journal.md`. This file is append-only — never rewrite or delete existing entries. If the file doesn't exist, create it with a `# Dev Journal` header.
+
+Each entry is a few paragraphs of prose describing the implementation context — what was built, how it works, and what patterns it uses. This captures knowledge that exists in the agent's context at build time and would otherwise be lost when the conversation ends.
+
+Entry format:
+
+```markdown
+## {date} — {feature name}
+
+{2-4 paragraphs covering:}
+- What was built and why (plain language, not the spec's rule format)
+- What code was written — files touched, new functions or structures introduced
+- How it works — the actual mechanism, not just what it does
+- Which patterns and conventions it uses (reference PAT-xxx, ABS-xxx where applicable)
+- Design decisions that aren't obvious from the code (why this approach, what was considered and rejected)
+```
+
+Data sources for the entry: the spec (what was intended), `git diff main...HEAD` (what was actually written), `.correctless/ARCHITECTURE.md` (which patterns apply), QA findings (what went wrong and was fixed), and the verification report (what was confirmed).
+
+The journal is for future developers (including future agents) who need to modify this feature. Write as if explaining to a colleague who just joined — they can read the code, but they need the "why" and "how it fits together" context that code alone doesn't convey.
+
 ### Convention Learning
 
 If this is the 3rd or more feature where the same architectural pattern has appeared (check .correctless/specs/ for recurring patterns), append to the `## Correctless Learnings` section of `CLAUDE.md`:

--- a/tests/test-dev-journal.sh
+++ b/tests/test-dev-journal.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+# Correctless — Dev Journal structural tests
+#
+# Verifies that /cdocs includes a dev journal step that appends
+# implementation context to docs/dev-journal.md.
+#
+# Run from repo root: bash tests/test-dev-journal.sh
+
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || { echo "FATAL: cannot cd to repo root" >&2; exit 2; }
+
+PASS=0 FAIL=0
+FAILED_IDS=""
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1 — $2"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_IDS="$FAILED_IDS $1"; echo "  FAIL: $1 — $2"; }
+
+CDOCS_SKILL="skills/cdocs/SKILL.md"
+
+echo "=== Dev Journal Tests ==="
+
+# 1: cdocs SKILL.md mentions dev journal
+if grep -qi 'dev.*journal\|development.*journal' "$CDOCS_SKILL"; then
+  pass "DJ-001" "cdocs SKILL.md mentions dev journal"
+else
+  fail "DJ-001" "cdocs SKILL.md does not mention dev journal"
+fi
+
+# 2: cdocs SKILL.md has a journal section or step
+if grep -qi 'journal' "$CDOCS_SKILL" && grep -qi 'append\|entry' "$CDOCS_SKILL"; then
+  pass "DJ-002" "cdocs SKILL.md has journal append instructions"
+else
+  fail "DJ-002" "cdocs SKILL.md missing journal append instructions"
+fi
+
+# 3: journal step mentions docs/dev-journal.md as target
+if grep -q 'docs/dev-journal.md' "$CDOCS_SKILL"; then
+  pass "DJ-003" "cdocs SKILL.md references docs/dev-journal.md"
+else
+  fail "DJ-003" "cdocs SKILL.md does not reference docs/dev-journal.md"
+fi
+
+# 4: journal step mentions what to include (files, patterns, implementation)
+if grep -qi 'files.*touched\|files.*changed\|patterns.*used\|how.*implemented\|what.*was.*built\|implementation.*context' "$CDOCS_SKILL"; then
+  pass "DJ-004" "cdocs SKILL.md describes journal entry content"
+else
+  fail "DJ-004" "cdocs SKILL.md does not describe what journal entries contain"
+fi
+
+# 5: journal step specifies date/time in entries
+if grep -qi 'date\|timestamp' "$CDOCS_SKILL" && grep -qi 'journal' "$CDOCS_SKILL"; then
+  pass "DJ-005" "cdocs SKILL.md specifies date in journal entries"
+else
+  fail "DJ-005" "cdocs SKILL.md does not specify date in journal entries"
+fi
+
+# 6: journal step is append-only (consistent with workflow-history)
+if grep -qi 'append.*journal\|journal.*append' "$CDOCS_SKILL"; then
+  pass "DJ-006" "cdocs SKILL.md specifies append-only journal"
+else
+  fail "DJ-006" "cdocs SKILL.md does not specify append-only journal"
+fi
+
+# 7: cdocs allowed-tools includes Write(docs/*) — already covers docs/dev-journal.md
+if head -5 "$CDOCS_SKILL" | grep -q 'Write(docs/\*)'; then
+  pass "DJ-007" "cdocs allowed-tools covers docs/dev-journal.md"
+else
+  fail "DJ-007" "cdocs allowed-tools may not cover docs/dev-journal.md"
+fi
+
+echo ""
+echo "========================================="
+echo "  Dev Journal Tests: $PASS passed, $FAIL failed"
+echo "========================================="
+if [ -n "$FAILED_IDS" ]; then
+  echo "  Failed: $FAILED_IDS"
+fi
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `/cdocs` now appends a dev journal entry to `docs/dev-journal.md` after each feature
- Each entry is 2-4 paragraphs of prose: what was built, how it works, patterns used, design decisions
- Append-only, date-stamped, captures implementation context that would otherwise be lost when the conversation ends

## Test plan
- [ ] 7 structural assertions in `tests/test-dev-journal.sh`
- [ ] Core test suite (67 tests) passes
- [ ] AP-005 drift test passes (CONTRIBUTING.md count updated to 55)