### PR TITLE
Fix documentation drift from new-user experience audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "correctless",
       "source": "./correctless",
-      "description": "Correctness workflow for structured development. 27 skills with configurable intensity levels: spec-before-code, skeptical review, enforced TDD, formal modeling, adversarial review, verification, documentation, and metrics. Intensity gates let you choose standard, high, or critical rigor per project.",
+      "description": "Correctness workflow for structured development. 28 skills with configurable intensity levels: spec-before-code, skeptical review, enforced TDD, formal modeling, adversarial review, verification, documentation, and metrics. Intensity gates let you choose standard, high, or critical rigor per project.",
       "version": "3.0.0"
     }
   ]

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -1,22 +1,24 @@
+> **Note:** This is a stale copy. The canonical version is at `.correctless/AGENT_CONTEXT.md`. Read that instead.
+
 # Agent Context — Correctless
 
 > Last updated: 2026-04-07
 
 ## What This Project Does
 
-Claude Code plugin framework that enforces a correctness-oriented development workflow. Ships as a single `correctless/` distribution with 27 skills and configurable intensity levels (standard, high, critical). Standard intensity (~10-15 min/feature) covers core TDD workflow; high/critical intensity (~1-2 hr/feature) adds formal modeling, adversarial review, and convergence auditing. The core principle: never let an agent grade its own work — each workflow phase uses a separate agent with a different lens.
+Claude Code plugin framework that enforces a correctness-oriented development workflow. Ships as a single `correctless/` distribution with 28 skills and configurable intensity levels (standard, high, critical). Standard intensity (~10-15 min/feature) covers core TDD workflow; high/critical intensity (~1-2 hr/feature) adds formal modeling, adversarial review, and convergence auditing. The core principle: never let an agent grade its own work — each workflow phase uses a separate agent with a different lens.
 
 ## Key Components
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| Skills | `skills/*/SKILL.md` | 27 skill definitions. Each is a slash command with frontmatter contract. |
-| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), sensitive-file-guard.sh (PreToolUse file protection), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, auto-format.sh (PostToolUse formatting), token-tracking.sh (PostToolUse token logging) |
+| Skills | `skills/*/SKILL.md` | 28 skill definitions. Each is a slash command with frontmatter contract. |
+| Hooks | `hooks/` | workflow-gate.sh (PreToolUse gating), sensitive-file-guard.sh (PreToolUse file protection), workflow-advance.sh (state machine), statusline.sh, audit-trail.sh, auto-format.sh (PostToolUse formatting), token-tracking.sh (PostToolUse token logging), import-guard.json (agent hook) |
 | Templates | `templates/` | Scaffolding for new projects: ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, configs |
 | Helpers | `helpers/` | PBT guides per language (high+ intensity) |
-| Distribution | `correctless/` | Single 27-skill distribution target — never edit directly |
+| Distribution | `correctless/` | Single 28-skill distribution target — never edit directly |
 | Setup | `setup` | Idempotent install script: detect stack, scaffold, register hooks |
-| Tests | `tests/test*.sh` | 48 test files (~3,800 shell tests) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation |
+| Tests | `tests/test*.sh` | 59 test files (~4,500 shell tests) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation |
 | Sync | `sync.sh` | Propagates source edits to the `correctless/` distribution |
 
 ## Design Patterns

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,18 +1,20 @@
+> **Note:** This is a stale copy. The canonical version is at `.correctless/ARCHITECTURE.md`. Read that instead.
+
 # Architecture — Correctless
 
 ## Key Components
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| Skills | `skills/*/SKILL.md` | 27 skill definitions (Markdown with frontmatter). Each defines one slash command's behavior, tools, and constraints. |
-| Hooks | `hooks/` | 4 bash scripts: workflow gate (PreToolUse), state machine (workflow-advance), statusline, audit trail. These enforce the workflow. |
+| Skills | `skills/*/SKILL.md` | 28 skill definitions (Markdown with frontmatter). Each defines one slash command's behavior, tools, and constraints. |
+| Hooks | `hooks/` | 7 bash scripts + 1 agent hook: workflow gate, sensitive-file-guard (PreToolUse), state machine, statusline, audit trail, auto-format, token-tracking (PostToolUse), import-guard (agent). |
 | Templates | `templates/` | Scaffolding templates for ARCHITECTURE.md, AGENT_CONTEXT.md, antipatterns, invariant templates (high+ intensity), spec templates, workflow configs. |
 | Helpers | `helpers/` | Property-based testing guides per language (Go, Python, TypeScript, Rust). High+ intensity. |
