### PR TITLE
Clear override on phase transition (#103)

### DIFF
--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -83,7 +83,7 @@ update_phase() {
   local ts
   ts="$(date -u +%FT%TZ)"
   locked_update_state "$sf" \
-    ".phase = \"$new_phase\" | .phase_entered_at = \"$ts\"" \
+    ".phase = \"$new_phase\" | .phase_entered_at = \"$ts\" | .override.active = false | .override.remaining_calls = 0" \
     || die "Failed to update phase"
   info "Phase: $new_phase"
 }
@@ -530,7 +530,7 @@ cmd_tests() {
     sf="$(state_file)"
     ts="$(now_iso)"
     locked_update_state "$sf" \
-      '.phase = "tdd-tests" | .phase_entered_at = $ts | .spec_hash = $hash | .spec_line_count = ($lines | tonumber)' \
+      '.phase = "tdd-tests" | .phase_entered_at = $ts | .spec_hash = $hash | .spec_line_count = ($lines | tonumber) | .override.active = false | .override.remaining_calls = 0' \
       --arg ts "$ts" --arg hash "$_spec_hash" --arg lines "$_spec_lines" \
       || die "Failed to update state for tdd-tests phase"
     info "Phase: tdd-tests"
@@ -570,7 +570,7 @@ cmd_qa() {
   sf="$(state_file)"
   ts="$(date -u +%FT%TZ)"
   locked_update_state "$sf" \
-    ".qa_rounds += 1 | .phase = \"tdd-qa\" | .phase_entered_at = \"$ts\"" \
+    ".qa_rounds += 1 | .phase = \"tdd-qa\" | .phase_entered_at = \"$ts\" | .override.active = false | .override.remaining_calls = 0" \
     || die "Failed to update state for QA phase"
   info "Phase: tdd-qa"
   info "Next: QA review (edits blocked)"
@@ -1000,7 +1000,9 @@ cmd_spec_update() {
   jq_filter='.spec_update_history = (.spec_update_history // []) + [{from_phase: .phase, reason: $reason, timestamp: $ts}]
      | .spec_updates = ((.spec_updates // 0) + 1)
      | .phase = "spec"
-     | .phase_entered_at = $ts'
+     | .phase_entered_at = $ts
+     | .override.active = false
+     | .override.remaining_calls = 0'
   if [ "$has_hash" = true ]; then
     jq_filter="$jq_filter"'
      | .spec_hash = $hash

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -83,7 +83,7 @@ update_phase() {
   local ts
   ts="$(date -u +%FT%TZ)"
   locked_update_state "$sf" \
-    ".phase = \"$new_phase\" | .phase_entered_at = \"$ts\"" \
+    ".phase = \"$new_phase\" | .phase_entered_at = \"$ts\" | .override.active = false | .override.remaining_calls = 0" \
     || die "Failed to update phase"
   info "Phase: $new_phase"
 }
@@ -530,7 +530,7 @@ cmd_tests() {
     sf="$(state_file)"
     ts="$(now_iso)"
     locked_update_state "$sf" \
-      '.phase = "tdd-tests" | .phase_entered_at = $ts | .spec_hash = $hash | .spec_line_count = ($lines | tonumber)' \
+      '.phase = "tdd-tests" | .phase_entered_at = $ts | .spec_hash = $hash | .spec_line_count = ($lines | tonumber) | .override.active = false | .override.remaining_calls = 0' \
       --arg ts "$ts" --arg hash "$_spec_hash" --arg lines "$_spec_lines" \
       || die "Failed to update state for tdd-tests phase"
     info "Phase: tdd-tests"
@@ -570,7 +570,7 @@ cmd_qa() {
   sf="$(state_file)"
   ts="$(date -u +%FT%TZ)"
   locked_update_state "$sf" \
-    ".qa_rounds += 1 | .phase = \"tdd-qa\" | .phase_entered_at = \"$ts\"" \
+    ".qa_rounds += 1 | .phase = \"tdd-qa\" | .phase_entered_at = \"$ts\" | .override.active = false | .override.remaining_calls = 0" \
     || die "Failed to update state for QA phase"
   info "Phase: tdd-qa"
   info "Next: QA review (edits blocked)"
@@ -1000,7 +1000,9 @@ cmd_spec_update() {
   jq_filter='.spec_update_history = (.spec_update_history // []) + [{from_phase: .phase, reason: $reason, timestamp: $ts}]
      | .spec_updates = ((.spec_updates // 0) + 1)
      | .phase = "spec"
-     | .phase_entered_at = $ts'
+     | .phase_entered_at = $ts
+     | .override.active = false
+     | .override.remaining_calls = 0'
   if [ "$has_hash" = true ]; then
     jq_filter="$jq_filter"'
      | .spec_hash = $hash

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -432,6 +432,18 @@ test_additional_coverage() {
   echo '{"tool_name": "Edit", "tool_input": {"file_path": "'"$TEST_DIR"'/index.ts"}}' | .correctless/hooks/workflow-gate.sh >/dev/null 2>&1 && override_exit=0 || override_exit=$?
   assert_eq "override expires after 10 calls" "2" "$override_exit"
 
+  # B11: Test override cleared on phase transition
+  ADV fix >/dev/null 2>&1
+  ADV override "phase transition test" >/dev/null 2>&1
+  local pre_transition_override
+  pre_transition_override="$(ADV status 2>&1 | grep 'Override:')"
+  assert_contains "override active before transition" "ACTIVE" "$pre_transition_override"
+  echo '{"name": "test-app", "scripts": {"test": "echo PASS && exit 0"}}' > package.json
+  ADV qa >/dev/null 2>&1
+  local post_transition_override
+  post_transition_override="$(jq -r '.override.active // false' "$(find .correctless/artifacts -name 'workflow-state-*.json' | head -1)")"
+  assert_eq "override cleared on phase transition" "false" "$post_transition_override"
+
   # N12: Test verify-phase rejected in Lite mode
   setup_test_project
   .claude/skills/workflow/setup >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Overrides now auto-expire when the workflow phase changes
- Fixes all 4 phase-transition paths: `update_phase()`, `cmd_tests` (inline with spec hash), `cmd_qa` (inline with qa_rounds), and `cmd_spec_update` (inline with spec update history)
- Closes #103

## Test plan
- [x] New test: grant override during QA, transition to impl via `fix`, verify override cleared
- [x] 71/71 full test suite passes
- [x] 3 files, 24 LOC — within `/cquick` scope