### PR TITLE
Pin R-002 amended clauses (closes coverage gap from PR #150)

### DIFF
--- a/tests/test-antipattern-scan.sh
+++ b/tests/test-antipattern-scan.sh
@@ -2934,8 +2934,14 @@ test_se_r009_drift_test() {
   local ctdd_skill="$REPO_DIR/skills/ctdd/SKILL.md"
 
   # (1) ctdd audit blockquote has a numbered check with anchor phrase "production call chain"
+  # Pipe-into-grep-q is SIGPIPE-prone under `set -uo pipefail` (this file): the
+  # first grep emits multiple lines; grep -qi exits on first match and SIGPIPEs
+  # the first grep; pipeline exits 141; && silently doesn't fire. Use herestring
+  # to avoid the pipe entirely. (AP-031 deferred follow-up #3 / PR #151.)
   local has_prod_chain="no"
-  grep -E '^> [0-9]+\.' "$ctdd_skill" 2>/dev/null | grep -qi 'production call chain' && has_prod_chain="yes"
+  local numbered_blockquote_lines
+  numbered_blockquote_lines="$(grep -E '^> [0-9]+\.' "$ctdd_skill" 2>/dev/null || true)"
+  grep -qi 'production call chain' <<< "$numbered_blockquote_lines" && has_prod_chain="yes"
   assert_eq "SE-R-009(1): audit check with 'production call chain' exists" "yes" "$has_prod_chain"
 
   # (2) PATTERN_META contains key dead-security-fn

--- a/tests/test-ap031-fixture-divergence.sh
+++ b/tests/test-ap031-fixture-divergence.sh
@@ -132,6 +132,9 @@ if [ ! -f "$CTDD_RED_AGENT" ]; then
   fail "R-002(d)" "agents/ctdd-red.md not found"
   fail "R-002(e)" "agents/ctdd-red.md not found"
   fail "R-002(f)" "agents/ctdd-red.md not found"
+  fail "R-002(h)" "agents/ctdd-red.md not found"
+  fail "R-002(i)" "agents/ctdd-red.md not found"
+  fail "R-002(j)" "agents/ctdd-red.md not found"
 else
   # BLOCK-SCOPED (R-004): first try to extract a dedicated "real-fixture" or
   # "real artifact" heading section (preferred — most specific scope).
@@ -223,6 +226,46 @@ else
     pass "R-002(f)" "ctdd-red directive block documents alternative live-file form and limitation"
   else
     fail "R-002(f)" "ctdd-red directive block missing alternative form / gitignored limitation"
+  fi
+
+  # Tests R-002 [unit]: post-review amended clauses pin (sprint/r004-amended-clause-pins).
+  # The MA-117 trigger-detection block and MA-211 language-aware citation forms were
+  # added to agents/ctdd-red.md after the original R-002 keyword contract was set, so
+  # R-004's keyword set didn't pin them. Without these checks, an edit to ctdd-red.md
+  # could silently remove the clauses and the test would still pass.
+
+  # R-002(h): MA-117 trigger-detection block — both halves must be present (the
+  # positive directive AND the negative-trigger exclusion). Mirrors R-001's
+  # detection-heuristics structure in skills/cspec/SKILL.md Step 3.
+  if grep -qF "Trigger detection" <<< "$real_fixture_block" && \
+     grep -qF "does NOT trigger" <<< "$real_fixture_block"; then
+    pass "R-002(h)" "ctdd-red directive block contains MA-117 trigger-detection (positive + negative)"
+  else
+    fail "R-002(h)" "ctdd-red directive block missing MA-117 trigger-detection block (need 'Trigger detection' AND 'does NOT trigger')"
+  fi
+
+  # R-002(i): producer-to-artifact reference table mirrors check 11's table.
+  # Requires both table headers AND at least one concrete producer mapping —
+  # headers alone could be a placeholder, but a real mapping anchors the contract.
+  if grep -qF "Producer" <<< "$real_fixture_block" && \
+     grep -qF "Artifact pattern" <<< "$real_fixture_block" && \
+     grep -qF "review-spec-findings-" <<< "$real_fixture_block"; then
+    pass "R-002(i)" "ctdd-red directive block contains producer-to-artifact table with concrete mapping"
+  else
+    fail "R-002(i)" "ctdd-red directive block missing producer table headers or concrete producer mapping"
+  fi
+
+  # R-002(j): MA-211 language-aware Source: citation forms. The original R-002(b)
+  # only pins '# Source:' (shell/Python). Non-shell projects need '// Source:'
+  # (Go/TS/Java) and '-- Source:' (SQL). All three must be present so a writer
+  # using any of these languages has a documented citation form.
+  # Note: '--' separator is required before '-- Source:' because grep parses
+  # a literal starting with '-' as an option flag otherwise.
+  if grep -qF -- "// Source:" <<< "$real_fixture_block" && \
+     grep -qF -- "-- Source:" <<< "$real_fixture_block"; then
+    pass "R-002(j)" "ctdd-red directive block contains MA-211 language-aware citation forms (// Source:, -- Source:)"
+  else
+    fail "R-002(j)" "ctdd-red directive block missing language-aware citation forms (need '// Source:' AND '-- Source:')"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Closes the only coverage weakness flagged by `/cverify` on PR #150 — the R-002 amended clauses (added post-review to incorporate mini-audit findings MA-117 and MA-211) were not pinned by R-004's keyword contract. Without these assertions, a future edit to `agents/ctdd-red.md` could silently remove them and the structural test would still pass.

Adds three new block-scoped assertions inside the existing R-002 section:

- **R-002(h)** — MA-117 trigger-detection block (`"Trigger detection"` AND `"does NOT trigger"`)
- **R-002(i)** — Producer-to-artifact reference table (`"Producer"` AND `"Artifact pattern"` headers + at least one concrete mapping like `"review-spec-findings-"`)
- **R-002(j)** — MA-211 language-aware Source: citation forms (`"// Source:"` AND `"-- Source:"`)

All three live inside the existing `real_fixture_block` block-scoped section extraction — no file-wide grep, AP-003 mitigation preserved per R-004.

## Notable

The `-- Source:` assertion needs `grep -qF -- "-- Source:"` with an explicit `--` separator. Without it, grep parses the leading dash as an option flag (caught during the RED demo against a stripped block — exactly the edge case the test needs to handle).

## Test plan

- [x] `bash tests/test-ap031-fixture-divergence.sh` — 42 passed, 0 failed (was 39, +3)
- [x] Full project test suite — all 94 files pass, no regressions
- [x] RED demo: assertion logic verified against a stripped copy of the block — all three new assertions fail when the amended clauses are removed, all three pass against the real ctdd-red.md

## Context

Follow-up #1 from PR #150 (AP-031 fixture divergence prevention). Sprint-style focused work — no spec, no /cauto pipeline, since this is pure test coverage hardening. ~43 LOC in one file.
