### PR TITLE
Fix ARG_MAX overflow in build-dashboard.sh read_file_json (#144)

### DIFF
--- a/correctless/scripts/build-dashboard.sh
+++ b/correctless/scripts/build-dashboard.sh
@@ -356,16 +356,17 @@ fi
 # STEP 12: Collect Artifact Browser data
 # ============================================================================
 
-# Helper: read a file and return JSON-safe content via jq --arg
+# Helper: read a file and return JSON-safe content via jq --rawfile.
+# --rawfile reads the file directly from the filesystem; content never transits
+# argv, so a single large artifact cannot overflow MAX_ARG_STRLEN (AP-039/PMB-019,
+# issue #144). read_file_json is only called on globbed existing files.
 read_file_json() {
   local filepath="$1"
   local name
   name=$(basename "$filepath")
-  local content
-  content=$(cat "$filepath" 2>/dev/null || echo "")
   local mtime
   mtime=$(stat -c '%Y' "$filepath" 2>/dev/null || stat -f '%m' "$filepath" 2>/dev/null || echo "0")
-  jq -n --arg name "$name" --arg path "$filepath" --arg content "$content" --arg mtime "$mtime" \
+  jq -n --rawfile content "$filepath" --arg name "$name" --arg path "$filepath" --arg mtime "$mtime" \
     '{"name": $name, "path": $path, "content": $content, "mtime": ($mtime | tonumber)}'
 }
 

--- a/scripts/build-dashboard.sh
+++ b/scripts/build-dashboard.sh
@@ -356,16 +356,17 @@ fi
 # STEP 12: Collect Artifact Browser data
 # ============================================================================
 
-# Helper: read a file and return JSON-safe content via jq --arg
+# Helper: read a file and return JSON-safe content via jq --rawfile.
+# --rawfile reads the file directly from the filesystem; content never transits
+# argv, so a single large artifact cannot overflow MAX_ARG_STRLEN (AP-039/PMB-019,
+# issue #144). read_file_json is only called on globbed existing files.
 read_file_json() {
   local filepath="$1"
   local name
   name=$(basename "$filepath")
-  local content
-  content=$(cat "$filepath" 2>/dev/null || echo "")
   local mtime
   mtime=$(stat -c '%Y' "$filepath" 2>/dev/null || stat -f '%m' "$filepath" 2>/dev/null || echo "0")
-  jq -n --arg name "$name" --arg path "$filepath" --arg content "$content" --arg mtime "$mtime" \
+  jq -n --rawfile content "$filepath" --arg name "$name" --arg path "$filepath" --arg mtime "$mtime" \
     '{"name": $name, "path": $path, "content": $content, "mtime": ($mtime | tonumber)}'
 }
 

--- a/tests/test-project-dashboard.sh
+++ b/tests/test-project-dashboard.sh
@@ -1992,6 +1992,64 @@ test_redesign_r011_distribution_sync() {
   fi
 }
 
+
+# ============================================================================
+# ARG_MAX regression: single large artifact must not transit argv (issue #144)
+# AP-039 / PMB-019 — read_file_json() passes file content via `jq --arg content`,
+# which puts the entire file on the command line. A single artifact larger than
+# MAX_ARG_STRLEN (~128KB on Linux) makes jq die with "Argument list too long",
+# silently dropping that artifact's content from the rendered dashboard.
+# ============================================================================
+
+test_argmax_large_artifact() {
+  echo ""
+  echo "--- ARG_MAX: single large artifact must not transit argv (issue #144) ---"
+
+  local TEST_DIR
+  TEST_DIR=$(setup_dashboard_project)
+  trap 'rm -rf "$TEST_DIR"' RETURN
+
+  # Build a SINGLE spec artifact >= 200KB (AP-039 scale-fixture contract) with a
+  # unique sentinel embedded so we can detect whether its content reached the HTML.
+  local sentinel="ARGMAX_SENTINEL_7f3a"
+  local big_spec="$TEST_DIR/.correctless/specs/huge.md"
+  {
+    echo "# Huge Spec"
+    echo "$sentinel"
+    # ~250KB of filler in one file (single-argument overflow, not aggregate)
+    head -c 250000 /dev/zero | tr '\0' 'X'
+    echo ""
+    echo "$sentinel"
+  } > "$big_spec"
+
+  # Sanity: confirm the fixture is genuinely large enough to overflow one argv slot.
+  local fsize
+  fsize=$(wc -c < "$big_spec")
+  if [ "$fsize" -lt 200000 ]; then
+    fail "ARGMAX-fixture" "Large-artifact fixture is only ${fsize} bytes (<200KB) — cannot exercise ARG_MAX"
+    return
+  fi
+
+  # Run the builder directly, capturing BOTH stdout and stderr.
+  local output
+  output=$(bash "$REPO_DIR/scripts/build-dashboard.sh" "$TEST_DIR" 2>&1)
+
+  # ARGMAX-a: the run must NOT emit "Argument list too long" anywhere.
+  if echo "$output" | grep -qi 'Argument list too long'; then
+    fail "ARGMAX-a" "Builder emitted 'Argument list too long' on a 250KB single artifact — content transits argv (read_file_json --arg content)"
+  else
+    pass "ARGMAX-a" "No 'Argument list too long' on a 250KB single artifact"
+  fi
+
+  # ARGMAX-b: the large artifact's content (sentinel) must reach the dashboard HTML.
+  local _f="$TEST_DIR/.correctless/dashboard/index.html"
+  if [ -f "$_f" ] && grep -qF "$sentinel" "$_f"; then
+    pass "ARGMAX-b" "Large artifact content embedded in dashboard (sentinel present)"
+  else
+    fail "ARGMAX-b" "Large artifact content silently dropped — sentinel '$sentinel' missing from dashboard HTML"
+  fi
+}
+
 # ============================================================================
 # Run all tests
 # ============================================================================
@@ -2024,6 +2082,7 @@ test_redesign_r008_existing_intents
 test_redesign_r009_empty_state_redesign
 test_redesign_r010_cdn_pattern
 test_redesign_r011_distribution_sync
+test_argmax_large_artifact
 
 echo ""
 echo "========================================="


### PR DESCRIPTION
## What

`scripts/build-dashboard.sh` failed with `jq: Argument list too long` (and silently dropped artifact content) on projects with large artifacts:

```
build-dashboard.sh: line 368: /usr/bin/jq: Argument list too long
```

The `read_file_json()` helper read each artifact into a shell variable and passed it to `jq` via `--arg content "$content"`, placing the entire file body on `jq`'s command line. Any single artifact larger than the per-argument limit (`MAX_ARG_STRLEN`, ~128KB on Linux) overflows argv and the `jq` exec dies — so that artifact's content never reaches the rendered dashboard. This is the **AP-039 / PMB-019** class: unbounded data must not transit argv (same shape as #144's sibling #209).

PR #124 already fixed the **outer** `collect_artifacts → BROWSER_SPECS` boundary (~1.8MB total) with temp files + `--slurpfile`, but left this **inner** per-file helper untouched — exactly the scope-narrowed-instead-of-class-widened pattern PMB-019 calls out.

## Fix

Route the file content through `--rawfile`, which reads the file directly from the filesystem so content never touches argv:

```sh
jq -n --rawfile content "$filepath" --arg name "$name" --arg path "$filepath" --arg mtime "$mtime" \
  '{"name": $name, "path": $path, "content": $content, "mtime": ($mtime | tonumber)}'
```

The now-unused `local content` / `content=$(cat ...)` lines are removed. `--rawfile` (jq 1.6+; the project uses 1.8.1) reads the file as a raw string — equivalent to the previous `--arg content "$content"` for the real call sites, since `read_file_json` is only ever invoked on globbed, existing files. The generated mirror `correctless/scripts/build-dashboard.sh` is re-synced via `sync.sh`, not hand-edited.

## Tests

`tests/test-project-dashboard.sh` gains `test_argmax_large_artifact`: it builds a project containing a single ≥200KB artifact (250KB, per the AP-039 scale-fixture contract) carrying a sentinel string, runs the dashboard builder, and asserts (a) no `Argument list too long` in the output, and (b) the sentinel appears in the rendered HTML (proving the content was actually embedded, not silently dropped). Before the fix both assertions fail; after, both pass. Full file: 137 passed, 0 failed. Whole suite green; shellcheck / `sync.sh --check` / sfg-lift all clean.

## Scope note

Instance fix at this one call site. The broader AP-039 sweep (mechanical scanner rule + scale-fixture test contract across all argv-passing sites, plus the fix-diff-reviewer "grep for siblings" prompt) is tracked in **#175** and intentionally out of scope here.

Closes #144