### PR TITLE
Fix workflow-gate.sh fail-open on non-scalar tool_name (#207)

### DIFF
--- a/correctless/hooks/workflow-gate.sh
+++ b/correctless/hooks/workflow-gate.sh
@@ -47,13 +47,22 @@ INPUT="$(cat)"
 # shellcheck disable=SC2034  # Variables assigned via eval+jq below, used later
 TOOL_NAME="" TOOL_INPUT_FILE="" TOOL_INPUT_COMMAND="" TOOL_INPUT_NEW="" TOOL_INPUT_EDITS="" TOOL_INPUT_EDITS_NEW=""
 # QA-R1-005: Fail-closed on malformed stdin JSON (PreToolUse must not degrade to fail-open)
+# #207: tool_name MUST be a scalar string. A non-string (array/object/number/bool/null
+# or absent) tool_name is unexpected input → jq errors → empty $_PARSED → the guard
+# below exits 2 (fail-closed, PAT-001 clause 5). This also prevents @sh from rendering
+# a multi-element array as multiple shell tokens, which would make `eval "$_PARSED"`
+# run an arbitrary command (exit 127, not a fail-closed exit 2). The other interpolated
+# fields are coerced to scalar-or-empty for the same token-safety reason.
 _PARSED="$(echo "$INPUT" | jq -r '
-  @sh "TOOL_NAME=\(.tool_name // "")",
-  @sh "TOOL_INPUT_FILE=\(.tool_input.file_path // "")",
-  @sh "TOOL_INPUT_COMMAND=\(.tool_input.command // "")",
-  @sh "TOOL_INPUT_NEW=\(.tool_input.new_string // .tool_input.content // "")",
-  @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path // empty] | join("\n"))",
-  @sh "TOOL_INPUT_EDITS_NEW=\([.tool_input.edits[]?.new_string // empty] | join("\n"))"
+  if (.tool_name | type) != "string" then error("non-string tool_name")
+  else
+    @sh "TOOL_NAME=\(.tool_name)",
+    @sh "TOOL_INPUT_FILE=\(.tool_input.file_path | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_COMMAND=\(.tool_input.command | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_NEW=\((.tool_input.new_string // .tool_input.content) | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path | select(type == "string")] | join("\n"))",
+    @sh "TOOL_INPUT_EDITS_NEW=\([.tool_input.edits[]?.new_string | select(type == "string")] | join("\n"))"
+  end
 ' 2>/dev/null)" || true
 if [ -z "$_PARSED" ]; then
   echo "BLOCKED [fail-closed]: failed to parse tool input JSON" >&2

--- a/hooks/workflow-gate.sh
+++ b/hooks/workflow-gate.sh
@@ -48,13 +48,22 @@ INPUT="$(cat)"
 # shellcheck disable=SC2034  # Variables assigned via eval+jq below, used later
 TOOL_NAME="" TOOL_INPUT_FILE="" TOOL_INPUT_COMMAND="" TOOL_INPUT_NEW="" TOOL_INPUT_EDITS="" TOOL_INPUT_EDITS_NEW=""
 # QA-R1-005: Fail-closed on malformed stdin JSON (PreToolUse must not degrade to fail-open)
+# #207: tool_name MUST be a scalar string. A non-string (array/object/number/bool/null
+# or absent) tool_name is unexpected input → jq errors → empty $_PARSED → the guard
+# below exits 2 (fail-closed, PAT-001 clause 5). This also prevents @sh from rendering
+# a multi-element array as multiple shell tokens, which would make `eval "$_PARSED"`
+# run an arbitrary command (exit 127, not a fail-closed exit 2). The other interpolated
+# fields are coerced to scalar-or-empty for the same token-safety reason.
 _PARSED="$(echo "$INPUT" | jq -r '
-  @sh "TOOL_NAME=\(.tool_name // "")",
-  @sh "TOOL_INPUT_FILE=\(.tool_input.file_path // "")",
-  @sh "TOOL_INPUT_COMMAND=\(.tool_input.command // "")",
-  @sh "TOOL_INPUT_NEW=\(.tool_input.new_string // .tool_input.content // "")",
-  @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path // empty] | join("\n"))",
-  @sh "TOOL_INPUT_EDITS_NEW=\([.tool_input.edits[]?.new_string // empty] | join("\n"))"
+  if (.tool_name | type) != "string" then error("non-string tool_name")
+  else
+    @sh "TOOL_NAME=\(.tool_name)",
+    @sh "TOOL_INPUT_FILE=\(.tool_input.file_path | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_COMMAND=\(.tool_input.command | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_NEW=\((.tool_input.new_string // .tool_input.content) | if type == "string" then . else "" end)",
+    @sh "TOOL_INPUT_EDITS=\([.tool_input.edits[]?.file_path | select(type == "string")] | join("\n"))",
+    @sh "TOOL_INPUT_EDITS_NEW=\([.tool_input.edits[]?.new_string | select(type == "string")] | join("\n"))"
+  end
 ' 2>/dev/null)" || true
 if [ -z "$_PARSED" ]; then
   echo "BLOCKED [fail-closed]: failed to parse tool input JSON" >&2

--- a/tests/test-workflow-gate.sh
+++ b/tests/test-workflow-gate.sh
@@ -883,6 +883,54 @@ test_inv013a_workflow_gate_consumes_extended_pattern
 test_inv013a_no_local_redefinition
 
 # ---------------------------------------------------------------------------
+# Test: Non-scalar tool_name fails CLOSED (exit 2) — never fail-open (#207)
+# ---------------------------------------------------------------------------
+# PAT-001 clause 5: a PreToolUse gate must exit 2 (block) on unexpected /
+# malformed input — never a non-0/non-2 code, and never exit 0.
+#
+# Root cause (hooks/workflow-gate.sh ~L51-63): the bulk parse
+#   jq -r @sh "TOOL_NAME=\(.tool_name // "")"
+# interpolates tool_name unguarded, so a NON-scalar tool_name escapes the
+# scalar contract that the downstream `eval` + `case "$TOOL_NAME"` assumes:
+#   - array  ["foo","Edit"]  -> @sh renders  TOOL_NAME='foo' 'Edit'
+#                               the `[ -z "$_PARSED" ]` guard passes (non-empty),
+#                               then `eval` runs the command `Edit` -> exit 127
+#                               (the hook dies under set -e BEFORE the gate decision)
+#   - number 42              -> @sh renders  TOOL_NAME=42 ; eval succeeds, the
+#                               case falls through every write-tool branch -> exit 0
+#                               (silent fail-open ALLOW)
+#   - object {"a":"Edit"}    -> @sh cannot render an object -> jq errors ->
+#                               empty _PARSED -> already exits 2 (correct today)
+# All three variants MUST block with exit 2 after the fix.
+
+test_non_scalar_tool_name_fails_closed() {
+  echo ""
+  echo "=== Non-scalar tool_name (#207): fails closed (exit 2), never 127 / never 0 ==="
+
+  setup_test_env
+  set_phase "tdd-impl"
+
+  local result exit_code
+
+  # Array tool_name -> currently exits 127 (eval runs the bare word `Edit`).
+  result="$(run_gate_raw '{"tool_name":["foo","Edit"],"tool_input":{"file_path":"src/x.go"}}')"
+  exit_code="$(extract_exit "$result")"
+  assert_eq "non-scalar tool_name: array fails closed (exit 2, not 127)" "2" "$exit_code"
+
+  # Object tool_name -> @sh cannot render object, empty _PARSED -> already 2.
+  result="$(run_gate_raw '{"tool_name":{"a":"Edit"},"tool_input":{"file_path":"src/x.go"}}')"
+  exit_code="$(extract_exit "$result")"
+  assert_eq "non-scalar tool_name: object fails closed (exit 2)" "2" "$exit_code"
+
+  # Number tool_name -> currently exits 0 (silent fail-open allow).
+  result="$(run_gate_raw '{"tool_name":42,"tool_input":{"file_path":"src/x.go"}}')"
+  exit_code="$(extract_exit "$result")"
+  assert_eq "non-scalar tool_name: number fails closed (exit 2, not 0)" "2" "$exit_code"
+}
+
+test_non_scalar_tool_name_fails_closed
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`hooks/workflow-gate.sh` failed **OPEN** when a tool envelope's `tool_name` was a non-scalar JSON value, violating PAT-001 clause 5 (a PreToolUse gate must exit `2` on unexpected input — never a non-0/non-2 code, never a silent allow).

Two fail-open shapes:

- **array** `tool_name` (e.g. `["foo","Edit"]`): `@sh` renders it as multiple shell tokens, the non-empty `$_PARSED` guard passes, then `eval` runs the bare command `Edit` → not found → under `set -e` the hook dies with **exit 127** before the gate decision. (This is the symptom in the issue.)
- **number** `tool_name` (e.g. `42`): `@sh` renders a bare assignment, `eval` succeeds, the `case` falls through every write-tool branch, and the hook **exits 0** (silently allows). This sibling fail-open was surfaced by the regression test and is **not** in the original report.

The harness only ever sends a string `tool_name`, so this is a latent fail-open, not a live exploit — but a PreToolUse gate must fail closed on malformed input.

## Fix

Guard `tool_name` to a scalar string inside the `jq` parse: a non-string value now raises `error("non-string tool_name")` → empty `$_PARSED` → the existing `[ -z "$_PARSED" ]` guard fires `exit 2` (fail-closed). The other `@sh`-interpolated fields (`file_path`, `command`, `new_string`/`content`, `edits[].file_path`, `edits[].new_string`) are coerced to scalar-or-empty for the same token-safety reason.

This ports the identical MA-R2-H1 fix already landed in `sensitive-file-guard.sh` (PR #206). The generated mirror `correctless/hooks/workflow-gate.sh` is re-synced via `sync.sh` (enforced by the hook-sync drift suite), not hand-edited.

## Tests

`tests/test-workflow-gate.sh` gains `test_non_scalar_tool_name_fails_closed` asserting array / object / number `tool_name` all exit `2`. The array case fails as exit 127 and the number case as exit 0 before the fix; both exit 2 after. Full file: 100 passed / 0 failed. Full suite (102 files) green; shellcheck / sync / sfg-lift clean.

## Scope note

This PR is the **instance fix** only. The issue also recommends a PAT-001 class amendment (scalar coercion required for every `@sh`-interpolated field across all PreToolUse hooks, plus per-hook non-string `tool_name` tests). That class-widening is left for human review and is intentionally out of scope for this autonomous fix.

Closes #207