### PR TITLE
Speed up canonicalize-path fuzz tests ~19x (DEP-001)

### DIFF
--- a/.claude/rules/canonicalize-path.md
+++ b/.claude/rules/canonicalize-path.md
@@ -85,6 +85,14 @@ are intended to load into editing context whenever an agent opens
 ## Tests
 
 - `tests/test-canonicalize-path.sh` — fuzz corpus + property-based + structural.
+  The fuzz tests (INV-001/INV-001a/INV-002) call `canonicalize_path` **in-process**
+  (sourced once at file top), never via a per-input `timeout … bash -c "source
+  lib.sh; …"`. Re-sourcing `lib.sh` per input across ~1000 inputs × 3 tests was
+  ~3000 forks and made the suite exceed bounded time, blocking the
+  full-`tests/test-*.sh` done-gate (DEP-001). Do **not** reintroduce a per-input
+  subprocess: the function is proven total and fork-free/bounded (INV-012), so a
+  per-input hang cannot occur by construction; a regression hang surfaces as a
+  suite-level timeout. Keep the in-process call.
 - `tests/test-sensitive-file-guard.sh` — INV-005 (canonical-only-at-matcher),
   INV-008 (canonical-on-both-sides), INV-005a (version probe before use).
 - `tests/test-architecture-drift.sh` — PAT-017 (rule-file presence + paths

--- a/tests/test-architecture-drift.sh
+++ b/tests/test-architecture-drift.sh
@@ -1543,7 +1543,7 @@ check_inv025() {
   block="$(awk -v h="$header" '
     index($0, h) > 0 { in_block = 1 }
     in_block { print }
-    in_block && /^Source:/ { exit }
+    in_block && /^[[:space:]]*-?[[:space:]]*Source:/ { exit }
   ' "$CLAUDE_MD")"
   # (b) PAT-001 migrated to .claude/rules/hooks-pretooluse.md
   if echo "$block" | grep -qF "PAT-001" \

--- a/tests/test-canonicalize-path.sh
+++ b/tests/test-canonicalize-path.sh
@@ -68,12 +68,14 @@ test_inv001_totality() {
   local input out rc lines
   while IFS= read -r -d '' input; do
     total_run=$((total_run + 1))
-    # Per-invocation 2s timeout
-    out="$(timeout 2 bash -c "
-      # shellcheck disable=SC1090
-      source '$LIB'
-      canonicalize_path \"\$1\"
-    " _ "$input" 2>/dev/null)"
+    # canonicalize_path is sourced once (top of file) and called in-process — no
+    # per-input subprocess/re-source. DEP-001 perf: the old `timeout 2 bash -c
+    # "source lib.sh; ..."` re-parsed lib.sh on every one of ~1000 inputs across
+    # three fuzz tests (~3000 forks); the function is proven total and
+    # fork-free/bounded (INV-012), so a per-input hang cannot occur by
+    # construction and a regression hang surfaces as a suite-level timeout. Every
+    # INV-001 assertion (single-line stdout, exit 0, no multi-line) is preserved.
+    out="$(canonicalize_path "$input" 2>/dev/null)"
     rc=$?
     if [ "$rc" -ne 0 ]; then
       total_failures=$((total_failures + 1))
@@ -112,10 +114,8 @@ test_inv001a_no_empty_output_on_nonempty_input() {
     # Strip whitespace for the "non-empty after trim" check
     trimmed="$(printf '%s' "$input" | tr -d ' \t\n')"
     [ -z "$trimmed" ] && continue
-    out="$(timeout 2 bash -c "
-      source '$LIB'
-      canonicalize_path \"\$1\"
-    " _ "$input" 2>/dev/null)"
+    # In-process call (DEP-001) — function sourced once at top of file.
+    out="$(canonicalize_path "$input" 2>/dev/null)"
     if [ -z "$out" ]; then
       violations=$((violations + 1))
       [ "$violations" -le 3 ] && echo "  INV-001a empty output on non-empty input: $(printf '%s' "$input" | xxd | head -1)" >&2
@@ -139,7 +139,8 @@ test_inv002_output_shape() {
   [ -f "$CORPUS_FILE" ] || generate_fuzz_corpus
   local violations=0 input out
   while IFS= read -r -d '' input; do
-    out="$(timeout 2 bash -c "source '$LIB'; canonicalize_path \"\$1\"" _ "$input" 2>/dev/null)"
+    # In-process call (DEP-001) — function sourced once at top of file.
+    out="$(canonicalize_path "$input" 2>/dev/null)"
     [ -z "$out" ] && continue
     # No `//`
     if printf '%s' "$out" | grep -q '//' ; then


### PR DESCRIPTION
## Summary

DEP-001 for the fix-diff-reviewer class-shaped-lens feature. The `canonicalize_path` fuzz tests re-sourced the shared library in a fresh subprocess for **every one of ~1000 inputs across three tests** (~3000 forks), taking **5m30s** and effectively hanging the full `tests/test-*.sh` suite — the blocker PR #180 used to justify an override-to-advance.

## Changes

- **`tests/test-canonicalize-path.sh`** — `INV-001` / `INV-001a` / `INV-002` fuzz tests now call `canonicalize_path` **in-process** (sourced once at file top) instead of `timeout 2 bash -c "source …; canonicalize_path …"` per input. Assertions are byte-identical. The function is proven total and fork-free/bounded (`INV-012`), so a per-input hang cannot occur by construction; a regression hang now surfaces as a suite-level timeout. The only thing lost is per-input hang attribution.
- **`.claude/rules/canonicalize-path.md`** — regression-guard note under Tests so a future edit doesn't reintroduce the per-input subprocess.
- **Cherry-pick `6021795`** — a 1-line pre-existing fix to `test-architecture-drift.sh`'s `INV-025` block-extraction regex (the only other thing keeping the full suite from green on `main`; independent of this work, already on the fix-diff-reviewer branch).

## Evidence

| | before | after |
|---|--:|--:|
| `test-canonicalize-path.sh` | 5m30s | **~18s** (8/8 pass, assertions unchanged) |
| `test-architecture-drift.sh` | red (INV-025 regex) | **110/0** |
| Full `tests/test-*.sh` suite | hung by canonicalize | **completes ~4.7min, 0 stable failures** |

## Why split out

Per the fix-diff-reviewer-class spec's `DEP-001`: the canonicalize fuzz governs the PAT-017 `canonicalize_path` **security boundary** — a different failure domain from the reviewer lens. Folding its remediation into the reviewer feature would couple the trust boundaries and risk silently degrading the security fuzz. This PR unblocks that feature's `CS-019` full-suite-green done-gate.
