### PR TITLE
Allow workflow-config.json edits during tdd-impl phase

### DIFF
--- a/correctless/hooks/workflow-gate.sh
+++ b/correctless/hooks/workflow-gate.sh
@@ -280,6 +280,9 @@ check_protected_file() {
       exit 2
       ;;
     *workflow-config.json)
+      if [ "$PHASE" = "tdd-impl" ]; then
+        return 0
+      fi
       echo "BLOCKED [$PHASE]: workflow-config.json is protected during active workflows to prevent test command manipulation. Use 'reset' to reconfigure." >&2
       exit 2
       ;;

--- a/hooks/workflow-gate.sh
+++ b/hooks/workflow-gate.sh
@@ -281,6 +281,9 @@ check_protected_file() {
       exit 2
       ;;
     *workflow-config.json)
+      if [ "$PHASE" = "tdd-impl" ]; then
+        return 0
+      fi
       echo "BLOCKED [$PHASE]: workflow-config.json is protected during active workflows to prevent test command manipulation. Use 'reset' to reconfigure." >&2
       exit 2
       ;;

--- a/tests/test-workflow-gate.sh
+++ b/tests/test-workflow-gate.sh
@@ -524,13 +524,32 @@ test_protected_files() {
   result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
   assert_eq "protected: Edit workflow-config allowed in tdd-impl" "0" "$(extract_exit "$result")"
 
-  # Edit workflow-config.json -> BLOCKED during other phases (e.g., spec)
+  # Bash redirect to workflow-config.json -> ALLOWED during tdd-impl
+  result="$(run_gate_bash "echo '{}' > .correctless/config/workflow-config.json")"
+  assert_eq "protected: Bash workflow-config allowed in tdd-impl" "0" "$(extract_exit "$result")"
+
+  # Edit workflow-config.json -> BLOCKED during spec
   set_phase "spec"
   result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
   assert_eq "protected: Edit workflow-config blocked in spec" "2" "$(extract_exit "$result")"
   assert_contains "protected: block message mentions workflow-config" "workflow-config.json" "$(extract_stderr "$result")"
 
+  # Bash redirect to workflow-config.json -> BLOCKED during spec
+  result="$(run_gate_bash "echo '{}' > .correctless/config/workflow-config.json")"
+  assert_eq "protected: Bash workflow-config blocked in spec" "2" "$(extract_exit "$result")"
+
+  # workflow-config.json blocked in tdd-tests phase
+  set_phase "tdd-tests"
+  result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
+  assert_eq "protected: Edit workflow-config blocked in tdd-tests" "2" "$(extract_exit "$result")"
+
+  # workflow-config.json blocked in tdd-qa phase
+  set_phase "tdd-qa"
+  result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
+  assert_eq "protected: Edit workflow-config blocked in tdd-qa" "2" "$(extract_exit "$result")"
+
   # Protected files blocked even in spec phase
+  set_phase "spec"
   result="$(run_gate "Edit" ".correctless/artifacts/workflow-state-test.json")"
   assert_eq "protected: workflow-state blocked in spec phase" "2" "$(extract_exit "$result")"
 

--- a/tests/test-workflow-gate.sh
+++ b/tests/test-workflow-gate.sh
@@ -520,13 +520,17 @@ test_protected_files() {
   assert_eq "protected: Edit workflow-state file blocked" "2" "$(extract_exit "$result")"
   assert_contains "protected: block message mentions state files" "workflow state files" "$(extract_stderr "$result")"
 
-  # Edit workflow-config.json -> BLOCKED during active workflow
+  # Edit workflow-config.json -> ALLOWED during tdd-impl (test registration)
   result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
-  assert_eq "protected: Edit workflow-config blocked" "2" "$(extract_exit "$result")"
+  assert_eq "protected: Edit workflow-config allowed in tdd-impl" "0" "$(extract_exit "$result")"
+
+  # Edit workflow-config.json -> BLOCKED during other phases (e.g., spec)
+  set_phase "spec"
+  result="$(run_gate "Edit" ".correctless/config/workflow-config.json")"
+  assert_eq "protected: Edit workflow-config blocked in spec" "2" "$(extract_exit "$result")"
   assert_contains "protected: block message mentions workflow-config" "workflow-config.json" "$(extract_stderr "$result")"
 
   # Protected files blocked even in spec phase
-  set_phase "spec"
   result="$(run_gate "Edit" ".correctless/artifacts/workflow-state-test.json")"
   assert_eq "protected: workflow-state blocked in spec phase" "2" "$(extract_exit "$result")"
 


### PR DESCRIPTION
## Summary
- Fixes AP-023 gate misclassification: workflow-config.json was blocked during all active workflow phases, forcing ~1.5 overrides/run for routine test registration (`commands.test`)
- Adds tdd-impl exception to `check_protected_file()` — config edits allowed only during implementation, blocked in all other phases (spec, tdd-tests, tdd-qa, review, verify, audit, docs)
- Adds 4 new test assertions covering Bash redirect path and multi-phase blocking (QA-R1-001/002)

## Test plan
- [x] 97 workflow-gate tests pass (up from 92)
- [x] Edit to workflow-config.json allowed during tdd-impl
- [x] Bash redirect to workflow-config.json allowed during tdd-impl
- [x] Edit blocked during spec, tdd-tests, tdd-qa phases
- [x] Bash redirect blocked during spec phase
- [x] QA audit converged (R1: 3 findings, 2 fixed, 1 deferred)