### PR TITLE
Guard setup migration against deleting tracked source files (#197)

### DIFF
--- a/correctless/setup
+++ b/correctless/setup
@@ -275,6 +275,12 @@ install_hooks() {
   local migrated=false
   for old_script in lib.sh antipattern-scan.sh; do
     if [ -f "$REPO_ROOT/scripts/$old_script" ]; then
+      # Never delete tracked source (e.g. running setup on the correctless source
+      # repo itself, where scripts/ IS the source of truth — issue #197). The
+      # delete-from-source migration is only safe for an untracked stale install.
+      if git -C "$REPO_ROOT" ls-files --error-unmatch "scripts/$old_script" >/dev/null 2>&1; then
+        continue
+      fi
       mv "$REPO_ROOT/scripts/$old_script" "$script_dest/$old_script"
       migrated=true
     fi

--- a/setup
+++ b/setup
@@ -275,6 +275,12 @@ install_hooks() {
   local migrated=false
   for old_script in lib.sh antipattern-scan.sh; do
     if [ -f "$REPO_ROOT/scripts/$old_script" ]; then
+      # Never delete tracked source (e.g. running setup on the correctless source
+      # repo itself, where scripts/ IS the source of truth — issue #197). The
+      # delete-from-source migration is only safe for an untracked stale install.
+      if git -C "$REPO_ROOT" ls-files --error-unmatch "scripts/$old_script" >/dev/null 2>&1; then
+        continue
+      fi
       mv "$REPO_ROOT/scripts/$old_script" "$script_dest/$old_script"
       migrated=true
     fi

--- a/tests/test-scripts-namespace-migration.sh
+++ b/tests/test-scripts-namespace-migration.sh
@@ -614,6 +614,80 @@ test_pmb003_all_scripts_installed() {
   cleanup
 }
 
+
+# ---------------------------------------------------------------------------
+# Issue #197 [regression]: setup on the correctless SOURCE repo must NOT delete
+# tracked scripts/lib.sh and scripts/antipattern-scan.sh.
+#
+# The install_hooks() upgrade-migration loop runs `mv scripts/<old> .correctless/scripts/`
+# whenever scripts/lib.sh or scripts/antipattern-scan.sh exist. On a target project
+# that is correct (scripts/ is not source). On the correctless source repo itself,
+# scripts/ is the TRACKED source of truth — the mv DELETES source files. There is
+# no guard for the source-repo case.
+#
+# SAFETY: this test runs `setup` ONLY inside its own throwaway /tmp git repo with
+# CWD inside that repo, so `git rev-parse --show-toplevel` resolves to the temp dir,
+# NEVER the real correctless tree.
+# ---------------------------------------------------------------------------
+
+test_source_repo_scripts_not_deleted() {
+  echo ""
+  echo "=== Issue #197: setup on source repo must NOT delete tracked scripts/ source ==="
+
+  local orig_pwd="$PWD"
+  local srcdir
+  srcdir="$(mktemp -d "/tmp/correctless-test-srcrepo-$$-XXXXXX")"
+
+  # --- Build a throwaway repo that LOOKS like the correctless source repo ---
+  cd "$srcdir" || { echo "  FAIL: cannot cd into temp repo $srcdir"; FAIL=$((FAIL + 1)); rm -rf "$srcdir"; return; }
+  git init -q
+  git branch -M main
+
+  # Keep setup's language/tooling detection happy the same way setup_test_project does
+  echo '{"name": "correctless-like", "scripts": {"test": "echo ok"}}' > package.json
+  echo 'export function hello() {}' > index.ts
+
+  # Source-repo markers: top-level skills/, agents/, templates/, sync.sh
+  mkdir -p skills agents templates scripts
+  echo '# sync source' > sync.sh
+  echo '# skill placeholder' > skills/placeholder.md
+  echo '# agent placeholder' > agents/placeholder.md
+  echo '{}' > templates/placeholder.json
+
+  # scripts/ is TRACKED source of truth — sentinel content + a 3rd script so it is
+  # clearly source (not merely the two install-set files).
+  echo 'SENTINEL_LIB=correctless-source-lib' > scripts/lib.sh
+  echo 'SENTINEL_SCAN=correctless-source-scan' > scripts/antipattern-scan.sh
+  echo '# another tracked source script' > scripts/build-dashboard.sh
+
+  git add -A
+  git -c user.email='t@example.test' -c user.name='test' commit -q -m "init source-like repo"
+
+  # Make the correctless `setup` script reachable exactly like setup_test_project does,
+  # so $SCRIPT_DIR/hooks and $SCRIPT_DIR/scripts exist for install_hooks().
+  mkdir -p .claude/skills/workflow
+  rsync -a --exclude='.git' --exclude='tests' "$REPO_DIR/" .claude/skills/workflow/
+
+  # Run setup with CWD = temp repo root (git toplevel resolves to $srcdir).
+  .claude/skills/workflow/setup >/dev/null 2>&1 || true
+
+  # --- RED assertions: tracked source scripts must STILL exist after setup ---
+  assert_file_exists "Issue #197: scripts/lib.sh NOT deleted from source repo" \
+    "$srcdir/scripts/lib.sh"
+  assert_file_exists "Issue #197: scripts/antipattern-scan.sh NOT deleted from source repo" \
+    "$srcdir/scripts/antipattern-scan.sh"
+
+  # Belt-and-suspenders: git must not report the tracked scripts as deleted.
+  local deletions
+  deletions="$(git -C "$srcdir" status --porcelain -- scripts/lib.sh scripts/antipattern-scan.sh \
+    | grep -E '^[ ]?D' || true)"
+  assert_eq "Issue #197: git status shows no deletion of tracked source scripts" "" "$deletions"
+
+  # --- Cleanup + restore CWD ---
+  cd "$orig_pwd" 2>/dev/null || cd "$REPO_DIR" 2>/dev/null || true
+  rm -rf "$srcdir"
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -636,6 +710,7 @@ test_r007_agent_context_source_refs_unchanged
 test_integration_hooks_find_lib_after_setup
 test_integration_upgrade_then_hooks
 test_pmb003_all_scripts_installed
+test_source_repo_scripts_not_deleted
 
 echo ""
 echo "======================"


### PR DESCRIPTION
## What

Running `setup` on the **correctless source repo itself** silently deleted tracked source files. `install_hooks()` has an upgrade-migration loop that `mv`s `scripts/lib.sh` and `scripts/antipattern-scan.sh` into `.correctless/scripts/`:

```sh
for old_script in lib.sh antipattern-scan.sh; do
  if [ -f "$REPO_ROOT/scripts/$old_script" ]; then
    mv "$REPO_ROOT/scripts/$old_script" "$script_dest/$old_script"   # deletes from source
    migrated=true
  fi
done
```

`REPO_ROOT=$(git rev-parse --show-toplevel)`. The migration is meant for installing **into a target project**, where `scripts/` is not the project's source. But on the correctless repo, `scripts/lib.sh` and `scripts/antipattern-scan.sh` **are** tracked source of truth — so the `mv` deletes them (`git status` showed `D scripts/lib.sh` / `D scripts/antipattern-scan.sh`). Dogfooding correctless requires re-running `setup` to refresh `.correctless/`, so every refresh was a data-loss hazard on the source repo (recovery was a manual `git checkout HEAD -- scripts/`).

## Fix

Guard the loop so it never deletes a tracked file. Before the `mv`, check whether the file is tracked by git in `REPO_ROOT` and skip if so:

```sh
if git -C "$REPO_ROOT" ls-files --error-unmatch "scripts/$old_script" >/dev/null 2>&1; then
  continue
fi
mv "$REPO_ROOT/scripts/$old_script" "$script_dest/$old_script"
migrated=true
```

The delete-from-source migration now runs **only** for an untracked stale install artifact — never for tracked source-of-truth. This is the issue's "at minimum, never delete a file that `git ls-files` reports as tracked, without explicit opt-in" direction. The legitimate install-into-target upgrade path (where `scripts/` files are untracked) is unaffected — confirmed by the existing R-002 migration tests still passing. The generated mirror `correctless/setup` is re-synced via `sync.sh`, not hand-edited.

## Tests

`tests/test-scripts-namespace-migration.sh` gains `test_source_repo_scripts_not_deleted`: it builds a throwaway temp git repo laid out like the correctless source tree (tracked `scripts/lib.sh` + `antipattern-scan.sh`, plus top-level `skills/`/`agents/`/`templates/`/`sync.sh`), runs `setup` inside it, and asserts the tracked scripts survive and `git status` shows no `D scripts/...` deletions. Before the fix the three assertions fail (the scripts are deleted); after, they pass. Full file: 101 passed, 0 failed. Whole suite green; shellcheck / `sync.sh --check` / sfg-lift all clean. The repro runs `setup` only inside a `/tmp` temp git repo — the real working tree is never touched.

Closes #197