-| Distribution | `correctless/` | Single 27-skill distribution. Intensity gates control which skills activate at each level. |
+| Distribution | `correctless/` | Single 28-skill distribution. Intensity gates control which skills activate at each level. |
 | Docs | `docs/` | Per-skill user-facing documentation and feature docs. |
 | Design Specs | `docs/design/correctless.md` | Design specification covering all intensity levels. |
 | Setup | `setup` | Bash script: detects stack, scaffolds config/hooks/templates, registers Claude Code hooks. Idempotent. |
-| Tests | `tests/test*.sh` | 32 test files covering setup, state machine, gate, full mode, MCP, bug fixes, QoL, decision UX, statusline, consolidation, crelease, cexplain, calm resets, dynamic rigor, intensity detection, wire-intensity-creview, wire-intensity-pipeline, auto-format, sensitive-file-guard, antipattern-scan, hook-sync, lib, lib-locking, token-tracking, token-tracking-setup, token-tracking-skill-field, allowed-tools-check, gate-path-exceptions, intensity-calibration, auto-recurring-patterns, shift-left-review, ci-hook-wiring, token-aware-intensity, semi-auto-mode. |
+| Tests | `tests/test*.sh` | 59 test files (~4,500 assertions) covering all hooks, scripts, skills, agents, Phase 2 components, Phase 3 components, and test-evasion antipattern validation. |
 | Sync | `sync.sh` | Copies source files into the `correctless/` distribution target. |
 
 ## Design Patterns
@@ -20,7 +22,7 @@
 ### PAT-001: Source → Distribution Sync
 - All development happens in root-level `skills/`, `hooks/`, `templates/`, `helpers/`
 - `sync.sh` copies to `correctless/` — this directory is never edited directly
-- All 27 skills are included; intensity gates control which activate at each level
+- All 28 skills are included; intensity gates control which activate at each level
 
 ### PAT-002: Agent Separation (The Lens Principle)
 - Never let an agent grade its own work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Correctless are documented here.
 
+## [Unreleased]
+
+### Added — Skills
+- `/cauto` — Semi-auto pipeline orchestrator: runs /ctdd through PR creation with flexible phase resume, tiered decision architecture, and spec-to-PR orchestration
+- `/carchitect` — Structured architecture definition: reverse-engineer from existing code or greenfield directed discovery, produces machine-referenceable entrypoints YAML
+
 ## [3.0.0] - 2026-04-04
 
 ### Changed — Single Distribution with Dynamic Rigor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 
 This project uses Correctless for structured development.
 Read .correctless/AGENT_CONTEXT.md before starting any work.
