### PR TITLE
Normalize mixed-shape audit-trail time field in compute-session-cost phase attribution

### DIFF
--- a/correctless/scripts/compute-session-cost.sh
+++ b/correctless/scripts/compute-session-cost.sh
@@ -188,7 +188,7 @@ AUDIT_TRAIL_FILE="$ARTIFACT_DIR/audit-trail-${BRANCH_SLUG}.jsonl"
 PHASE_TRANSITIONS="[]"
 if [ -f "$AUDIT_TRAIL_FILE" ]; then
   # Extract phase transitions — each entry where phase differs from previous
-  PHASE_TRANSITIONS=$(jq -R 'try (fromjson | {phase: .phase, timestamp: .timestamp}) catch empty' "$AUDIT_TRAIL_FILE" 2>/dev/null | jq -n '
+  PHASE_TRANSITIONS=$(jq -R 'try (fromjson | {phase: .phase, timestamp: (.ts // .timestamp)}) catch empty' "$AUDIT_TRAIL_FILE" 2>/dev/null | jq -n '
     [inputs] | reduce .[] as $entry (
       {transitions: [], last_phase: null};
       if $entry.phase != .last_phase then

--- a/scripts/compute-session-cost.sh
+++ b/scripts/compute-session-cost.sh
@@ -188,7 +188,7 @@ AUDIT_TRAIL_FILE="$ARTIFACT_DIR/audit-trail-${BRANCH_SLUG}.jsonl"
 PHASE_TRANSITIONS="[]"
 if [ -f "$AUDIT_TRAIL_FILE" ]; then
   # Extract phase transitions — each entry where phase differs from previous
-  PHASE_TRANSITIONS=$(jq -R 'try (fromjson | {phase: .phase, timestamp: .timestamp}) catch empty' "$AUDIT_TRAIL_FILE" 2>/dev/null | jq -n '
+  PHASE_TRANSITIONS=$(jq -R 'try (fromjson | {phase: .phase, timestamp: (.ts // .timestamp)}) catch empty' "$AUDIT_TRAIL_FILE" 2>/dev/null | jq -n '
     [inputs] | reduce .[] as $entry (
       {transitions: [], last_phase: null};
       if $entry.phase != .last_phase then

--- a/tests/test-session-cost.sh
+++ b/tests/test-session-cost.sh
@@ -133,6 +133,14 @@ create_audit_trail() {
   echo "$trail_path"
 }
 
+# Append a hook-edit audit-trail entry in the EXACT shape hooks/audit-trail.sh
+# writes (line 110): the time field is named `ts`, NOT `timestamp`.
+# Arguments: $1=trail_path, $2=phase, $3=ts, $4=file (optional)
+append_hook_edit_entry() {
+  local trail_path="$1" phase="$2" ts="$3" file="${4:-hooks/audit-trail.sh}"
+  echo "{\"ts\":\"$ts\",\"phase\":\"$phase\",\"tool\":\"Edit\",\"file\":\"$file\",\"branch\":\"feature/ts-shape\",\"session_id\":null}" >> "$trail_path"
+}
+
 echo "=== Session Cost Analysis Tests ==="
 
 # ============================================================================
@@ -1459,6 +1467,57 @@ test_r018_agent_context() {
 }
 
 # ============================================================================
+# R-004b: ts-shaped hook-edit audit entries captured as phase boundaries
+# Regression for: compute-session-cost.sh reads .timestamp, but
+# hooks/audit-trail.sh writes .ts — so ts-shaped entries yield a null time
+# and are reordered or dropped during phase attribution.
+# ============================================================================
+
+test_r004b_ts_field_normalization() {
+  echo ""
+  echo "--- R-004b: ts-shaped hook-edit entries captured as phase boundaries ---"
+
+  local TEST_DIR FAKE_HOME
+  TEST_DIR=$(setup_test_env)
+  FAKE_HOME=$(mktemp -d)
+
+  local proj_slug
+  proj_slug=$(echo "$TEST_DIR" | tr '/' '-' | sed 's/^-//')
+  local jsonl_path
+  jsonl_path=$(create_session_dir "$FAKE_HOME" "$proj_slug" "ts-shape-session")
+
+  git -C "$TEST_DIR" checkout -q -b "feature/ts-shape" 2>/dev/null
+  local branch_slug
+  branch_slug=$(cd "$TEST_DIR" && source "$LIB_SH" && branch_slug "feature/ts-shape")
+
+  # Mixed-shape audit trail (as production produces): an orchestration entry
+  # (timestamp shape) at 10:00, then a hook-edit entry (ts shape, exactly what
+  # hooks/audit-trail.sh writes) at 10:10 as the LATER phase boundary.
+  local trail_path
+  trail_path=$(create_audit_trail "$TEST_DIR" "$branch_slug" \
+    "tdd-impl" "2026-04-15T10:00:00Z")
+  append_hook_edit_entry "$trail_path" "tdd-qa" "2026-04-15T10:10:00Z"
+
+  # One transcript turn AFTER the ts-shaped boundary. Its correct bucket is the
+  # phase opened by the ts-shaped entry (tdd-qa at 10:10).
+  write_transcript_entry "$jsonl_path" "claude-sonnet-4-6" 500 250 0 0 "feature/ts-shape" "2026-04-15T10:15:00Z"
+
+  local output
+  output=$(cd "$TEST_DIR" && HOME="$FAKE_HOME" bash "$SCRIPT" "feature/ts-shape" 2>/dev/null)
+
+  # The ts-shaped entry's time MUST be captured as a phase-transition boundary,
+  # so the 10:15 turn buckets into tdd-qa. Under the bug, .timestamp is null for
+  # the ts-shaped entry: the null sorts first and the turn is attributed to the
+  # wrong phase (tdd-impl), leaving tdd-qa with 0 turns. This assertion fails RED
+  # until the ingestion normalizes with (.ts // .timestamp).
+  local qa_turns
+  qa_turns=$(echo "$output" | jq '[.by_phase[] | select(.phase == "tdd-qa") | .turns] | add // 0' 2>/dev/null)
+  assert_eq "R004b-a" "ts-shaped hook-edit entry captured as phase boundary (10:15 turn buckets into tdd-qa)" "1" "$qa_turns"
+
+  rm -rf "$TEST_DIR" "$FAKE_HOME"
+}
+
+# ============================================================================
 # Run all tests
 # ============================================================================
 
@@ -1466,6 +1525,7 @@ test_r001_script_exists_and_outputs_json
 test_r002_session_discovery
 test_r003_cost_computation
 test_r004_phase_attribution
+test_r004b_ts_field_normalization
 test_r005_output_schema
 test_r006_pricing
 test_r007_dashboard_cost


### PR DESCRIPTION
Closes #222

## Problem
`scripts/compute-session-cost.sh:191` ingested audit-trail phase boundaries reading the time as `.timestamp` only. But `hooks/audit-trail.sh:110` writes hook-edit entries with the field named `ts`. Every `ts`-shaped hook entry therefore yielded `timestamp: null`, and the downstream `sort_by(.timestamp)` / `select(.timestamp <= …)` (:341/:347) sorted those null-timed transitions to the front — mis-bucketing session turns into an earlier phase and making per-phase USD cost attribution unreliable.

## Fix
One-line normalization at the single ingestion point:
```diff
- {phase: .phase, timestamp: .timestamp}
+ {phase: .phase, timestamp: (.ts // .timestamp)}
```
Downstream references consume the already-normalized field, so no other change is needed. The `:224/:256/:280` reads (session transcripts, legitimately `timestamp`) are intentionally untouched.

## Test (TDD, RED→GREEN)
Extended `tests/test-session-cost.sh` (existing file — no new file, to respect the test-count invariant) with case `R004b-a`: a mixed-shape audit trail (a `timestamp`-shaped orchestration entry + a `ts`-shaped hook-edit entry) asserts the `ts` entry is captured as a phase boundary. It fails RED against the bug (turn mis-attributed, tdd-qa gets 0 turns) and passes GREEN after the fix. Suite: `Session Cost Tests: 90 passed, 0 failed`.

## Verification
- Full regression suite (106 test files) green.
- Regression oracle verdict: `pass`. Note: `patterns.test_file_marker` is empty, so the oracle explicitly degrades to whole-suite blocking (no per-file flake tolerance).
- CI-superset gate green: shellcheck (`--severity=warning`, matching CI), `sync.sh --check`, and the SFG-lift check all exit 0.

## Deferred (human review)
The root cause is a mixed `ts`/`timestamp` audit-trail schema. Other audit-trail time consumers may share the pattern (e.g. `scripts/decision-record.sh`, and the SFG-protected `scripts/prune-scan.sh`, `scripts/wf/utility.sh`, `scripts/lib.sh`). A class-fix sweep — or canonicalizing the time field at the `audit-trail.sh` source — is left for human review; each site needs the transcript-vs-audit-trail distinction verified, and several are SFG-protected so out of scope for autonomous resolution.

---
🤖 Opened autonomously by `/cchores`. One issue, TDD fix with agent separation (separate test-writer and fix agents), fail-closed gating.