### PR TITLE
Fix intermittent GREEN-gate flake under output-capture (#186)

### DIFF
--- a/correctless/hooks/workflow-advance.sh
+++ b/correctless/hooks/workflow-advance.sh
@@ -260,6 +260,29 @@ has_formal_model() {
 # Test execution helpers
 # ---------------------------------------------------------------------------
 
+# Run the configured test command, streaming output to a temp file (bounded
+# memory — avoids accumulating the whole suite in one shell variable, which under
+# output-capture + concurrent load can transiently truncate, issue #186).
+# Sets TEST_CAPTURE_FILE to the temp path; returns the command's exit code.
+run_test_to_file() {
+  TEST_CAPTURE_FILE="$(mktemp)"
+  # Run in a subshell so an `exit` in the configured test command terminates the
+  # subshell, not this hook process (the previous `$(eval ...)` form relied on
+  # command-substitution subshell isolation for the same reason).
+  ( eval "$1" ) > "$TEST_CAPTURE_FILE" 2>&1
+}
+
+# GREEN gate: run the suite once, retry ONCE on failure to absorb the issue #186
+# output-capture flake. Returns 0 if EITHER attempt passes; returns non-zero only
+# when BOTH attempts fail. Leaves TEST_CAPTURE_FILE pointing at the last run's
+# output (caller is responsible for removing it).
+green_suite_passes() {
+  run_test_to_file "$1" && return 0
+  rm -f "$TEST_CAPTURE_FILE"
+  run_test_to_file "$1" && return 0   # retry once (#186)
+  return 1
+}
+
 tests_fail_not_build_error() {
   local test_cmd fail_pattern build_pattern
   # Use first affected package's config, or global fallback
@@ -278,27 +301,35 @@ tests_fail_not_build_error() {
 
   [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
 
-  local output exit_code
-  output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
+  # Stream test output to a temp file (issue #186 — no retry on the RED gate;
+  # tests MUST fail here). run_test_to_file sets TEST_CAPTURE_FILE.
+  local exit_code
+  run_test_to_file "$test_cmd" && exit_code=0 || exit_code=$?
 
   if [ "$exit_code" -eq 0 ]; then
+    rm -f "$TEST_CAPTURE_FILE"
     die "Tests pass — they need to fail first (RED phase). Write tests that exercise the spec rules, then advance."
   fi
 
   # Check for build errors vs test failures
   if [ -n "$build_pattern" ] && [ "$build_pattern" != "null" ]; then
-    if echo "$output" | grep -qE "$build_pattern"; then
+    if grep -qE "$build_pattern" "$TEST_CAPTURE_FILE"; then
       # Could be build error — check if there are also test failures
       if [ -n "$fail_pattern" ] && [ "$fail_pattern" != "null" ]; then
-        if echo "$output" | grep -qE "$fail_pattern"; then
+        if grep -qE "$fail_pattern" "$TEST_CAPTURE_FILE"; then
+          rm -f "$TEST_CAPTURE_FILE"
           return 0  # Has both build-like and fail-like output — treat as test failure
         fi
       fi
-      die "Tests don't compile (build error), not a test failure. Fix compilation errors before advancing.\n\nOutput:\n$output"
+      local build_out
+      build_out="$(cat "$TEST_CAPTURE_FILE")"
+      rm -f "$TEST_CAPTURE_FILE"
+      die "Tests don't compile (build error), not a test failure. Fix compilation errors before advancing.\n\nOutput:\n$build_out"
     fi
   fi
 
   # Exit code non-zero and no build error detected — it's a test failure
+  rm -f "$TEST_CAPTURE_FILE"
   return 0
 }
 
@@ -309,37 +340,47 @@ tests_pass() {
     packages="$(detect_affected_packages)"
     for pkg in $packages; do
       [ "$pkg" = "." ] && continue
-      local cmd output exit_code
+      local cmd
       cmd="$(read_package_config '.commands.test' "$pkg")"
       [ -n "$cmd" ] && [ "$cmd" != "null" ] || continue
       any_run=true
-      output="$(eval "$cmd" 2>&1)" && exit_code=0 || exit_code=$?
-      if [ "$exit_code" -ne 0 ]; then
-        die "Tests do not pass in package '$pkg'. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+      # GREEN gate: retry once to absorb the issue #186 output-capture flake.
+      if ! green_suite_passes "$cmd"; then
+        local fail_tail
+        fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+        rm -f "$TEST_CAPTURE_FILE"
+        die "Tests do not pass in package '$pkg'. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
       fi
+      rm -f "$TEST_CAPTURE_FILE"
     done
     # If no package tests ran, fall back to global test command
     if [ "$any_run" = "false" ]; then
-      local test_cmd output exit_code
+      local test_cmd
       test_cmd="$(read_config_field '.commands.test')"
       [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
-      output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
-      if [ "$exit_code" -ne 0 ]; then
-        die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+      if ! green_suite_passes "$test_cmd"; then
+        local fail_tail
+        fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+        rm -f "$TEST_CAPTURE_FILE"
+        die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
       fi
+      rm -f "$TEST_CAPTURE_FILE"
     fi
     return 0
   fi
 
-  local test_cmd output exit_code
+  local test_cmd
   test_cmd="$(read_config_field '.commands.test')"
   [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
 
-  output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
-
-  if [ "$exit_code" -ne 0 ]; then
-    die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+  # GREEN gate: retry once to absorb the issue #186 output-capture flake.
+  if ! green_suite_passes "$test_cmd"; then
+    local fail_tail
+    fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+    rm -f "$TEST_CAPTURE_FILE"
+    die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
   fi
+  rm -f "$TEST_CAPTURE_FILE"
   return 0
 }
 

--- a/hooks/workflow-advance.sh
+++ b/hooks/workflow-advance.sh
@@ -260,6 +260,29 @@ has_formal_model() {
 # Test execution helpers
 # ---------------------------------------------------------------------------
 
+# Run the configured test command, streaming output to a temp file (bounded
+# memory — avoids accumulating the whole suite in one shell variable, which under
+# output-capture + concurrent load can transiently truncate, issue #186).
+# Sets TEST_CAPTURE_FILE to the temp path; returns the command's exit code.
+run_test_to_file() {
+  TEST_CAPTURE_FILE="$(mktemp)"
+  # Run in a subshell so an `exit` in the configured test command terminates the
+  # subshell, not this hook process (the previous `$(eval ...)` form relied on
+  # command-substitution subshell isolation for the same reason).
+  ( eval "$1" ) > "$TEST_CAPTURE_FILE" 2>&1
+}
+
+# GREEN gate: run the suite once, retry ONCE on failure to absorb the issue #186
+# output-capture flake. Returns 0 if EITHER attempt passes; returns non-zero only
+# when BOTH attempts fail. Leaves TEST_CAPTURE_FILE pointing at the last run's
+# output (caller is responsible for removing it).
+green_suite_passes() {
+  run_test_to_file "$1" && return 0
+  rm -f "$TEST_CAPTURE_FILE"
+  run_test_to_file "$1" && return 0   # retry once (#186)
+  return 1
+}
+
 tests_fail_not_build_error() {
   local test_cmd fail_pattern build_pattern
   # Use first affected package's config, or global fallback
@@ -278,27 +301,35 @@ tests_fail_not_build_error() {
 
   [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
 
-  local output exit_code
-  output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
+  # Stream test output to a temp file (issue #186 — no retry on the RED gate;
+  # tests MUST fail here). run_test_to_file sets TEST_CAPTURE_FILE.
+  local exit_code
+  run_test_to_file "$test_cmd" && exit_code=0 || exit_code=$?
 
   if [ "$exit_code" -eq 0 ]; then
+    rm -f "$TEST_CAPTURE_FILE"
     die "Tests pass — they need to fail first (RED phase). Write tests that exercise the spec rules, then advance."
   fi
 
   # Check for build errors vs test failures
   if [ -n "$build_pattern" ] && [ "$build_pattern" != "null" ]; then
-    if echo "$output" | grep -qE "$build_pattern"; then
+    if grep -qE "$build_pattern" "$TEST_CAPTURE_FILE"; then
       # Could be build error — check if there are also test failures
       if [ -n "$fail_pattern" ] && [ "$fail_pattern" != "null" ]; then
-        if echo "$output" | grep -qE "$fail_pattern"; then
+        if grep -qE "$fail_pattern" "$TEST_CAPTURE_FILE"; then
+          rm -f "$TEST_CAPTURE_FILE"
           return 0  # Has both build-like and fail-like output — treat as test failure
         fi
       fi
-      die "Tests don't compile (build error), not a test failure. Fix compilation errors before advancing.\n\nOutput:\n$output"
+      local build_out
+      build_out="$(cat "$TEST_CAPTURE_FILE")"
+      rm -f "$TEST_CAPTURE_FILE"
+      die "Tests don't compile (build error), not a test failure. Fix compilation errors before advancing.\n\nOutput:\n$build_out"
     fi
   fi
 
   # Exit code non-zero and no build error detected — it's a test failure
+  rm -f "$TEST_CAPTURE_FILE"
   return 0
 }
 
@@ -309,37 +340,47 @@ tests_pass() {
     packages="$(detect_affected_packages)"
     for pkg in $packages; do
       [ "$pkg" = "." ] && continue
-      local cmd output exit_code
+      local cmd
       cmd="$(read_package_config '.commands.test' "$pkg")"
       [ -n "$cmd" ] && [ "$cmd" != "null" ] || continue
       any_run=true
-      output="$(eval "$cmd" 2>&1)" && exit_code=0 || exit_code=$?
-      if [ "$exit_code" -ne 0 ]; then
-        die "Tests do not pass in package '$pkg'. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+      # GREEN gate: retry once to absorb the issue #186 output-capture flake.
+      if ! green_suite_passes "$cmd"; then
+        local fail_tail
+        fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+        rm -f "$TEST_CAPTURE_FILE"
+        die "Tests do not pass in package '$pkg'. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
       fi
+      rm -f "$TEST_CAPTURE_FILE"
     done
     # If no package tests ran, fall back to global test command
     if [ "$any_run" = "false" ]; then
-      local test_cmd output exit_code
+      local test_cmd
       test_cmd="$(read_config_field '.commands.test')"
       [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
-      output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
-      if [ "$exit_code" -ne 0 ]; then
-        die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+      if ! green_suite_passes "$test_cmd"; then
+        local fail_tail
+        fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+        rm -f "$TEST_CAPTURE_FILE"
+        die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
       fi
+      rm -f "$TEST_CAPTURE_FILE"
     fi
     return 0
   fi
 
-  local test_cmd output exit_code
+  local test_cmd
   test_cmd="$(read_config_field '.commands.test')"
   [ -n "$test_cmd" ] && [ "$test_cmd" != "null" ] || die "No test command configured"
 
-  output="$(eval "$test_cmd" 2>&1)" && exit_code=0 || exit_code=$?
-
-  if [ "$exit_code" -ne 0 ]; then
-    die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$(echo "$output" | tail -30)"
+  # GREEN gate: retry once to absorb the issue #186 output-capture flake.
+  if ! green_suite_passes "$test_cmd"; then
+    local fail_tail
+    fail_tail="$(tail -30 "$TEST_CAPTURE_FILE")"
+    rm -f "$TEST_CAPTURE_FILE"
+    die "Tests do not pass. Fix failures before advancing.\n\nOutput (last 30 lines):\n$fail_tail"
   fi
+  rm -f "$TEST_CAPTURE_FILE"
   return 0
 }
 

--- a/tests/test-bugfixes.sh
+++ b/tests/test-bugfixes.sh
@@ -264,6 +264,137 @@ WCONF
 }
 
 # ---------------------------------------------------------------------------
+# Bug 5: GREEN-gate retry-once + stream-to-file — issue #186
+# ---------------------------------------------------------------------------
+# The GREEN gate `tests_pass()` in hooks/workflow-advance.sh bails on the first
+# suite failure. Under output-capture + concurrent load, a nested $() inside a
+# test can transiently return empty, so a single spurious assertion failure
+# intermittently blocks the phase transition even though the suite is green.
+# Fix contract:
+#   - retry-once: on a GREEN-gate suite failure, re-run the suite once; only a
+#     failure that persists across BOTH runs blocks.
+#   - persistent failure still blocks (retry must not swallow real breakage).
+#   - a clean pass is unaffected.
+#   - the RED gate (tests_fail_not_build_error) keeps its "must fail first"
+#     semantics — retry-once must NOT leak into it.
+
+# Drive a fresh throwaway project to the tdd-impl phase so that `ADV qa` runs the
+# GREEN gate (tests_pass). $1 = commands.test, $2 = commands.test_new (always a
+# RED-gate failure so `ADV impl` reaches tdd-impl without invoking $1),
+# $3 = branch name. Callers MUST pass the test command single-quoted so that any
+# $(...) / $((...)) / $var inside it is preserved literally (jq --arg embeds the
+# already-set shell variable verbatim — no shell or JSON-escaping hazard).
+green_gate_reach_impl() {
+  local test_cmd="$1" test_new="$2" branch="$3"
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b "$branch"
+
+  jq -n --arg t "$test_cmd" --arg tn "$test_new" '
+    {
+      project: { name: "test-app", language: "typescript", description: "" },
+      commands: { test: $t, test_new: $tn, lint: "echo ok", build: "echo ok" },
+      patterns: {
+        test_file: "*.test.ts",
+        source_file: "*.ts",
+        test_fail_pattern: "FAIL",
+        build_error_pattern: "SyntaxError|Cannot find module"
+      },
+      is_monorepo: false,
+      packages: {},
+      workflow: { min_qa_rounds: 1, require_review: true, auto_update_antipatterns: true }
+    }' > .correctless/config/workflow-config.json
+
+  ADV init "green gate flake" >/dev/null 2>&1
+  mkdir -p .correctless/specs
+  echo "# Spec" > .correctless/specs/green-gate-flake.md
+  ADV review >/dev/null 2>&1
+  ADV tests >/dev/null 2>&1
+  echo '// test' > green.test.ts
+  git add green.test.ts >/dev/null 2>&1
+  # RED gate uses commands.test_new (always fails) → reaches tdd-impl without
+  # touching the flaky counter in commands.test.
+  ADV impl >/dev/null 2>&1
+}
+
+test_green_gate_retry_once() {
+  echo ""
+  echo "=== Bug 5: GREEN-gate retry-once + stream-to-file (issue #186) ==="
+
+  # Flaky counter lives INSIDE the throwaway project (relative path resolved from
+  # the eval cwd, which is TEST_DIR) — never a hardcoded /tmp path.
+  local counter="$TEST_DIR/.flaky-counter"
+  # STATEFUL command: FAIL on the 1st invocation, PASS on the 2nd. No embedded
+  # double quotes → embeds cleanly as a JSON string via jq --arg.
+  local flaky_cmd='c=$(cat .flaky-counter 2>/dev/null || echo 0); c=$((c+1)); echo $c > .flaky-counter; if [ $c -eq 1 ]; then echo FAILhere; exit 1; else echo PASS; exit 0; fi'
+
+  # --- #186.1 [integration] PRIMARY (RED today): retry-once tolerates a single
+  #     transient flake. First tests_pass run fails; retry re-runs; 2nd passes;
+  #     the gate must SUCCEED. Current code bails on the first failure → FAILS. ---
+  green_gate_reach_impl "$flaky_cmd" 'echo NEW_FAIL && exit 1' feature/green-gate-flake
+  rm -f "$counter"   # fresh counter for this assertion
+  local flaky_out flaky_exit
+  flaky_out="$(ADV qa 2>&1)" && flaky_exit=0 || flaky_exit=$?
+  assert_eq "#186.1: GREEN gate SUCCEEDS when test fails once then passes on retry" "0" "$flaky_exit"
+  # Surface the gate output for the RED-phase report (only when it blocked).
+  if [ "$flaky_exit" != "0" ]; then
+    echo "  ---- #186.1 gate output (RED — expected once fix lands) ----"
+    echo "$flaky_out" | sed 's/^/  | /'
+    echo "  ------------------------------------------------------------"
+  fi
+
+  # --- #186.2 [integration] guard: a PERSISTENT failure still BLOCKS. Prevents
+  #     retry-once from swallowing real breakage. Passes before AND after fix. ---
+  green_gate_reach_impl 'echo FAILhere; exit 1' 'echo NEW_FAIL && exit 1' feature/green-gate-persist
+  local persist_exit
+  (ADV qa >/dev/null 2>&1) && persist_exit=0 || persist_exit=$?
+  assert_eq "#186.2: GREEN gate BLOCKS when the suite fails on both runs" "1" "$persist_exit"
+
+  # --- #186.3 [integration] a CLEAN pass is unaffected. Passes before/after. ---
+  green_gate_reach_impl 'echo PASS; exit 0' 'echo NEW_FAIL && exit 1' feature/green-gate-clean
+  local clean_exit
+  (ADV qa >/dev/null 2>&1) && clean_exit=0 || clean_exit=$?
+  assert_eq "#186.3: GREEN gate SUCCEEDS when the suite passes cleanly" "0" "$clean_exit"
+
+  # --- #186.4 [integration] regression guard: retry-once must NOT leak into the
+  #     RED gate. tests_fail_not_build_error still requires tests to FAIL; a
+  #     passing commands.test (no test_new) must still BLOCK `ADV impl` with the
+  #     "tests pass — they need to fail first" semantics. Passes before/after. ---
+  setup_test_project
+  .claude/skills/workflow/setup >/dev/null 2>&1
+  git checkout -q -b feature/red-gate-unchanged
+  cat > .correctless/config/workflow-config.json <<'WCONF'
+{
+  "project": { "name": "test-app", "language": "typescript", "description": "" },
+  "commands": {
+    "test": "echo PASSED; exit 0",
+    "lint": "echo ok",
+    "build": "echo ok"
+  },
+  "patterns": {
+    "test_file": "*.test.ts",
+    "source_file": "*.ts",
+    "test_fail_pattern": "FAIL",
+    "build_error_pattern": "SyntaxError|Cannot find module"
+  },
+  "is_monorepo": false,
+  "packages": {},
+  "workflow": { "min_qa_rounds": 1, "require_review": true, "auto_update_antipatterns": true }
+}
+WCONF
+  ADV init "red gate unchanged" >/dev/null 2>&1
+  mkdir -p .correctless/specs
+  echo "# Spec" > .correctless/specs/red-gate-unchanged.md
+  ADV review >/dev/null 2>&1
+  ADV tests >/dev/null 2>&1
+  echo '// test' > red.test.ts
+  git add red.test.ts >/dev/null 2>&1
+  local red_exit
+  (ADV impl >/dev/null 2>&1) && red_exit=0 || red_exit=$?
+  assert_eq "#186.4: RED gate still BLOCKS impl when tests pass (retry not leaked into RED gate)" "1" "$red_exit"
+}
+
+# ---------------------------------------------------------------------------
 # Bug 3: QA Findings Status — R-006, R-007
 # ---------------------------------------------------------------------------
 
@@ -395,6 +526,7 @@ echo "====================================="
 
 test_slug_truncation
 test_red_gate_test_new
+test_green_gate_retry_once
 test_qa_findings_status
 test_sync_check
 


### PR DESCRIPTION
## Summary

Fixes #186 — the full-suite GREEN gate (`tests_pass` in `hooks/workflow-advance.sh`) flaked intermittently under output-capture, blocking `cmd_qa` / `cmd_verify` / `cmd_done` transitions on a genuinely-green suite.

**Root cause:** the gate captured the entire suite's combined output into one shell variable (`output="$(eval "$test_cmd" 2>&1)"`). Under output-capture plus concurrent session load, that single command-substitution pipe races with git/subshell-heavy tests and transiently truncates — surfacing as a *different* spurious assertion failure each run. Because the gate bails on the first failure, one flake blocks the transition.

## Fix

Combines the two lowest-risk options from the issue:

1. **Stream to a temp file** (`run_test_to_file`) instead of capturing into a variable. The `eval` runs in a subshell (`( eval "$1" )`) so a test command's `exit` terminates the subshell, not the hook — preserving the isolation the previous `$(eval ...)` form relied on. Gate consumers `grep`/`tail` the file. Bounds memory and removes the funnel-through-one-pipe race.
2. **Retry the GREEN suite once** (`green_suite_passes`) — only a failure that persists across *both* runs blocks. Matches the proven manual workaround.

The RED gate (`tests_fail_not_build_error`) deliberately does **not** retry — tests must still fail first — so retry-once cannot leak into it.

## Tests

Adds 4 integration tests in `tests/test-bugfixes.sh`:

- `#186.1` retry-once tolerates a single transient flake (fail-then-pass → gate succeeds)
- `#186.2` a persistent failure still blocks (retry doesn't swallow real breakage)
- `#186.3` a clean pass is unaffected
- `#186.4` retry-once does not leak into the RED gate

## Verification

- `tests/test-bugfixes.sh` → 19 passed, 0 failed
- `sync.sh --check` → clean (mirror `correctless/hooks/` regenerated via `sync.sh`)
- `shellcheck --severity=warning` → exit 0 on both hooks
- pre-commit hooks (sync check + shellcheck) → passed

Closes #186
