### PR TITLE
Attribute real single-file MultiEdit events in audit-trail (#248)

### DIFF
--- a/correctless/hooks/audit-trail.sh
+++ b/correctless/hooks/audit-trail.sh
@@ -337,7 +337,15 @@ case "$TOOL_NAME" in
     fi
     ;;
   MultiEdit)
-    FILES="$TOOL_INPUT_EDITS"
+    # R-248: a real Claude Code MultiEdit carries its single target at top-level
+    # .tool_input.file_path (TOOL_INPUT_FILE); edits[] hold only old/new strings.
+    # Prefer that, mirroring the default Edit/Write branch. Fall back to the
+    # legacy per-edit file_path list (TOOL_INPUT_EDITS) only when it is empty.
+    if [ -n "$TOOL_INPUT_FILE" ]; then
+      FILES="$TOOL_INPUT_FILE"
+    else
+      FILES="$TOOL_INPUT_EDITS"
+    fi
     ;;
   Grep)
     # QA-R2-002: Grep uses .tool_input.path, not .tool_input.file_path.

--- a/hooks/audit-trail.sh
+++ b/hooks/audit-trail.sh
@@ -337,7 +337,15 @@ case "$TOOL_NAME" in
     fi
     ;;
   MultiEdit)
-    FILES="$TOOL_INPUT_EDITS"
+    # R-248: a real Claude Code MultiEdit carries its single target at top-level
+    # .tool_input.file_path (TOOL_INPUT_FILE); edits[] hold only old/new strings.
+    # Prefer that, mirroring the default Edit/Write branch. Fall back to the
+    # legacy per-edit file_path list (TOOL_INPUT_EDITS) only when it is empty.
+    if [ -n "$TOOL_INPUT_FILE" ]; then
+      FILES="$TOOL_INPUT_FILE"
+    else
+      FILES="$TOOL_INPUT_EDITS"
+    fi
     ;;
   Grep)
     # QA-R2-002: Grep uses .tool_input.path, not .tool_input.file_path.

--- a/tests/test-audit-trail.sh
+++ b/tests/test-audit-trail.sh
@@ -615,4 +615,38 @@ else
   fail "R-006-newline" "A trail=$cA_nl B trail=$cB_nl (want 0/0), rc=$RC — newline injection forged a cross-repo record"
 fi
 
+# ============================================================================
+# R-248 [integration]: REAL-shape single-file MultiEdit is logged.
+# Issue #248: a REAL Claude Code MultiEdit call carries its single target at the
+# TOP-LEVEL `.tool_input.file_path`; its `edits[]` entries hold only
+# {old_string, new_string} — there is NO per-edit `.file_path`. The hook builds
+# FILES from `.tool_input.edits[]?.file_path`, which is EMPTY for the real shape,
+# so `[ -n "$FILES" ] || exit 0` bails and the MultiEdit is NEVER logged.
+# Expected: a MultiEdit is attributed to `.tool_input.file_path`, like Edit/Write.
+#
+# NOTE: deliberately does NOT use payload_multiedit() (line 259) — that helper
+# builds the SYNTHETIC {edits:[{file_path:...}]} shape that MASKS this bug. We
+# construct the REAL top-level-file_path shape by hand with jq -nc.
+# RED: fails today (FILES empty -> hook bails, trail stays 0).
+# GREEN: passes once the MultiEdit branch reads top-level .tool_input.file_path.
+# ============================================================================
+section "R-248: real-shape single-file MultiEdit is logged (top-level file_path)"
+R248_R="$(new_root)"; R248="$R248_R/R"
+mk_repo "$R248" feature/repo-r yes            # real git repo + artifacts + state
+tf248="$(trail_file "$R248")"
+before248="$(count_lines "$tf248")"           # expect 0 (no trail yet)
+# REAL MultiEdit shape: single target at TOP-LEVEL .tool_input.file_path; the
+# edits[] entries carry ONLY {old_string,new_string} — NO per-edit file_path.
+R248_TARGET="$R248/hooks/foo.sh"
+R248_PAYLOAD="$(jq -nc --arg f "$R248_TARGET" \
+  '{tool_name:"MultiEdit",tool_input:{file_path:$f,edits:[{old_string:"a",new_string:"b"}]},session_id:"s"}')"
+run_hook "$R248" "$R248_PAYLOAD"
+after248="$(count_lines "$tf248")"
+file248="$(jq -r '.file' "$tf248" 2>/dev/null | tail -1)"
+if [ "$before248" = 0 ] && [ "$after248" = 1 ] && [ "$RC" = 0 ] && [ "$file248" = "$R248_TARGET" ]; then
+  pass "R-248" "real-shape MultiEdit logged 1 record attributed to top-level file_path ($before248->$after248)"
+else
+  fail "R-248" "trail $before248->$after248 (want 0->1), rc=$RC, .file='$file248' (want '$R248_TARGET') — real MultiEdit dropped (FILES empty, hook bailed)"
+fi
+
 summary "test-audit-trail"


### PR DESCRIPTION
Closes #248.

## Summary
`hooks/audit-trail.sh` now records real single-file `MultiEdit` events. Previously they were silently dropped from the audit trail and adherence coverage.

## Root cause
A real Claude Code `MultiEdit` call carries its single target at the **top-level** `.tool_input.file_path`, with `edits[]` holding only `{old_string, new_string}` — no per-edit `file_path`. The `MultiEdit)` branch read only the per-edit list (`TOOL_INPUT_EDITS`, built from `.tool_input.edits[]?.file_path`). For a real MultiEdit that list is empty, so `FILES` was empty and the fail-open hook bailed at `[ -n "$FILES" ] || exit 0` before logging. This is a silent-telemetry drop: real MultiEdits never reached the trail or `modified_files` coverage.

## Fix
The `MultiEdit)` branch now prefers the top-level target `TOOL_INPUT_FILE` (mirroring the Edit/Write branch), falling back to the legacy per-edit list only when the top-level target is absent. The change is confined to that one branch — the bulk jq parse, the newline/TAB delimiter guards, per-repo grouping, and fail-open `exit 0` are untouched.

## Test
Adds regression test **R-248** to `tests/test-audit-trail.sh`, using the **real** MultiEdit payload shape (top-level `file_path` + `edits[]` of old/new strings). The pre-existing `payload_multiedit()` helper builds the *synthetic* per-edit shape that masked this bug, so the new test constructs the real shape directly. R-248 fails on the old code (trail 0→0) and passes with the fix (trail 0→1, attributed to the top-level path).

## Verification
- `tests/test-audit-trail.sh`: 30 passed, 0 failed (was 29 + failing R-248 before the fix).
- Full regression suite (`commands.test`, 107 files): all pass, no regressions.
- CI-superset: `shellcheck --severity=warning` clean, `sync.sh --check` clean, sfg-lift clean.
- Distribution mirror `correctless/hooks/audit-trail.sh` synced.

## Scope
Fix (`hooks/audit-trail.sh`) + its distribution mirror + the regression test. No shared docs or SFG-protected files touched. The pre-existing `get_target_file` write-awareness concern (#250) and the adherence-slug GC bug (#249) are tracked separately.