-Available commands: /csetup, /cspec, /creview, /ctdd, /cverify, /cdocs, /crefactor, /cpr-review, /cstatus, /csummary, /cmetrics, /cdebug, /chelp
+Available commands: /csetup, /cspec, /creview, /cmodel, /creview-spec, /ctdd, /cverify, /caudit, /cupdate-arch, /cdocs, /cpostmortem, /cdevadv, /credteam, /crefactor, /cpr-review, /ccontribute, /cmaintain, /cstatus, /csummary, /cmetrics, /cdebug, /chelp, /cwtf, /cquick, /crelease, /cexplain, /cauto, /carchitect
 
 ## GitHub Operations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,10 @@ bash sync.sh --check      # Verify distributions are in sync (exit 0 = clean)
 
 ```
 skills/               # Source skills (28 SKILL.md files)
-hooks/                # Hooks (bash: gate, sensitive-file-guard, state machine, statusline, audit trail, auto-format, token-tracking; agent: import-guard)
+hooks/                # 8 hooks (bash: gate, sensitive-file-guard, state machine, statusline, audit trail, auto-format, token-tracking; agent: import-guard)
 templates/            # Config, doc, and spec templates
 helpers/              # PBT guides per language (high+ intensity)
-tests/                # 59 test files (~4,744 assertions)
+tests/                # 59 test files (~4,500 assertions)
 setup                 # Install script
 sync.sh               # Copies source → correctless/ distribution
 correctless/          # Single distribution (28 skills, intensity-gated)
@@ -88,7 +88,7 @@ Run ShellCheck before submitting: `shellcheck hooks/*.sh`
 ## Testing
 
 ```bash
-# Run all 59 test suites — use the canonical command from workflow-config.json:
+# Run all test suites — use the canonical command from workflow-config.json:
 jq -r '.commands.test' .correctless/config/workflow-config.json | bash
 
 # Quick smoke test (2 suites):

--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ graph LR
 | [`/cwtf`](docs/skills/cwtf.md) | Suspect agents took shortcuts | Did agents actually follow instructions? |
 | [`/cexplain`](docs/skills/cexplain.md) | Onboarding or exploring a codebase | Guided mermaid diagrams, prose walkthroughs, HTML export |
 
+### Analysis
+
+| Skill | When to Use | What It Does |
+|-------|------------|--------------|
+| [`/cpostmortem`](docs/skills/cpostmortem.md) | After a bug escapes | Trace which phase missed it, add antipattern + class fix |
+| [`/cdevadv`](docs/skills/cdevadv.md) | Periodic deep analysis | Devil's advocate — challenge architecture and strategy |
+
 ### Intensity-Gated
 
 | Skill | Min Intensity | What It Does |
@@ -245,8 +252,6 @@ graph LR
 | [`/caudit`](docs/skills/caudit.md) | high | Olympics convergence audit (QA / Hacker / Performance presets) |
 | [`/creview-spec`](docs/skills/creview-spec.md) | high | 4-agent adversarial spec review |
 | [`/cupdate-arch`](docs/skills/cupdate-arch.md) | high | Keep ARCHITECTURE.md current after features land |
-| [`/cpostmortem`](docs/skills/cpostmortem.md) | standard | Trace which phase missed a bug, add antipattern + class fix |
-| [`/cdevadv`](docs/skills/cdevadv.md) | standard | Devil's advocate — challenge architecture and strategy |
 | [`/cmodel`](docs/skills/cmodel.md) | critical | Alloy formal modeling for state machines and protocols |
 | [`/credteam`](docs/skills/credteam.md) | critical | Live adversarial red team with source code access |
 
@@ -427,13 +432,14 @@ rm -rf .correctless/
 | **Spec** | A document defining what "correct" means for a feature: testable rules, edge cases, security assumptions. A spec that can't be tested is incomplete. |
 | **Invariant** | A rule that must always be true: "auth tokens expire after 24 hours." Specs are lists of invariants. |
 | **Intensity** | The configured rigor level: standard, high, or critical. Higher intensity unlocks more skills but costs more tokens and time. |
+| **Mini-audit** | After QA clears, three adversarial specialist agents (cross-component interaction, hostile input, resource bounds) hunt for issues the QA lens misses. Runs at the end of `/ctdd`. |
 | **Mutation testing** | Introduce small bugs into code and check if tests catch them. If a test passes with a mutation, that test is weak. Available at high+ intensity. |
 | **STRIDE** | Threat modeling framework: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege. |
 | **RED / GREEN** | TDD phases. RED = write tests that fail. GREEN = write code to make tests pass. |
 
 ## Status
 
-**Correctless 3.0.0 — Early release.** 28 skills, 3 intensity levels, ~4,496 automated tests, 7 enforcement hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
+**Correctless 3.0.0 — Early release.** 28 skills, 3 intensity levels, ~4,500 automated tests, 8 hooks. Real-world usage ongoing — [file issues as you find them](https://github.com/joshft/correctless/issues).
 
 ## License
 

--- a/correctless/setup
+++ b/correctless/setup
@@ -1211,7 +1211,7 @@ else
 This project uses Correctless for structured development.
 Read .correctless/AGENT_CONTEXT.md before starting any work.
 Do NOT Read AGENT_CONTEXT.md from the project root — it may be stale or absent.
-Available commands: /csetup, /cspec, /creview, /cmodel, /creview-spec, /ctdd, /cverify, /caudit, /cupdate-arch, /cdocs, /cpostmortem, /cdevadv, /credteam, /crefactor, /cpr-review, /ccontribute, /cmaintain, /cstatus, /csummary, /cmetrics, /cdebug, /chelp, /cwtf, /cquick, /crelease, /cexplain
+Available commands: /csetup, /cspec, /creview, /cmodel, /creview-spec, /ctdd, /cverify, /caudit, /cupdate-arch, /cdocs, /cpostmortem, /cdevadv, /credteam, /crefactor, /cpr-review, /ccontribute, /cmaintain, /cstatus, /csummary, /cmetrics, /cdebug, /chelp, /cwtf, /cquick, /crelease, /cexplain, /cauto, /carchitect
 CMDEOF
   ok "Updated CLAUDE.md"
 fi

--- a/correctless/skills/chelp/SKILL.md
+++ b/correctless/skills/chelp/SKILL.md
@@ -62,7 +62,7 @@ Correctless (critical intensity):
 
 ### 3. Show Commands
 
-All 27 skills are always visible. Skills gated behind an intensity level are annotated with their minimum.
+All 28 skills are always visible. Skills gated behind an intensity level are annotated with their minimum.
 
 ```
 Feature workflow:

--- a/docs/design/correctless.md
+++ b/docs/design/correctless.md
@@ -1,6 +1,6 @@
 # Correctless: Correctness-Oriented Development Workflow
 
-> **Note:** This is the original design specification. The implementation has evolved — 13 skills were added, the bounty/penalty economics were refined, and several feedback loops were closed. As of v3.0, Correctless ships as a single plugin with 27 skills and configurable intensity levels (standard, high, critical). The former "Lite" and "Full" distributions have been merged. See the [README](../../README.md) and the actual [skill files](../../skills/) for the current implementation.
+> **Note:** This is the original design specification. The implementation has evolved — 13 skills were added, the bounty/penalty economics were refined, and several feedback loops were closed. As of v3.0, Correctless ships as a single plugin with 28 skills and configurable intensity levels (standard, high, critical). The former "Lite" and "Full" distributions have been merged. See the [README](../../README.md) and the actual [skill files](../../skills/) for the current implementation.
 
 ## Intensity Levels
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Correctless Documentation
 
-Correctness-oriented development workflow for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). 27 skills, 5 hooks, enforced TDD with agent separation.
+Correctness-oriented development workflow for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). 28 skills, 8 hooks, enforced TDD with agent separation.
 
 [README](https://github.com/joshft/correctless) | [Standard Workflow Guide](standard-workflow.md) | [Quick Start](https://github.com/joshft/correctless#quick-start) | [Changelog](https://github.com/joshft/correctless/blob/main/CHANGELOG.md)
 
@@ -13,6 +13,8 @@ Correctness-oriented development workflow for [Claude Code](https://docs.anthrop
 - [/ctdd](skills/ctdd.md) — Enforced TDD: RED → test audit → GREEN → QA
 - [/cverify](skills/cverify.md) — Verify implementation matches spec
 - [/cdocs](skills/cdocs.md) — Update documentation
+- [/carchitect](skills/carchitect.md) — Structured architecture definition
+- [/cauto](skills/cauto.md) — Semi-auto pipeline orchestrator
 - [/crelease](skills/crelease.md) — Version bumping, changelog, release tagging
 
 ### Code Quality

--- a/docs/skills/cauto.md
+++ b/docs/skills/cauto.md
@@ -1,0 +1,104 @@
+# /cauto — Semi-Auto Implementation Pipeline
+
+> Orchestrate the full implementation pipeline after spec review. Runs /ctdd, /simplify, /cverify, /cupdate-arch, /cdocs, then creates a PR — with flexible phase resume and autonomous decision-making.
+
+## When to Use
+
+- After `/creview` (or `/creview-spec`) approves a spec — this runs the entire implementation pipeline
+- When you want hands-off execution from TDD through PR creation
+- When resuming a pipeline that was interrupted (escalation, context overflow, hard stop)
+- **Not for:** features that don't have an approved spec yet (run `/cspec` and `/creview` first)
+
+## How It Fits in the Workflow
+
+`/cauto` is the pipeline orchestrator. Instead of manually running `/ctdd` → `/cverify` → `/cdocs` → PR, `/cauto` runs them all in sequence, handling failures, retries, and escalation. It respects the same workflow state machine as manual invocation — skills still run in separate agents with `context: fork`. The orchestrator invokes skills; skills do not auto-continue on their own.
+
+## What It Does
+
+1. **Phase gate** — reads the current workflow phase and computes remaining pipeline steps. Accepts any active phase from `review` through `documented`. Rejects `spec` and `model` (spec must be reviewed first).
+2. **Install freshness check** — detects stale hooks before any skill runs. Warns if source files changed since last setup.
+3. **Invoke /ctdd** — spawns a sub-agent for the full RED → GREEN → QA → mini-audit cycle. If TDD triggers a spec-update, escalates to the human.
+4. **Commit before /simplify** — creates a clean revert point ("TDD complete").
+5. **Invoke /simplify** — runs Claude Code's built-in simplification. Post-simplify validation reverts if tests fail or `.correctless/` paths were modified.
+6. **Invoke /cverify** — verifies implementation matches spec.
+7. **Invoke /cupdate-arch** (high+ intensity only) — updates architecture documentation.
+8. **Invoke /cdocs** — updates project documentation.
+9. **Consolidation** — scoped commit and push. Only stages known pipeline output paths. Belt-and-suspenders guard prevents committing artifacts.
+10. **Create PR** — via `gh pr create` (default), skip, or custom command. PR body includes summary, test plan, QA findings, and verification status.
+
+### Escalation
+
+When a failure persists after N attempts (3 at standard, 2 at high/critical), the pipeline stops and writes a structured escalation file. Re-running `/cauto` after the human resolves the issue resumes from where it left off.
+
+### Phase 2: Tiered Decision Architecture
+
+Decisions are routed through a tiered hierarchy: Policy (deterministic) → Worker (self-resolution) → Decision Agent (ephemeral) → Supervisor (lightweight) → Hard Stop (human). Token and time budgets are enforced with warn at 75% and hard stop at 100%.
+
+### Phase 3: Spec-to-PR Orchestration
+
+When no workflow exists, `/cauto` can start from scratch — running `/cspec` interactively or accepting a provided spec file. Autonomous review with supervisor triage incorporates findings automatically. A mandatory spec approval gate always requires human confirmation before implementation begins.
+
+## Example
+
+```
+Agent: Reading workflow state... phase is "review". Full pipeline ahead.
+       Checking install freshness... all hooks current.
+       Reading preferences... pr_creation: gh, defaults for all others.
+
+       Starting /ctdd...
+       [RED → test audit → GREEN → /simplify → QA → mini-audit]
+       /ctdd complete. Committing TDD changes.
+
+       Running /simplify... accepted (tests pass, no protected paths modified).
+
+       Starting /cverify...
+       Verification complete — 5/5 rules covered, 0 smells.
+
+       Skipping /cupdate-arch (standard intensity).
+
+       Starting /cdocs...
+       Documentation updated.
+
+       Consolidation: staging pipeline outputs...
+       Pushed to origin/feature/my-feature.
+
+       Creating PR via gh...
+       PR #42 created: https://github.com/user/repo/pull/42
+
+       Pipeline Summary:
+       ┌──────────────┬──────────┬────────┬────────┐
+       │ Step         │ Duration │ Tokens │ Result │
+       ├──────────────┼──────────┼────────┼────────┤
+       │ ctdd         │ 8m 12s   │ 45,200 │ pass   │
+       │ simplify     │ 0m 34s   │ —      │ pass   │
+       │ cverify      │ 1m 05s   │ 8,300  │ pass   │
+       │ cupdate-arch │ —        │ —      │ skip   │
+       │ cdocs        │ 2m 18s   │ 12,100 │ pass   │
+       └──────────────┴──────────┴────────┴────────┘
+```
+
+## What It Reads / Writes
+
+| Reads | Writes |
+|-------|--------|
+| Workflow state (`.correctless/artifacts/workflow-state-{slug}.json`) | All artifacts from invoked skills |
+| `.correctless/config/workflow-config.json` | `.correctless/artifacts/audit-trail-{slug}.jsonl` |
+| `.correctless/preferences.md` | `.correctless/artifacts/escalation-{slug}.md` (on failure) |
+| `.correctless/config/auto-policy.json` (Phase 2) | `.correctless/meta/overrides/{slug}-{date}.json` |
+| Approved spec | PR on GitHub |
+
+## Intensity Levels
+
+| Aspect | Standard | High | Critical |
+|--------|----------|------|----------|
+| Pipeline | ctdd → simplify → cverify → cdocs → PR | + cupdate-arch | + cupdate-arch |
+| Failure threshold | 3 attempts | 2 attempts | 2 attempts |
+| Supervisor activations | Same | Same | Same |
+
+## Common Issues
+
+- **"Run /creview first"**: The spec must be reviewed before `/cauto` can run. Run `/creview` or `/creview-spec` first.
+- **Escalation during /ctdd**: Usually a spec issue — the spec contradicts implementation reality. Fix the spec and re-run.
+- **Push failure**: Auth or rejected push. The local commit is preserved. Fix the issue and re-run — the phase gate routes to PR-only.
+- **"gh CLI not installed"**: Set `pr_creation: skip` in `.correctless/preferences.md` or install `gh`.
+- **Context overflow**: Each skill runs in a fresh context via `context: fork`. If the orchestrator itself overflows, re-run — the checkpoint system saves progress.

--- a/docs/skills/cquick.md
+++ b/docs/skills/cquick.md
@@ -38,6 +38,14 @@ Agent: Checking branch... on fix/typo-in-readme. Good.
        Committed: "Fix typo in configuration example"
 ```
 
+## What It Reads / Writes
+
+| Reads | Writes |
+|-------|--------|
+| `.correctless/config/workflow-config.json` | Test files (project test directory) |
+| `.correctless/artifacts/workflow-state-{slug}.json` (existence check) | Source files (implementation) |
+| | Git commit |
+
 ## Intensity Levels
 
 `/cquick` works the same at all intensity levels. It deliberately skips all ceremony — that's the point.

--- a/docs/standard-workflow.md
+++ b/docs/standard-workflow.md
@@ -126,15 +126,18 @@ sequenceDiagram
     Note over SL: Statusline renders continuously
 ```
 
-Five hooks run on every tool call:
+Eight hooks enforce the workflow:
 
 | Hook | Type | Purpose |
 |---|---|---|
 | **sensitive-file-guard.sh** | PreToolUse | Blocks writes to `.env`, credentials, keys. Fail-closed, no overrides. |
 | **workflow-gate.sh** | PreToolUse | Enforces phase-specific file restrictions (RED blocks source, QA blocks everything). |
+| **import-guard.json** | PreToolUse (agent) | Detects when tests bypass documented entrypoints. |
 | **audit-trail.sh** | PostToolUse | Logs every file modification with phase context to JSONL. Tracks adherence metrics. |
 | **auto-format.sh** | PostToolUse | Runs the project's formatter on edited files. Allowlist-validated, array-based execution. |
+| **token-tracking.sh** | PostToolUse | Logs subagent token usage, cost, and duration to JSONL. |
 | **statusline.sh** | Statusline | Shows branch, phase, QA round, cost, context %, lines delta. |
+| **workflow-advance.sh** | On command | State machine — validates transitions, enforces gates. |
 
 All PreToolUse hooks follow [PAT-001](https://github.com/joshft/correctless/blob/main/.claude/rules/hooks-pretooluse.md): `set -euo pipefail` + `set -f`, jq check, bulk `eval`+`jq @sh` stdin parse, fast-path exit 0 before loading config.
 

--- a/setup
+++ b/setup
@@ -1211,7 +1211,7 @@ else
 This project uses Correctless for structured development.
 Read .correctless/AGENT_CONTEXT.md before starting any work.
 Do NOT Read AGENT_CONTEXT.md from the project root — it may be stale or absent.
-Available commands: /csetup, /cspec, /creview, /cmodel, /creview-spec, /ctdd, /cverify, /caudit, /cupdate-arch, /cdocs, /cpostmortem, /cdevadv, /credteam, /crefactor, /cpr-review, /ccontribute, /cmaintain, /cstatus, /csummary, /cmetrics, /cdebug, /chelp, /cwtf, /cquick, /crelease, /cexplain
+Available commands: /csetup, /cspec, /creview, /cmodel, /creview-spec, /ctdd, /cverify, /caudit, /cupdate-arch, /cdocs, /cpostmortem, /cdevadv, /credteam, /crefactor, /cpr-review, /ccontribute, /cmaintain, /cstatus, /csummary, /cmetrics, /cdebug, /chelp, /cwtf, /cquick, /crelease, /cexplain, /cauto, /carchitect
 CMDEOF
   ok "Updated CLAUDE.md"
 fi

--- a/skills/chelp/SKILL.md
+++ b/skills/chelp/SKILL.md
@@ -62,7 +62,7 @@ Correctless (critical intensity):
 
 ### 3. Show Commands
 
-All 27 skills are always visible. Skills gated behind an intensity level are annotated with their minimum.
+All 28 skills are always visible. Skills gated behind an intensity level are annotated with their minimum.
 
 ```
 Feature workflow:

--- a/tests/test-qol.sh
+++ b/tests/test-qol.sh
@@ -111,7 +111,7 @@ fi
 echo "--- R-005: cquick in sync.sh skill list ---"
 SYNC="$REPO_DIR/sync.sh"
 
-# Check the skill list (single for-loop listing all 27 skills)
+# Check the skill list (single for-loop listing all 28 skills)
 skill_line=$(grep "^for skill in" "$SYNC" | head -1)
 if echo "$skill_line" | grep -q "cquick"; then
   assert_eq "R-005a: cquick in skill list" "yes" "yes"


### PR DESCRIPTION
## Summary
New-user experience audit found 17 issues (2 BLOCKING, 7 HIGH, 5 MEDIUM, 3 LOW). The dominant pattern is stale counts from rapid development — 9 PRs in one session without a doc-sync pass.

Key fixes:
- Created missing `docs/skills/cauto.md` (was a 404 from README)
- Updated skill count 27→28 across 7 files
- Updated hook count to 8 across 4 files
- Added stale-copy notices to root AGENT_CONTEXT.md and ARCHITECTURE.md
- Updated CLAUDE.md command list from 13 to all 28 commands
- Fixed intensity-gated table in README
- Added Mini-audit to glossary
- Reconciled assertion counts

## Test plan
- [ ] Architecture drift tests pass (62 assertions, AP-005 counts verified)
- [ ] Core test suite passes (69 tests)
- [ ] MCP tests pass (209 tests)
- [ ] `sync.sh --check` clean