### PR TITLE
Add CI conclusion job for branch protection check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: Test Suite (jq ${{ matrix.jq_version }})
+    name: Tests (jq ${{ matrix.jq_version }})
     runs-on: ubuntu-latest
     # AP-011: Matrix across jq versions to catch operator precedence and
     # other version-portability bugs before they hit main. See PMB-001.
@@ -123,6 +123,19 @@ jobs:
         run: |
           bash sync.sh
           git diff --exit-code || (echo "sync.sh produced changes — run sync.sh and commit" && exit 1)
+
+  test-suite:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check matrix results
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Test matrix failed: ${{ needs.test.result }}"
+            exit 1
+          fi
 
   shellcheck:
     name: ShellCheck


### PR DESCRIPTION
## Summary
- Branch protection requires a check named "Test Suite" but the jq version matrix (AP-011) produces "Test Suite (jq 1.7.1)" and "Test Suite (jq 1.8.1)" — the unsuffixed name is never reported, blocking all PRs (including dependabot #89)
- Add a lightweight `test-suite` conclusion job with `name: Test Suite` that gates on matrix results
- Rename matrix legs from "Test Suite (jq X)" to "Tests (jq X)" to avoid ambiguity

## Test plan
- [ ] This PR's own CI run produces a "Test Suite" check (the conclusion job)
- [ ] Branch protection is satisfied and the PR can merge
- [ ] Unblocks dependabot PR #89